### PR TITLE
fix(ci): pin Python 3.11.7 for uv in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.11.7"
+  UV_PYTHON_DOWNLOADS: never
 
 jobs:
   hygiene:

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What
Pin the GitHub Actions Python version to `3.11.7` and set `UV_PYTHON_DOWNLOADS=never` in CI so `uv` uses the runner-provided interpreter instead of downloading a managed Python build.
Also update `uv.lock` so the editable root package version matches `pyproject.toml` (`0.3.0`).

## Why
CI was failing when `uv` retried downloading `python-build-standalone` from GitHub Releases and hit an HTTP/2 refused-stream error.
The workflow was installing generic `3.11`, while the repo requires `>=3.11.7` and pins `3.11.7` in `.python-version`, which triggered `uv`'s fallback interpreter download path.

## How
Use `actions/setup-python` to install the exact version expected by the repo: `3.11.7`.
Disable `uv` managed Python downloads in CI with `UV_PYTHON_DOWNLOADS=never` so the job stays on the interpreter already installed by the runner.
Keep the lockfile aligned with the project version declared in `pyproject.toml`.

## Testing
- [ ] Unit
- [ ] Integration / E2E
- [x] Manual (reviewed workflow diff and verified YAML parses; CI rerun pending)

## Risk
Low. The change only affects CI environment bootstrapping.
Primary failure mode is if a job implicitly relied on `uv` downloading a different interpreter version, but that would already be inconsistent with the repo's pinned Python version.

## Rollback
Revert the workflow change commit:
`git revert <commit-sha>`

If needed, remove the branch from the remote:
`git push origin --delete codex/fix-ci-python-bootstrap`
