### PR TITLE
chore: align docs with conventional commit workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PR title must follow Conventional Commits, e.g. "fix: correct release manifest sync". -->
+
 ## What
 <!-- What changed? -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development setup
 
-This repo uses `uv` for deterministic dependency management.
+This repo uses `uv` for dependency management.
 
 For CI lanes, required checks, and branch-protection guidance, see `docs/ci.md`.
 
@@ -16,19 +16,25 @@ Common workflows:
 
 Pytest test tiers:
 
-- `unit` — hermetic, fast, default on PRs
+- `unit` — fast, default on PRs
 - `integration` — local component boundaries without secrets
-- `e2e` — dockerized golden path; kept separate from pytest by design
+- `e2e` — dockerized golden path, kept separate from pytest by design
 
 ## Branching & PRs
 
 - Branch off `master`.
 - Keep PRs small and reviewable (prefer <300 LOC).
 - Include a rollback plan when behavior changes.
+- Use squash merges for pull requests.
+- Treat the PR title as the canonical release-note and changelog signal.
 
 ## Commit / PR title conventions
 
-PR titles follow Conventional Commits:
+This repository enforces Conventional Commit PR titles. With squash merges, the PR
+title becomes the canonical commit message on `master`, which is what Release
+Please uses to build release notes.
+
+Allowed PR title types:
 
 - `feat: ...`
 - `fix: ...`
@@ -37,6 +43,10 @@ PR titles follow Conventional Commits:
 - `refactor: ...`
 - `test: ...`
 - `ci: ...`
+- `deps: ...`
+
+Commit messages inside the PR do not need separate enforcement as long as the
+repository uses squash merge consistently.
 
 ## Presubmit expectations
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,6 +12,7 @@ This repository uses three CI lanes with intentionally different scopes:
 
 Recommended required status checks for `master` branch protection:
 
+- `PR Title`
 - `Repo Hygiene`
 - `Lint (ruff)`
 - `Typecheck (mypy)`
@@ -35,9 +36,11 @@ Do not require `Integration Tests (pytest)` or nightly `E2E` on pull requests. T
 GitHub branch protection settings for `master`:
 
 - Require a pull request before merging.
-- Require the four presubmit checks listed above to pass.
+- Require the five presubmit checks listed above to pass.
 - Require branches to be up to date before merging.
 - Require conversation resolution before merging.
+- Allow squash merge and prefer it as the default merge strategy.
+- If possible in repo settings, disable merge strategies that bypass the PR-title-as-canonical-signal model.
 - Do not require nightly `E2E` or push-only integration checks for PR mergeability.
 
 ## Failure Artifacts
@@ -55,3 +58,4 @@ When CI fails, use these uploaded artifacts first:
 - Presubmit is optimized for fast feedback. After the cheap repo-hygiene gate, lint, typecheck, and unit tests run in parallel.
 - Integration tests are deterministic but intentionally non-blocking for PR iteration.
 - Nightly E2E stays separate because it validates the dockerized golden path rather than the fast developer loop.
+- Conventional Commit PR titles are part of the presubmit contract because squash merges make the PR title the canonical commit message on `master`.


### PR DESCRIPTION
## What
- Updated contributing guidance to reflect the actual Conventional Commits workflow used by the repo.
- Documented squash merge as the expected merge strategy.
- Documented that the PR title is the canonical release-note and changelog signal.
- Added `PR Title` to the recommended required checks in `docs/ci.md`.
- Added a PR-template reminder that the PR title must follow Conventional Commits.

## Why
- PR title enforcement already exists, but the surrounding docs were only partially aligned with how Release Please actually works.
- For a squash-merge workflow, commit-message enforcement is unnecessary if the PR title is consistently enforced and documented as the source of truth.
- This makes release behavior more predictable and reduces confusion for contributors and reviewers.

## How
- Updated `CONTRIBUTING.md` to describe the squash-merge model and allowed Conventional Commit title types, including `deps`.
- Updated `docs/ci.md` so recommended branch-protection checks include `PR Title`.
- Added a lightweight reminder to the PR template instead of adding more automation or commit enforcement.

## Testing
- [ ] Unit
- [ ] Integration / E2E
- [x] Manual (verified docs and template now match the existing `pr-title.yml` enforcement and Release Please workflow)

## Risk
- Low risk.
- Changes are documentation and contributor-process alignment only.
- Main failure mode would be documentation drift if GitHub repo merge settings do not match the documented squash-merge recommendation.

## Rollback
- Revert this PR commit.
