### PR TITLE
ci: tighten presubmit and document CI lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,29 @@ env:
   PYTHON_VERSION: "3.11"
 
 jobs:
+  hygiene:
+    name: Repo Hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if forbidden paths are tracked
+        shell: bash
+        run: |
+          set -euo pipefail
+          forbidden_regex='(^mlruns/|^mlartifacts/|^\.venv/|^venv/|^\.pytest_cache/|^\.mypy_cache/|^\.ruff_cache/|^__pycache__/|\.DS_Store$|^data/|^artifacts/)'
+          if git ls-files | egrep -n "${forbidden_regex}"; then
+            echo "Forbidden files are tracked by git. Remove from the index and add to .gitignore."
+            exit 1
+          fi
+
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: hygiene
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +77,7 @@ jobs:
     name: Typecheck (mypy)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: lint
+    needs: hygiene
 
     steps:
       - uses: actions/checkout@v4
@@ -97,24 +116,14 @@ jobs:
           path: mypy.txt
 
 
-  test:
+  unit:
     name: Unit Tests (pytest)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: typecheck
+    needs: hygiene
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Fail if forbidden paths are tracked
-        shell: bash
-        run: |
-          set -euo pipefail
-          forbidden_regex='(^mlruns/|^mlartifacts/|^\.venv/|^venv/|^\.pytest_cache/|^\.mypy_cache/|^\.ruff_cache/|^__pycache__/|\.DS_Store$|^data/|^artifacts/)'
-          if git ls-files | egrep -n "${forbidden_regex}"; then
-            echo "Forbidden files are tracked by git. Remove from the index and add to .gitignore."
-            exit 1
-          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -175,7 +184,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: test
+    needs: [lint, typecheck, unit]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,35 +33,10 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build images
+      - name: Run E2E
         run: |
           set -euo pipefail
-          docker compose build
-
-      - name: Start infra
-        run: |
-          set -euo pipefail
-          make up
-
-      - name: Run pipeline
-        run: |
-          set -euo pipefail
-          make run-pipeline
-
-      - name: Promote
-        run: |
-          set -euo pipefail
-          make promote
-
-      - name: Serve
-        run: |
-          set -euo pipefail
-          make serve
-
-      - name: Smoke test
-        run: |
-          set -euo pipefail
-          make smoke-test
+          make test-e2e
 
       - name: Dump docker state (on failure)
         if: failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 This repo uses `uv` for deterministic dependency management.
 
+For CI lanes, required checks, and branch-protection guidance, see `docs/ci.md`.
+
 Common workflows:
 
 - `make check` — format + lint + type + fast unit tests

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ help:
 	@echo "  make rollback-prod     prod -> previous prod"
 	@echo "  make serve             start serving API"
 	@echo "  make smoke-test        smoke tests against serving"
+	@echo "  make test-e2e          run the golden path without automatic teardown"
 	@echo "  make e2e               pipeline -> gate -> promote -> serve -> smoke"
 	@echo "  make e2e-keep          like e2e, but keep stack up"
 	@echo ""
@@ -117,7 +118,7 @@ precommit:
 install-hooks:
 	@$(PRECOMMIT) install
 
-.PHONY: up down logs build reset run-pipeline policy-check promote promote-dry-run rollback-prod serve smoke-test e2e e2e-keep
+.PHONY: up down logs build reset run-pipeline policy-check promote promote-dry-run rollback-prod serve smoke-test test-e2e e2e e2e-keep
 up:
 	@$(COMPOSE) up -d $(SVC_INFRA)
 	@echo "MLflow UI: http://localhost:5050"
@@ -158,26 +159,25 @@ serve: build
 smoke-test: build
 	@$(COMPOSE) run --rm --use-aliases --build smoke
 
-e2e: build
+test-e2e: build
+	@set -euo pipefail; \
+	$(COMPOSE) up -d $(SVC_INFRA); \
+	$(COMPOSE) run --rm --use-aliases pipeline; \
+	$(assert_allowed_true); \
+	$(COMPOSE) run --rm --use-aliases promote; \
+	$(COMPOSE) up -d --build serving; \
+	$(COMPOSE) run --rm --use-aliases --build smoke
+
+e2e:
 	@set -euo pipefail; \
 	cleanup() { $(COMPOSE) down -v; }; \
 	trap cleanup EXIT; \
-	$(COMPOSE) up -d $(SVC_INFRA); \
-	$(COMPOSE) run --rm --use-aliases pipeline; \
-	$(assert_allowed_true); \
-	$(COMPOSE) run --rm --use-aliases promote; \
-	$(COMPOSE) up -d --build serving; \
-	$(COMPOSE) run --rm --use-aliases --build smoke; \
+	$(MAKE) test-e2e; \
 	echo "✅ E2E passed"
 
-e2e-keep: build
+e2e-keep:
 	@set -euo pipefail; \
-	$(COMPOSE) up -d $(SVC_INFRA); \
-	$(COMPOSE) run --rm --use-aliases pipeline; \
-	$(assert_allowed_true); \
-	$(COMPOSE) run --rm --use-aliases promote; \
-	$(COMPOSE) up -d --build serving; \
-	$(COMPOSE) run --rm --use-aliases --build smoke; \
+	$(MAKE) test-e2e; \
 	echo "✅ E2E passed (stack kept up). Use 'make logs' or 'make down' when done."
 
 .PHONY: clean

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,57 @@
+# CI Guide
+
+This repository uses three CI lanes with intentionally different scopes:
+
+| Lane | Workflow | Trigger | Scope |
+| --- | --- | --- | --- |
+| Presubmit | `CI` | pull requests | repo hygiene, lint, typecheck, unit tests |
+| Postsubmit | `CI` | push to `master` | repo hygiene, lint, typecheck, unit tests, integration tests |
+| Nightly | `E2E` | schedule + manual dispatch | dockerized golden-path verification |
+
+## Required PR Checks
+
+Recommended required status checks for `master` branch protection:
+
+- `Repo Hygiene`
+- `Lint (ruff)`
+- `Typecheck (mypy)`
+- `Unit Tests (pytest)`
+
+Do not require `Integration Tests (pytest)` or nightly `E2E` on pull requests. Those are intentionally kept out of the fast presubmit loop.
+
+## Local To CI Mapping
+
+- `make test` or `make test-unit`
+  Matches the PR unit-test path.
+- `make test-integration`
+  Matches the push-to-`master` integration path.
+- `make test-e2e`
+  Matches the nightly workflow command path and leaves the stack up for log collection.
+- `make e2e`
+  Local wrapper around the same golden-path steps, with automatic teardown.
+
+## Branch Protection Recommendations
+
+GitHub branch protection settings for `master`:
+
+- Require a pull request before merging.
+- Require the four presubmit checks listed above to pass.
+- Require branches to be up to date before merging.
+- Require conversation resolution before merging.
+- Do not require nightly `E2E` or push-only integration checks for PR mergeability.
+
+## Failure Artifacts
+
+When CI fails, use these uploaded artifacts first:
+
+- `mypy-output`
+- `pytest-output`
+- `pytest-integration-output`
+- `coverage-xml`
+- `docker-logs-<run_id>` from the nightly E2E workflow
+
+## Design Notes
+
+- Presubmit is optimized for fast feedback. After the cheap repo-hygiene gate, lint, typecheck, and unit tests run in parallel.
+- Integration tests are deterministic but intentionally non-blocking for PR iteration.
+- Nightly E2E stays separate because it validates the dockerized golden path rather than the fast developer loop.

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What
- Reshaped CI into explicit presubmit, postsubmit, and nightly lanes.
- Added a cheap `Repo Hygiene` gate and parallelized presubmit checks so lint, typecheck, and unit tests no longer wait on each other.
- Kept integration tests out of PR iteration and scoped them to push-to-`master`.
- Unified nightly E2E around the canonical Make target instead of duplicating the golden-path steps in workflow YAML.
- Added `docs/ci.md` with required checks, local-to-CI command mapping, failure artifacts, and recommended branch-protection settings.

## Why
- This PR aims to make the CI shape intentional: fast presubmit, deterministic slower coverage elsewhere, and a clear operational contract for reviewers and maintainers.
- The previous workflow already had the right ingredients, but presubmit was serialized and E2E logic was duplicated between GitHub Actions and the Makefile.
- This change reduces drift, shortens PR feedback time, and makes required checks explicit.

## How
- Added a `Repo Hygiene` job as the single cheap prerequisite for presubmit.
- Made `Lint (ruff)`, `Typecheck (mypy)`, and `Unit Tests (pytest)` depend only on that hygiene gate so they run in parallel.
- Kept `Integration Tests (pytest)` on non-PR runs only, and made it depend on the completed presubmit jobs.
- Introduced `make test-e2e` as the canonical golden-path command used by nightly CI, while keeping `make e2e` as the local wrapper with automatic teardown.
- Added `docs/ci.md` and linked it from `CONTRIBUTING.md`.

## Testing
- [x] Unit
- [x] Integration / E2E
- [x] Manual (verified `pytest -m unit`, `pytest -m integration`, and `make e2e`; reviewed workflow triggers and job dependencies)

## Risk
- Moderate CI-shape change touching job dependencies and workflow semantics.
- Main failure modes are mis-specified job dependencies, missing expected status-check names in branch protection, or drift between local and CI E2E paths.
- Risk is reduced by keeping the same underlying test commands and validating all three lanes locally.

## Rollback
- Revert this PR commit.
- If needed, restore the previous serialized `ci.yml`, restore the explicit step-by-step `e2e.yml`, and remove `docs/ci.md`.
- Branch-protection settings can be updated independently after rollback if required.
