### PR TITLE
feat: switch to alias-based MLflow releases (candidate/prod)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,47 @@
 SHELL := /bin/bash
-PROJECT_NAME := mlflow-e2e-platform
+PROJECT_NAME := model-release-platform
 
-.PHONY: up down logs run-pipeline promote serve smoke-test clean
+.PHONY: up down logs build run-pipeline promote serve smoke-test clean reset
 
+# Start core infra services
 up:
 	docker compose up -d postgres minio mlflow-server minio-init
 	@echo "MLflow UI: http://localhost:5050"
 	@echo "MinIO Console: http://localhost:9001 (user: minioadmin / pass: minioadmin)"
 
+# Stop everything and wipe volumes
 down:
 	docker compose down -v
 
+# Full nuke: containers, volumes, and images
+reset: down
+	docker compose build --no-cache pipeline promote serving smoke
+
+# Tail logs
 logs:
 	docker compose logs -f --tail=200
 
-run-pipeline:
+# Build all runtime images
+build:
+	docker compose build pipeline promote serving smoke
+
+# Run training + registration pipeline (rebuild first)
+run-pipeline: build
 	docker compose run --rm pipeline
 
-promote:
+# Promote candidate -> prod (rebuild first)
+promote: build
 	docker compose run --rm promote
 
-serve:
-	docker compose up -d serving
+# Start serving API
+serve: build
+	docker compose up -d --build serving
 	@echo "Serving API: http://localhost:8000 (GET /health, POST /predict)"
 
-smoke-test:
-	docker compose run --rm smoke
+# Run smoke tests against serving API
+smoke-test: build
+	docker compose run --rm --build smoke
 
+# Clean local Python junk
 clean:
 	rm -rf .pytest_cache .ruff_cache **/__pycache__ || true


### PR DESCRIPTION
## Summary
Replace deprecated MLflow stages ("Staging"/"Production") with alias-based promotion.

## Changes
- Registration assigns model version alias: `candidate`
- Promotion updates alias: `prod` -> chosen version (currently candidate)
- Serving loads model from `models:/{name}@prod` (alias), not stage

## How to test
make down || true
make up
make run-pipeline
make promote
make serve
make smoke-test

## Notes
- This aligns with MLflow's stage deprecation guidance by using aliases as stable pointers.
- Future: add `champion` alias + version tags for more metadata.
