### PR TITLE
fix(ci): allow deps type in PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,6 +24,7 @@ jobs:
             refactor
             test
             ci
+            deps
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: >


### PR DESCRIPTION
## What
- Update PR title validation workflow to accept `deps` as a valid Conventional Commit type.

## Why
- Dependabot opens PRs with titles like `deps(actions): ...`, which currently fail the PR title check and block merging.

## How
- Add `deps` to the allowed `types` list in `.github/workflows/pr-title.yml`.
- Keep existing subject rules unchanged (lowercase start, no trailing period).

## Testing
- [x] Unit
- [ ] Integration / E2E
- [x] Manual (validated that `deps(actions): ...` passes PR title check)

## Risk
- Low. Only affects PR title validation. Possible failure mode: allowing `deps` could let non-Dependabot PRs use `deps` titles (intended/acceptable).

## Rollback
- Revert this commit (git revert <SHA>) to remove `deps` from the allowed types list.
