### PR TITLE
chore: add open source workflow baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Report a reproducible defect in the repository's current behavior
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for reproducible defects in the current system behavior.
+        Do not report security issues here. Follow SECURITY.md instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Short, concrete description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Exact commands, inputs, or actions needed to reproduce the problem.
+      placeholder: |
+        1. Run ...
+        2. Execute ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Python version, and whether this was local, CI, or dockerized.
+      placeholder: macOS/Linux, Python 3.11.x, local make e2e path, etc.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      render: text

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Propose a scoped feature or roadmap-aligned enhancement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for a scoped feature request.
+        For larger roadmap changes, explain the problem and the expected operator or developer value.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Describe the preferred solution or direction.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Describe alternatives or trade-offs.
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: What should this include, and what should it explicitly not include?
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does done look like?

--- a/.github/ISSUE_TEMPLATE/03-docs.yml
+++ b/.github/ISSUE_TEMPLATE/03-docs.yml
@@ -1,0 +1,25 @@
+name: Documentation update
+description: Report missing, incorrect, or stale documentation
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Documentation problem
+      description: What is missing, incorrect, or stale?
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Affected page or file
+      description: Link the page, file, or section if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested fix
+      description: Optional. Describe the correction or addition you expect.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/jellewillekes/ml-lifecycle-platform/blob/master/SECURITY.md
+    about: Report security vulnerabilities privately using the process in SECURITY.md
+  - name: Support guidance
+    url: https://github.com/jellewillekes/ml-lifecycle-platform/blob/master/SUPPORT.md
+    about: Read the support guidance before opening a new issue

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
 
 
   - package-ecosystem: "docker"
-    directory: "/project"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -37,22 +37,6 @@ updates:
 
     commit-message:
       prefix: "deps(docker)"
-
-
-  - package-ecosystem: "docker"
-    directory: "/serving"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Amsterdam"
-
-    labels:
-      - dependencies
-
-    commit-message:
-      prefix: "deps(docker)"
-
 
   - package-ecosystem: "docker"
     directory: "/mlflow_server"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,38 @@ Pytest test tiers:
 - Use squash merges for pull requests.
 - Treat the PR title as the canonical release-note and changelog signal.
 
+## Issues, milestones, and roadmap work
+
+- Use GitHub Issues for planned work, bugs, feature requests, and documentation
+  follow-ups.
+- Link implementation PRs to issues when possible using `Closes #<issue>` or
+  `Related to #<issue>`.
+- Group roadmap work with milestones such as `M0`, `M1`, and later phases instead
+  of encoding long-term status only in docs.
+- Keep issue scope crisp. One issue should usually map to one reviewable PR or one
+  small sequence of tightly related PRs.
+- Prefer public issue discussion for design clarification unless the topic is
+  security-sensitive.
+
+## Contribution expectations
+
+- Start with a GitHub issue for non-trivial changes before opening a large PR.
+- Keep changes single-purpose. Avoid mixing refactor, infra, and behavior changes in
+  one PR unless there is no safe separation.
+- If you change user-visible behavior, include tests and a clear rollback note.
+- If you touch docker/services or the local golden path, explain how you validated
+  `make e2e` or why it was not run.
+- If your change is part of a roadmap work package, reference the issue and preserve
+  the documented scope and non-goals.
+
+## Maintainer response model
+
+- This project is currently maintained on a best-effort basis by a small maintainer
+  set.
+- Issues and PRs may not receive an immediate response.
+- Small, well-scoped, well-tested contributions are significantly easier to review
+  and merge than large speculative changes.
+
 ## Commit / PR title conventions
 
 This repository enforces Conventional Commit PR titles. With squash merges, the PR
@@ -68,7 +100,7 @@ Before opening a PR:
 Dependabot opens weekly PRs for:
 
 - GitHub Actions versions
-- Python dependencies at repo root
+- Dockerfiles in supported repository paths
 
 ## Pre-commit hooks (optional)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,30 @@
+# Maintainers
+
+## Current model
+
+This project is currently maintained by a single primary maintainer.
+
+See [`.github/CODEOWNERS`](.github/CODEOWNERS) for the current review owner.
+
+## Decision model
+
+Until the maintainer group expands, repository decisions are made by the primary
+maintainer with the following priorities:
+
+- keep the local golden path working
+- keep changes small and reviewable
+- prefer reversible architecture steps
+- preserve documented guardrails and ADR decisions once accepted
+
+## Contribution model
+
+External contributions are welcome through issues and pull requests.
+
+The best contributions are:
+
+- small in scope
+- linked to an issue or clearly motivated in the PR description
+- tested appropriately for their blast radius
+- aligned with the current roadmap and architecture constraints
+
+As the project grows, this file can evolve into a fuller governance document.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support
+
+## How to get help
+
+Use the following paths depending on the kind of request:
+
+- bug reports: open a GitHub issue using the bug template
+- feature requests: open a GitHub issue using the feature template
+- documentation problems: open a GitHub issue using the docs template
+- security reports: follow [`SECURITY.md`](SECURITY.md) and do not open a public issue
+
+## Before opening an issue
+
+Please check:
+
+- [`README.md`](README.md) for the project overview and local commands
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations
+- [`docs/architecture/current-state.md`](docs/architecture/current-state.md) for the
+  current verified system shape
+- existing open and closed GitHub issues for duplicates
+
+## What maintainers can help with
+
+This repository is currently maintained as a small open source project. Maintainer
+support is best-effort and focused on:
+
+- reproducible bugs in the current supported local workflow
+- documentation corrections
+- scoped contributions aligned with the active roadmap
+
+Support is not a guarantee of custom design consulting, immediate turnaround, or
+private feature implementation.


### PR DESCRIPTION
## What

Add a minimal open source workflow baseline for the repository.

This PR adds the missing public-facing community health and issue intake files, updates contributor guidance, and fixes stale Dependabot paths. This to make it easier for others to contribute in case interested.

## Why

The repository already has strong CI, release automation, and contributor basics, but it was still missing a few standard OSS workflow pieces:
- no support-routing doc
- no issue templates
- no maintainer model note
- stale Dependabot paths from older layouts

Before scaling roadmap work and opening more public collaboration, the repo should clearly explain how contributors are expected to work with issues, milestones, and PRs.

## How

This is workflow and documentation only. It does not change platform behavior.

## Testing

- [ ] Unit
- [ ] Integration / E2E
- [x] Manual

Manual:
- `git diff --check`

## Risk

Low. This changes repository workflow and documentation only.

## Rollback

Revert this PR. 
