### PR TITLE
docs: freeze m0 portability charter and adrs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@
 <!-- What changed? -->
 
 ## Why
-<!-- Why now? What user/system impact? Link issue(s) if applicable. -->
+<!-- Why now? What user or system impact? Link issue(s) if applicable. -->
 
 ## How
-<!-- Key decisions / tradeoffs. Call out anything non-obvious. -->
+<!-- Key decisions and trade-offs. Explain changes and anything non-obvious. -->
 
 ## Testing
 - [ ] Unit
@@ -15,7 +15,7 @@
 - [ ] Manual (describe)
 
 ## Risk
-<!-- Blast radius and failure modes. -->
+<!-- How can the change result in mal functioning of the platform?. -->
 
 ## Rollback
-<!-- Concrete rollback: revert SHA / command / config change. -->
+<!-- Clear rollback option: revert SHA / command / config change. -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Agents
+AGENTS.md
+
 # Python bytecode
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-All notable changes to this project are documented here.
+All important changes and updates to this project are documented here.
 
-This repo follows Conventional Commits and uses Release Please to generate release PRs.
+This repo uses Conventional Commits and Release Please.
 
 ## [0.3.0](https://github.com/jellewillekes/ml-lifecycle-platform/compare/v0.2.1...v0.3.0) (2026-03-02)
 
@@ -35,13 +35,14 @@ This repo follows Conventional Commits and uses Release Please to generate relea
 
 The sections above are managed by Release Please.
 
-The section below is a manually preserved historical note for the initial platform release.
+The section below contains the initial platform release notes.
 
 ## [0.1.0](https://github.com/jellewillekes/ml-lifecycle-platform/releases/tag/v0.1.0)
 
 Initial Platform Release
 
-This release bootstraps a production-style model release platform with safe promotion, progressive delivery, reproducibility, and operational foundations.
+This release introduced the core model release platform with safe promotion,
+progressive delivery, reproducibility, and operational basics.
 
 ### Highlights
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,14 @@
 
 ## Development setup
 
-This repo uses `uv` for dependency management.
+This repo uses `uv`.
 
 For CI lanes, required checks, and branch-protection guidance, see `docs/ci.md`.
 For release behavior and Release Please expectations, see `docs/releases.md`.
 For the verified baseline system shape before the M0 refactor, see
 `docs/architecture/current-state.md`.
+For the frozen M0 target shape and portability scope that roadmap PRs must
+follow, see `docs/architecture/m0-portability-charter.md`.
 
 Common workflows:
 
@@ -52,8 +54,10 @@ Pytest test tiers:
 - If you change user-visible behavior, include tests and a clear rollback note.
 - If you touch docker/services or the local golden path, explain how you validated
   `make e2e` or why it was not run.
-- If your change is part of a roadmap work package, reference the issue and preserve
-  the documented scope and non-goals.
+- If your change is part of a roadmap work package, reference the issue and keep
+  the documented scope and non-goals intact.
+- If your change is part of `M0`, keep the package moves and new files aligned
+  with `docs/architecture/m0-portability-charter.md` and the ADRs it references.
 
 ## Maintainer response model
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,14 +2,14 @@
 
 ## Current model
 
-This project is currently maintained by a single primary maintainer.
+This project currently has one primary maintainer.
 
 See [`.github/CODEOWNERS`](.github/CODEOWNERS) for the current review owner.
 
 ## Decision model
 
-Until the maintainer group expands, repository decisions are made by the primary
-maintainer with the following priorities:
+Until the maintainer group expands, the primary maintainer makes repo
+decisions with these priorities:
 
 - keep the local golden path working
 - keep changes small and reviewable
@@ -18,13 +18,13 @@ maintainer with the following priorities:
 
 ## Contribution model
 
-External contributions are welcome through issues and pull requests.
+External contributions are welcome.
 
-The best contributions are:
+Good contributions are:
 
 - small in scope
 - linked to an issue or clearly motivated in the PR description
 - tested appropriately for their blast radius
 - aligned with the current roadmap and architecture constraints
 
-As the project grows, this file can evolve into a fuller governance document.
+This file might become a larger governance document later.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![E2E](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml/badge.svg?event=schedule)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
 [![Coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform)
 
-A production-style model release platform that manages the full lifecycle of machine learning models with an emphasis on safety, reproducibility, and operational discipline.
+A production ML platform for safe, reproducible model promotion and serving, composed of modular, industry-standard infra services.
 
 The platform supports:
 
@@ -17,37 +17,30 @@ The platform supports:
 - Online serving
 - End-to-end verification
 
-This repository serves as a reference implementation for ML platform engineering patterns.
+This repo is a reference implementation for ML platform engineering patterns, mainly for personal use.
 
-For the verified baseline architecture and current capabilities, start with
-`docs/architecture/current-state.md`.
+See `docs/architecture/current-state.md` for the verified baseline.
+See `docs/architecture/m0-portability-charter.md` for the frozen `M0` target.
 
 ---
 
 ## System Guarantees
 
-The platform enforces the following invariants:
+The platform guarantees the following properties:
 
-- Reproducible runs
-  Every training run logs dataset fingerprint, config hash, git SHA, and is immutable.
-
-- Quality-gated promotion
-  `candidate → prod` promotion only happens when evaluation gates pass and all required metadata is present.
-
-- Alias-first registry model
-  Deployment is driven by MLflow aliases (`candidate`, `prod`, `champion`). Stages are not used.
-
-- Deterministic rollback
-  Each promotion records `previous_prod_version`. Rollback is a based on alias mutation.
-
-- Artifact lineage
-  Every model version links to its source training run and metadata.
-
-- Control-plane / data-plane separation
-  Training, registry policy, and serving are independent.
-
-- End-to-end verifiability
-  CI and E2E validate training, policy checks, promotion, serving, and rollback.
+- Reproducible runs: every training run logs dataset fingerprint, config hash,
+  and git SHA.
+- Quality-gated promotion: `candidate -> prod` only happens after evaluation
+  passes and required metadata is present.
+- Alias-first registry model: deployment is driven by MLflow aliases
+  (`candidate`, `prod`, `champion`), not stages.
+- Deterministic rollback: each promotion records `previous_prod_version`.
+  Rollback is alias mutation.
+- Artifact lineage: every model version links back to its source training run.
+- Control-plane / data-plane separation: training, registry policy, and serving
+  are separate.
+- End-to-end verifiability: CI and E2E validate training, policy checks,
+  promotion, serving, and rollback.
 
 ---
 
@@ -76,12 +69,12 @@ Promotion is blocked if any tag is missing.
 
 ### Policy Check (Non-Mutating)
 
-Promotion can be executed in dry-run mode.
+Promotion supports dry-run mode.
 
-- Evaluates metadata requirements
-- Verifies evaluation gate status
-- Returns a structured JSON decision report
-- Performs no registry writes or state changes
+- checks required metadata
+- checks evaluation gate status
+- returns a structured JSON decision report
+- performs no registry writes
 
 Example:
 
@@ -100,7 +93,7 @@ The output contract:
 }
 ```
 
-CI and E2E rely on this contract.
+CI and E2E rely on this output.
 
 ### Rollback Metadata
 
@@ -133,10 +126,13 @@ previous_prod_version=<version>
 - Shadow traffic duplicator
 
 ### Lifecycle
+
 ```
 Ingest → Featurize → Train → Evaluate → Register → Promote → Serve
 ```
-Serving Path:
+
+Serving path:
+
 ```
 models:/<name>@prod → FastAPI → Clients
 ```
@@ -218,7 +214,7 @@ Clients
 make down && make clean && make up && make run-pipeline && make policy-check && make promote && make serve && make smoke-test && make e2e
 ```
 
-Service Endpoints:
+Service endpoints:
 
 - MLflow UI: http://localhost:5050
 - MinIO Console: http://localhost:9001
@@ -260,7 +256,7 @@ POST /predict?mode=prod|candidate|canary|shadow
 | canary    | Deterministic traffic split between prod and candidate                   |
 | shadow    | Executes candidate in parallel; response derived from prod               |
 
-Canary routing is deterministic per request (bucketed by payload hash).
+Canary routing is deterministic per request.
 
 ---
 
@@ -278,7 +274,7 @@ Canary routing is deterministic per request (bucketed by payload hash).
 
 ### Recovery
 
-Rollback is explicit and deterministic:
+Rollback is explicit:
 
 ```bash
 make rollback-prod
@@ -337,5 +333,5 @@ release model and failure-handling notes, see `docs/releases.md`.
 
 ## Security & Licensing
 
-- Security issues: see SECURITY.md
-- License: MIT (see LICENSE)
+- Security issues: see `SECURITY.md`
+- License: MIT in `LICENSE`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,7 @@
 Do not open public issues for security reports.
 
 Contact the maintainer via GitHub direct message and include:
+
 - description
 - reproduction steps
 - impact assessment

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## How to get help
 
-Use the following paths depending on the kind of request:
+Use these paths:
 
 - bug reports: open a GitHub issue using the bug template
 - feature requests: open a GitHub issue using the feature template
@@ -11,7 +11,7 @@ Use the following paths depending on the kind of request:
 
 ## Before opening an issue
 
-Please check:
+Please check these first:
 
 - [`README.md`](README.md) for the project overview and local commands
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations
@@ -21,12 +21,9 @@ Please check:
 
 ## What maintainers can help with
 
-This repository is currently maintained as a small open source project. Maintainer
-support is best-effort and focused on:
+This is a small OSS project. Maintainer support is best-effort and focused on:
 
-- reproducible bugs in the current supported local workflow
+- possible bugs or new features in the current local workflow
+- contributions aligned with the active roadmap
 - documentation corrections
-- scoped contributions aligned with the active roadmap
-
-Support is not a guarantee of custom design consulting, immediate turnaround, or
-private feature implementation.
+- planning deployment in GCP / AWS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,16 +64,16 @@ services:
     ports:
       - "5050:5000"
 
-    # ✅ IMPORTANT: use a health endpoint that definitely exists.
-    # MLflow responds on "/" once it’s up.
+    # Use a health endpoint that always exists.
+    # MLflow responds on "/" once it is up.
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:5000/"]
       interval: 5s
       timeout: 3s
       retries: 30
 
-    # NOTE: your mlflow_server image already uses ENTRYPOINT ["/start.sh"].
-    # If you ever switch away from ENTRYPOINT, the correct command would be:
+    # The mlflow_server image already uses ENTRYPOINT ["/start.sh"].
+    # If that changes, use:
     # command: ["/start.sh"]
 
   pipeline:

--- a/docs/adrs/ADR-0001-portability-surface.md
+++ b/docs/adrs/ADR-0001-portability-surface.md
@@ -1,0 +1,102 @@
+# ADR-0001: M0 Portability Surface
+
+Status: Accepted
+
+Date: 2026-03-03
+
+## Context
+
+The repo is entering `M0: Stable portable local platform`.
+
+Today the system is still local-first:
+
+- local Docker Compose is the main runtime path
+- MLflow is the registry and release-control source of truth
+- release policy, promotion, rollback, and serving behavior already live in
+  concrete Python modules and tests
+
+Without a hard boundary, `M0` becomes a broad abstraction exercise.
+
+## Decision
+
+`M0` portability is limited to four backend-facing interfaces:
+
+- `ArtifactStore`
+- `EventStore`
+- `JobRunner`
+- `Secrets`
+
+Only these four interfaces are allowed as implementation boundaries (seams) in
+`M0`.
+
+Everything else stays concrete in `M0`, including:
+
+- MLflow registry and release-control behavior
+- release policy evaluation
+- registry workflows such as register, promote, rollback, and reproduce
+- lineage and reproducibility contracts
+- serving routing semantics and API behavior
+
+## Interface intent
+
+### `ArtifactStore`
+
+Handles runtime artifacts used by training, evaluation, registration, serving,
+and reproducibility.
+
+Examples:
+
+- model artifacts
+- evaluation reports
+- reproducibility payloads
+
+### `EventStore`
+
+Handles structured platform events.
+
+This does not mean adding a workflow engine or a message bus in `M0`.
+
+### `JobRunner`
+
+Runs bounded jobs and runtime steps.
+
+This does not mean turning the platform into a full workflow orchestrator in
+`M0`.
+
+### `Secrets`
+
+Provides runtime secrets needed by local or hosted backends.
+
+This is not a full redesign of config handling.
+
+## Explicit non-interfaces for M0
+
+The following are outside the `M0` portability surface:
+
+- `ModelRegistry`
+- `ReleaseControlPlane`
+- `ReleasePolicy`
+- `ServingRouter`
+- `FeatureStore`
+- `ExperimentTracker`
+- `DeploymentManager`
+
+MLflow and the existing release-control behavior stay concrete by design.
+
+## Consequences
+
+- limits refactor scope
+- keeps `M0` reviewable
+- preserves the current local golden path while backend boundaries are added
+- prevents speculative abstractions from spreading through the repo
+
+Trade-offs:
+
+- some concrete dependencies remain in place in `M0`
+- alternate backends outside these four interfaces must wait for a later phase
+  or a new ADR
+
+## Related documents
+
+- [`m0-portability-charter.md`](../architecture/m0-portability-charter.md)
+- [`ADR-0002-mlflow-control-plane.md`](./ADR-0002-mlflow-control-plane.md)

--- a/docs/adrs/ADR-0002-mlflow-control-plane.md
+++ b/docs/adrs/ADR-0002-mlflow-control-plane.md
@@ -1,0 +1,80 @@
+# ADR-0002: MLflow Remains The M0 Control Plane
+
+Status: Accepted
+
+Date: 2026-03-03
+
+## Context
+
+The repo already uses MLflow as the release-control system:
+
+- model versions are registered in MLflow
+- aliases `candidate`, `prod`, and `champion` define release state
+- promotion policy reads MLflow model-version metadata
+- promotion mutates MLflow aliases and tags
+- rollback uses MLflow alias metadata such as `previous_prod_version`
+- serving resolves `models:/<name>@prod`
+
+That is already reflected in the Makefile workflows, Docker Compose runtime,
+integration tests, and current docs.
+
+If `M0` also tried to abstract the release-control plane, the refactor would
+get larger and riskier.
+
+## Decision
+
+MLflow remains the registry and release-control source of truth for all of
+`M0`.
+
+In `M0`:
+
+- MLflow registered model versions remain the authoritative release records
+- MLflow aliases remain the authoritative release pointers
+- MLflow model-version tags remain the authoritative promotion and rollback
+  metadata
+- serving continues to resolve models from MLflow aliases
+- policy evaluation continues to read its decision inputs from MLflow metadata
+
+Do not add an alternate registry, release database, or second control plane in
+`M0`.
+
+## What stays concrete in M0
+
+These behaviors stay concrete and MLflow-backed in `M0`:
+
+- `candidate -> prod -> champion` alias flow
+- promotion dry-run and allow-or-block decisions
+- rollback via `previous_prod_version`
+- source training run linkage
+- dataset fingerprint, config hash, git SHA, and training run metadata checks
+
+This is intentional even while other backend boundaries are narrowed.
+
+## Consequences
+
+- preserves the current local Compose workflow
+- keeps release semantics stable during package movement
+- avoids splitting source of truth across multiple systems
+- lets later `M0` PRs refactor structure without redefining release behavior
+
+Trade-offs:
+- registry portability is deferred beyond `M0`
+- hosted environments in `M1` and later must still integrate around MLflow
+  unless a later ADR changes that direction
+
+## Rejected alternatives
+
+### Introduce a generic registry interface in M0
+
+Rejected because it would widen the refactor and force early abstraction
+decisions the repo does not need yet.
+
+### Add a separate release-control database or service in M0
+
+Rejected because it would create two sources of truth during the phase meant to
+stabilize local portability.
+
+## Related documents
+
+- [`m0-portability-charter.md`](../architecture/m0-portability-charter.md)
+- [`ADR-0001-portability-surface.md`](./ADR-0001-portability-surface.md)

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -4,12 +4,12 @@ Last verified: 2026-03-02
 
 ## Purpose
 
-This document is a verified snapshot of what is built in the repository today. It
-describes the current product shape, package layout, operational model, release
-history, and known gaps before the M0 portability refactor begins.
+This document is a verified snapshot of the repo today. It covers the current
+product shape, package layout, operating model, release history, and known gaps
+before the `M0` portability refactor.
 
-Use this page as the baseline for future architecture work. It describes the system
-as it exists now, not the target shape proposed for M0 and beyond.
+Use it as the baseline for future architecture work. It describes the current
+system, not the target `M0+` shape.
 
 ## Verification basis
 
@@ -28,10 +28,10 @@ This snapshot is based on:
 
 ## Executive summary
 
-This repository is a real Python package, not a placeholder scaffold. The package is
-published as `ml-lifecycle-platform` in [`pyproject.toml`](../../pyproject.toml),
-with implementation code under [`src/ml_lifecycle_platform/`](../../src/ml_lifecycle_platform/)
-and tests under [`tests/`](../../tests/).
+This is a real Python package, not a scaffold. It is published as
+`ml-lifecycle-platform` in [`pyproject.toml`](../../pyproject.toml), with code
+under [`src/ml_lifecycle_platform/`](../../src/ml_lifecycle_platform/) and tests
+under [`tests/`](../../tests/).
 
 Today the platform implements:
 
@@ -46,10 +46,10 @@ Today the platform implements:
 - professional repository governance with CI lanes, PR-title enforcement, release
   automation, and security/legal baselines
 
-The repository is already a serious local-first reference implementation for safe ML
-model release operations. It is not yet a hosted production platform, and it does
-not yet have the M0 portability split, handbook/runbook set, drift pipeline, or
-environment-aware deployment workflow.
+The repo is already a local-first reference implementation for safe ML model
+release operations. It is not yet a hosted platform. It does not yet have the
+`M0` portability split, handbook/runbook set, drift pipeline, or
+environment-aware deployment flow.
 
 ## Product and system shape
 
@@ -77,8 +77,8 @@ The current architecture is organized around these package areas:
 
 ### Local operational model
 
-The canonical local system today is a Docker Compose stack plus Makefile command
-wrappers. The stack includes:
+The canonical local system today is Docker Compose plus Makefile wrappers. The
+stack includes:
 
 - MLflow
 - PostgreSQL
@@ -87,7 +87,7 @@ wrappers. The stack includes:
 - Docker Compose
 - `make` targets for operator workflows
 
-The key local entrypoints are defined in [`Makefile`](../../Makefile) and backed by
+The key local entrypoints are in [`Makefile`](../../Makefile) and backed by
 [`docker-compose.yml`](../../docker-compose.yml).
 
 ### Runtime flow
@@ -254,9 +254,9 @@ The repository uses an intentionally split CI model:
 - pushes to `master` add integration tests
 - nightly or manual execution runs the dockerized E2E lane
 
-Release management is Conventional-Commit-driven and handled through Release Please.
-The release source of truth is the squash-merged PR history on `master`, not an
-ad hoc manual changelog process.
+Release management is driven by Conventional Commits and handled by Release
+Please. The release source of truth is the squash-merged PR history on
+`master`, not a manual changelog process.
 
 ## What is not done yet
 
@@ -279,18 +279,18 @@ These are not platform gaps, but they are real repository follow-ups:
 
 - [`.github/dependabot.yml`](../../.github/dependabot.yml) still contains stale
   directories such as `/project` and `/serving`
-- repository health files are not complete for a public OSS workflow yet; there is
-  no `CODE_OF_CONDUCT.md`, issue-template set, or maintainer/governance doc
+- repository health files are still incomplete for a public OSS workflow; there
+  is no `CODE_OF_CONDUCT.md`, and the maintainer/governance model is still
+  minimal
 - some comments still reflect older layout assumptions and should be scrubbed during
   the OSS workflow cleanup
 
 ## Relationship to the roadmap
 
-This page documents the baseline that future M0 work must preserve while changing
-structure. The next architecture documents should answer a different question:
+This page documents the baseline that future `M0` work must preserve while it
+changes structure. The next architecture docs answer a different question:
 
 - this page: what exists today
-- M0 charter and ADRs: what shape the repository is allowed to move toward
+- `M0` charter and ADRs: what shape the repo may move toward
 
-Contributors should use this page to understand the current system before reading
-future portability or cloud-roadmap documents.
+Read this page first, then read future portability or cloud-roadmap docs.

--- a/docs/architecture/m0-portability-charter.md
+++ b/docs/architecture/m0-portability-charter.md
@@ -1,0 +1,319 @@
+# M0 Portability Charter
+
+Status: Accepted target shape for roadmap phase `M0`
+
+Last updated: 2026-03-03
+
+## Purpose
+
+Freeze the target repository and package shape for
+`M0: Stable portable local platform` before code moves.
+
+Later `M0` PRs should cite this charter and the linked ADRs instead of arguing
+about scope again.
+
+This is a target-state document. For the current repo shape, see
+[`current-state.md`](./current-state.md).
+
+## Roadmap context
+
+Repository roadmap phases:
+
+- `M0`: Stable portable local platform
+- `M1`: First hosted GCP staging platform
+- `M2`: Operable GCP platform
+- `M3`: Closed-loop MLOps
+- `M4`: Scale-up and alternate backends
+
+Near-term execution focus:
+
+- `UP-01` through `UP-10`
+
+## M0 goals
+
+- freeze the package and repository shape before refactoring work begins
+- keep the local Docker Compose developer and operator flow first-class
+- narrow portability to a small, explicit backend seam
+- preserve MLflow as the registry and release-control source of truth
+- create a stable reference for later `M0` PRs
+
+## M0 non-goals
+
+- code movement in `UP-01`
+- behavior changes in `UP-01`
+- a new CLI in `UP-01`
+- deployment work in `UP-01`
+
+## M0 anti-goals
+
+- replace MLflow with another registry or release-control system
+- abstract every subsystem behind a portability interface
+- make hosted GCP the primary developer path before `M1`
+- redesign the serving API, release policy, or model lifecycle semantics
+- introduce Kubernetes, Terraform, or environment-specific deployment work
+- broaden the portability surface beyond `ArtifactStore`, `EventStore`,
+  `JobRunner`, and `Secrets`
+- collapse all existing operator workflows into a brand-new command surface
+
+## Preserved invariants
+
+- MLflow remains the registry and release-control source of truth.
+- Local Docker Compose remains the first-class operator path.
+- `make up`, `make run-pipeline`, `make policy-check`, `make promote`,
+  `make serve`, `make smoke-test`, and `make e2e` remain valid local workflows.
+- Alias-based release control remains `candidate`, `prod`, and `champion`.
+- Promotion remains policy-gated and dry-run capable.
+- Rollback remains alias mutation against MLflow metadata rather than rebuild or
+  retrain.
+
+## M0 portability boundary
+
+`M0` portability is limited to the boundary between core logic and backend
+implementations.
+
+Portable interfaces:
+
+- `ArtifactStore`
+- `EventStore`
+- `JobRunner`
+- `Secrets`
+
+Everything else stays concrete in `M0`, including:
+
+- MLflow model registry and release control
+- release policy evaluation
+- lineage and reproducibility contracts
+- serving routing behavior
+- local Docker Compose operator flows
+
+See [`ADR-0001-portability-surface.md`](../adrs/ADR-0001-portability-surface.md)
+and
+[`ADR-0002-mlflow-control-plane.md`](../adrs/ADR-0002-mlflow-control-plane.md).
+
+## Target repository shape
+
+This is the target `M0` tree. Later `M0` PRs may add or populate these paths.
+
+```text
+.
+├── configs/
+│   ├── local/
+│   │   ├── pipeline.env
+│   │   ├── promote.env
+│   │   ├── rollback.env
+│   │   └── serving.env
+│   └── README.md
+├── deployments/
+│   ├── local/
+│   │   ├── docker-compose.yml
+│   │   └── README.md
+│   └── README.md
+├── docs/
+│   ├── adrs/
+│   │   ├── ADR-0001-portability-surface.md
+│   │   └── ADR-0002-mlflow-control-plane.md
+│   └── architecture/
+│       ├── current-state.md
+│       └── m0-portability-charter.md
+├── src/ml_lifecycle_platform/
+│   ├── backends/
+│   │   ├── __init__.py
+│   │   ├── interfaces/
+│   │   │   ├── __init__.py
+│   │   │   ├── artifact_store.py
+│   │   │   ├── event_store.py
+│   │   │   ├── job_runner.py
+│   │   │   └── secrets.py
+│   │   ├── local/
+│   │   │   ├── __init__.py
+│   │   │   ├── artifact_store.py
+│   │   │   ├── event_store.py
+│   │   │   ├── job_runner.py
+│   │   │   └── secrets.py
+│   │   └── mlflow/
+│   │       ├── __init__.py
+│   │       └── control_plane.py
+│   ├── cli/
+│   │   ├── __init__.py
+│   │   ├── main.py
+│   │   ├── pipeline.py
+│   │   ├── registry.py
+│   │   └── serving.py
+│   ├── core/
+│   │   ├── __init__.py
+│   │   ├── config.py
+│   │   ├── constants.py
+│   │   ├── policy/
+│   │   │   ├── __init__.py
+│   │   │   └── release_policy.py
+│   │   ├── registry/
+│   │   │   ├── __init__.py
+│   │   │   ├── promote.py
+│   │   │   ├── register.py
+│   │   │   ├── reproduce.py
+│   │   │   └── rollback.py
+│   │   └── contracts/
+│   │       ├── __init__.py
+│   │       ├── dataset_fingerprint.py
+│   │       ├── feature_stats.py
+│   │       ├── model_ref.py
+│   │       └── repro_contract.py
+│   └── runtime/
+│       ├── __init__.py
+│       ├── pipeline/
+│       │   ├── __init__.py
+│       │   ├── evaluate.py
+│       │   ├── featurize.py
+│       │   ├── ingest.py
+│       │   ├── orchestrate.py
+│       │   └── train.py
+│       └── serving/
+│           ├── __init__.py
+│           ├── app.py
+│           ├── constants.py
+│           ├── metrics.py
+│           ├── router.py
+│           ├── settings.py
+│           └── smoke_test.py
+├── docker-compose.yml
+├── Makefile
+└── tests/
+```
+
+## Meaning of each target area
+
+### `src/ml_lifecycle_platform/core/`
+
+`core/` holds business logic that should stay stable when runtime wiring or
+backend implementations change.
+
+Contents:
+
+- release policy rules
+- registry workflows such as register, promote, rollback, and reproduce
+- contracts for lineage, fingerprints, and reproducibility
+- shared constants and config helpers that are not backend implementations
+
+`core/` may depend on the narrow portability interfaces. It should not depend
+on a broad set of backend-specific details.
+
+### `src/ml_lifecycle_platform/backends/`
+
+`backends/` holds backend-facing adapters and concrete implementations.
+
+In `M0` it includes:
+
+- the portable interface definitions for `ArtifactStore`, `EventStore`,
+  `JobRunner`, and `Secrets` under `backends/interfaces/`
+- local-first concrete implementations under `backends/local/`
+- MLflow-specific control-plane integration code under `backends/mlflow/`
+
+`backends/` is the only package area that should add portability adapters in
+`M0`.
+
+### `src/ml_lifecycle_platform/runtime/`
+
+`runtime/` holds execution entrypoints and process wiring.
+
+In `M0` it includes:
+
+- pipeline step entrypoints
+- orchestration wiring
+- serving application wiring
+- runtime-only settings and operational hooks
+
+`runtime/` is where the system runs. It should not define release policy or
+registry semantics.
+
+### `src/ml_lifecycle_platform/cli/`
+
+`cli/` is the future home for command entrypoints after the package split.
+
+This charter reserves the package area and module names. `UP-01` does not add a
+new CLI. Existing Makefile and module execution paths remain authoritative in
+early `M0`.
+
+### `configs/`
+
+`configs/` is the future home for repo-root runtime configuration inputs.
+
+In `M0` the reserved local shape is:
+
+- `pipeline.env`
+- `promote.env`
+- `rollback.env`
+- `serving.env`
+
+### `deployments/`
+
+`deployments/` is the future home for repo-root deployment assets.
+
+In `M0` the reserved local path is:
+
+- `deployments/local/docker-compose.yml`
+
+This does not replace the current repo-root `docker-compose.yml`.
+
+## Compatibility rule for local Compose
+
+The current local Compose path stays valid in `M0`:
+
+- the repo-root [`docker-compose.yml`](../../docker-compose.yml) remains valid
+- the repo-root [`Makefile`](../../Makefile) remains the canonical local operator
+  entrypoint
+- later `M0` PRs may introduce `deployments/local/`, but they must not break the
+  current `make`-driven local flow while `M0` is in progress
+
+## Local sequence diagram
+
+The local golden path for `train -> evaluate -> register -> promote -> serve`
+stays:
+
+```mermaid
+sequenceDiagram
+    participant Operator as Operator via make
+    participant Pipeline as Runtime Pipeline
+    participant MLflow as MLflow Registry
+    participant Artifacts as Artifact Store
+    participant Promote as Promote Runtime
+    participant Serving as Serving Runtime
+    participant Client as Client
+
+    Operator->>Pipeline: make run-pipeline
+    Pipeline->>Artifacts: log model and reports
+    Pipeline->>MLflow: train run metadata
+    Pipeline->>MLflow: register candidate model version
+    Pipeline->>MLflow: set alias candidate
+
+    Operator->>Promote: make policy-check
+    Promote->>MLflow: read candidate metadata and gate state
+    MLflow-->>Promote: allowed or blocked decision
+
+    Operator->>Promote: make promote
+    Promote->>MLflow: move prod and champion aliases
+    Promote->>MLflow: record previous_prod_version
+
+    Operator->>Serving: make serve
+    Serving->>MLflow: resolve models:/<name>@prod
+    Serving->>Artifacts: load model artifacts
+
+    Client->>Serving: POST /predict
+    Serving-->>Client: prod prediction
+```
+
+## M0 review checklist
+
+Reviewers for later `M0` PRs should check:
+
+- every new package or file being introduced already appears in this charter
+- portability work is limited to the four named interfaces
+- MLflow remains the release-control source of truth
+- the local Compose golden path is still present and documented
+- scope changes are recorded by revising this charter or its ADRs first
+
+## Rollback
+
+This is a docs-only baseline.
+
+If later `M0` work changes these boundaries, update this charter and the ADRs
+before moving code.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,33 +1,34 @@
 # CI Guide
 
-This repository uses three CI lanes with intentionally different scopes:
+This repo uses three CI lanes with different scopes:
 
 | Lane | Workflow | Trigger | Scope |
 | --- | --- | --- | --- |
-| Presubmit | `CI` | pull requests | repo hygiene, lint, typecheck, unit tests |
+| Presubmit | `CI` | pull requests | repo hygiene, lint, typecheck, unit tests (usual checks) |
 | Postsubmit | `CI` | push to `master` | repo hygiene, lint, typecheck, unit tests, integration tests |
-| Nightly | `E2E` | schedule + manual dispatch | dockerized golden-path verification |
+| Nightly | `E2E` | schedule + manual dispatch | golden-path verification |
 
 ## Required PR Checks
 
 Recommended required status checks for `master` branch protection:
 
-- `PR Title`
+- `PR Title` (conventional)
 - `Repo Hygiene`
 - `Lint (ruff)`
 - `Typecheck (mypy)`
 - `Unit Tests (pytest)`
 
-Do not require `Integration Tests (pytest)` or nightly `E2E` on pull requests. Those are intentionally kept out of the fast presubmit loop.
+Do not require `Integration Tests (pytest)` or nightly `E2E` on pull requests.
+Those stay out of the fast presubmit loop, we keep them in merge loop.
 
-## Local To CI Mapping
+## Local to CI Mapping
 
 - `make test` or `make test-unit`
   Matches the PR unit-test path.
 - `make test-integration`
   Matches the push-to-`master` integration path.
 - `make test-e2e`
-  Matches the nightly workflow command path and leaves the stack up for log collection.
+  Matches the nightly workflow command path and leaves the stack up for logs.
 - `make e2e`
   Local wrapper around the same golden-path steps, with automatic teardown.
 
@@ -40,7 +41,8 @@ GitHub branch protection settings for `master`:
 - Require branches to be up to date before merging.
 - Require conversation resolution before merging.
 - Allow squash merge and prefer it as the default merge strategy.
-- If possible in repo settings, disable merge strategies that bypass the PR-title-as-canonical-signal model.
+- If possible, disable merge strategies that bypass the
+  PR-title that do not follow Conventional Commits 
 - Do not require nightly `E2E` or push-only integration checks for PR mergeability.
 
 ## Failure Artifacts
@@ -55,7 +57,9 @@ When CI fails, use these uploaded artifacts first:
 
 ## Design Notes
 
-- Presubmit is optimized for fast feedback. After the cheap repo-hygiene gate, lint, typecheck, and unit tests run in parallel.
-- Integration tests are deterministic but intentionally non-blocking for PR iteration.
-- Nightly E2E stays separate because it validates the dockerized golden path rather than the fast developer loop.
-- Conventional Commit PR titles are part of the presubmit contract because squash merges make the PR title the canonical commit message on `master`.
+- Presubmit is for fast feedback. After repo hygiene passes, lint, typecheck,
+  and unit tests run in parallel.
+- Integration tests are deterministic but non-blocking for commiting to a PR.
+- Nightly E2E is separate because it validates the golden path (dockerized), not in the fast developer loop.
+- Conventional Commit PR titles matter because squash merges make the PR title
+  the canonical commit message on `master` and are added to `CHANGELOG.md`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,7 +1,7 @@
 # Release Process
 
-This repository uses Release Please to manage version bumps, changelog updates,
-release PRs, and Git tags.
+This repo uses Release Please for versioning, changelog updates, release PRs,
+and Git tags.
 
 ## Source Of Truth
 
@@ -61,12 +61,12 @@ If Release Please reports that a tag already exists:
   - `CHANGELOG.md`
   - `.release-please-manifest.json`
 
-If the tag exists and the manifest is stale, fix the manifest to the published
-version and rerun the workflow.
+If the tag exists and the manifest is stale, update the manifest to the
+published version and rerun the workflow.
 
 ## Operator Rules
 
-- Keep `pyproject.toml` version, `CHANGELOG.md`, and
+- Keep `pyproject.toml`, `CHANGELOG.md`, and
   `.release-please-manifest.json` aligned.
 - Use squash merge consistently.
 - Do not assume every merged PR will result in a release PR.

--- a/mlflow_server/Dockerfile
+++ b/mlflow_server/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.11-slim
 
-# Keep runtime small but functional: curl for healthchecks/debugging.
+# Keep the runtime small. curl is used for health checks.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Pin MLflow to a minor line for stability (adjust if you want a different minor).
-# psycopg2-binary: Postgres backend store
-# boto3: S3/MinIO artifacts
+# Pin MLflow to a stable minor line.
+# psycopg2-binary is for the Postgres backend store.
+# boto3 is for S3/MinIO artifacts.
 RUN pip install --no-cache-dir \
   "mlflow==2.14.*" \
   psycopg2-binary \

--- a/mlflow_server/start.sh
+++ b/mlflow_server/start.sh
@@ -9,7 +9,7 @@ set -eu
 : "${BACKEND_STORE_URI:?BACKEND_STORE_URI must be set}"
 : "${ARTIFACT_ROOT:?ARTIFACT_ROOT must be set}"
 
-# Optional: helpful to see what config the container got
+# Log the resolved config.
 echo "[mlflow-server] starting"
 echo "[mlflow-server] host=${MLFLOW_HOST} port=${MLFLOW_PORT}"
 echo "[mlflow-server] backend_store_uri=${BACKEND_STORE_URI}"
@@ -18,10 +18,8 @@ if [ -n "${MLFLOW_S3_ENDPOINT_URL:-}" ]; then
   echo "[mlflow-server] s3_endpoint=${MLFLOW_S3_ENDPOINT_URL}"
 fi
 
-# NOTE:
-# We intentionally do NOT pass --serve-artifacts.
-# With S3/MinIO artifact stores, clients upload artifacts directly using boto3.
-# This keeps the MLflow server simple and avoids version/flag mismatches.
+# Do not pass --serve-artifacts.
+# With S3/MinIO, clients upload artifacts directly with boto3.
 exec mlflow server \
   --host "${MLFLOW_HOST}" \
   --port "${MLFLOW_PORT}" \

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# Centralized constants across pipeline steps.
+# Shared constants.
 
 # Contracts schema versions
 DATASET_FINGERPRINT_SCHEMA_VERSION = "dataset_fingerprint/v1"
@@ -8,7 +8,7 @@ MODEL_REF_SCHEMA_VERSION = "model_ref/v1"
 FEATURE_STATS_SCHEMA_VERSION = "feature_stats/v1"
 REPRO_CONTRACT_SCHEMA_VERSION = "repro_contract/v1"
 
-# MLflow tags (keys)
+# MLflow tag keys
 TAG_STEP = "step"
 TAG_MODEL_NAME = "model_name"
 
@@ -19,8 +19,8 @@ TAG_ROW_COUNT = "row_count"
 TAG_DATA_SOURCE_URI = "data_source_uri"
 
 # Promotion guardrail tags
-# NOTE: Dataset lineage already exists as multiple tags (content/schema hashes, row_count, uri).
-# For promotion safety we additionally compute a single stable fingerprint hash.
+# Dataset lineage already exists as several tags. Promotion also uses one stable
+# fingerprint hash.
 TAG_DATASET_FINGERPRINT = "dataset_fingerprint"
 TAG_CONFIG_HASH = "config_hash"
 TAG_TRAINING_RUN_ID = "training_run_id"
@@ -36,7 +36,7 @@ TAG_PREVIOUS_PROD_VERSION = "previous_prod_version"
 
 # MLflow tag values
 GATE_PASSED = "passed"
-GATE_FAILED = "failed"  # for later - tests
+GATE_FAILED = "failed"  # Used in tests.
 RELEASE_STATUS_PREVIOUS_PROD = "previous_prod"
 
 # Steps
@@ -47,7 +47,7 @@ STEP_EVALUATE = "evaluate"
 STEP_REGISTER = "register"
 STEP_PROMOTE = "promote"
 
-# Artifacts (filenames)
+# Artifact file names
 ART_TRAIN_RUN_ID = "TRAIN_RUN_ID"
 ART_GATE_OK = "gate_ok.txt"
 ART_REGISTERED_VERSION = "REGISTERED_VERSION"
@@ -61,7 +61,7 @@ ART_REPRO_EXPECTED_PREDICTIONS_JSON = "expected_predictions.json"
 ART_REPRO_REPORT_JSON = "reproduce_report.json"
 ART_UV_LOCK = "uv.lock"
 
-# Artifact paths (within MLflow)
+# Artifact paths inside MLflow
 MLFLOW_ARTIFACT_PATH_REPORTS = "reports"
 MLFLOW_ARTIFACT_PATH_MODEL = "model"
 MLFLOW_ARTIFACT_PATH_REPRO = "repro"
@@ -71,7 +71,7 @@ ALIAS_CANDIDATE = "candidate"
 ALIAS_PROD = "prod"
 ALIAS_CHAMPION = "champion"
 
-# Target file names
+# Dataset file names
 LABEL_COL = "target"
 RAW_CSV = "raw.csv"
 TRAIN_CSV = "train.csv"

--- a/src/ml_lifecycle_platform/common/dataset_fingerprint.py
+++ b/src/ml_lifecycle_platform/common/dataset_fingerprint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-# Backwards-compatible import path.
-# New canonical location: ml_lifecycle_platform.contracts.dataset_fingerprint
+# Backward-compatible import path.
+# Canonical location: ml_lifecycle_platform.contracts.dataset_fingerprint
 from ml_lifecycle_platform.contracts.dataset_fingerprint import (  # noqa: F401
     DatasetFingerprint,
     compute_fingerprint,

--- a/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
+++ b/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
@@ -23,7 +23,7 @@ from ml_lifecycle_platform.common.constants import (
 
 @dataclass(frozen=True)
 class DatasetFingerprint:
-    """Minimal dataset lineage contract for a model training run."""
+    """Dataset lineage contract for one training run."""
 
     git_sha: str
     dataset_content_hash: str
@@ -80,13 +80,7 @@ def _sha256_bytes(payload: bytes) -> str:
 
 
 def get_git_sha() -> str:
-    """Return current git SHA if available.
-
-    Order of precedence:
-      1) GIT_SHA env var (recommended in CI)
-      2) `git rev-parse HEAD` if repo is present in container
-      3) "unknown"
-    """
+    """Return the current git SHA if available."""
     env_sha = os.getenv("GIT_SHA")
     if env_sha:
         return env_sha.strip()
@@ -101,14 +95,14 @@ def get_git_sha() -> str:
 
 
 def schema_hash(df: pd.DataFrame) -> str:
-    """Hash only schema: column names + dtypes."""
+    """Hash only the schema: column names and dtypes."""
     schema = [(str(c), str(df[c].dtype)) for c in df.columns]
     payload = json.dumps(schema, separators=(",", ":"), sort_keys=False).encode("utf-8")
     return _sha256_bytes(payload)
 
 
 def content_hash(df: pd.DataFrame, *, index_cols: Sequence[str] | None = None) -> str:
-    """Hash dataset content in a deterministic way."""
+    """Hash dataset content deterministically."""
     df2 = df.copy()
     df2 = df2.reindex(sorted(df2.columns), axis=1)
 
@@ -130,7 +124,7 @@ def compute_fingerprint(
     index_cols: Sequence[str] | None = None,
     git_sha: str | None = None,
 ) -> DatasetFingerprint:
-    """Fingerprint over training+test membership."""
+    """Fingerprint the combined train and test data."""
     combined = pd.concat([train_df, test_df], axis=0, ignore_index=True)
     return DatasetFingerprint(
         git_sha=get_git_sha() if git_sha is None else git_sha,

--- a/src/ml_lifecycle_platform/contracts/feature_stats.py
+++ b/src/ml_lifecycle_platform/contracts/feature_stats.py
@@ -10,7 +10,7 @@ from ml_lifecycle_platform.common.constants import FEATURE_STATS_SCHEMA_VERSION
 
 @dataclass(frozen=True)
 class FeatureStats:
-    """Skeleton contract for feature distribution stats."""
+    """Feature distribution stats contract."""
 
     stats: dict[str, dict[str, float]]
     schema_version: str = FEATURE_STATS_SCHEMA_VERSION

--- a/src/ml_lifecycle_platform/contracts/model_ref.py
+++ b/src/ml_lifecycle_platform/contracts/model_ref.py
@@ -10,7 +10,7 @@ from ml_lifecycle_platform.common.constants import MODEL_REF_SCHEMA_VERSION
 
 @dataclass(frozen=True)
 class ModelRef:
-    """Reference to a model in the registry or a specific run artifact."""
+    """Reference to a registry model or run artifact."""
 
     model_name: str
     alias: str | None = None

--- a/src/ml_lifecycle_platform/pipeline/evaluate.py
+++ b/src/ml_lifecycle_platform/pipeline/evaluate.py
@@ -35,7 +35,7 @@ def main() -> None:
     X_test = test_df.drop(columns=[LABEL_COL])
     y_test = test_df[LABEL_COL].astype(int)
 
-    # Orchestrator passes TRAIN_RUN_ID
+    # The orchestrator writes TRAIN_RUN_ID.
     train_run_id = (ART_DIR / ART_TRAIN_RUN_ID).read_text(encoding="utf-8").strip()
 
     model_uri = f"runs:/{train_run_id}/{MLFLOW_ARTIFACT_PATH_MODEL}"
@@ -54,7 +54,7 @@ def main() -> None:
     report_path = ART_DIR / ART_EVALUATION_JSON
     write_json(report_path, metrics)
 
-    # ROC curve
+    # ROC curve.
     fig_path = ART_DIR / ART_ROC_CURVE_PNG
     plt.figure()
     RocCurveDisplay.from_predictions(y_test, proba)
@@ -69,7 +69,7 @@ def main() -> None:
         )
         mlflow.log_artifact(str(fig_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
 
-        # Gate decision (simple): roc_auc >= 0.95
+        # Simple gate: roc_auc >= 0.95.
         gate_ok = metrics["eval_roc_auc"] >= 0.95
         gate_path = ART_DIR / ART_GATE_OK
         gate_path.write_text("true" if gate_ok else "false", encoding="utf-8")

--- a/src/ml_lifecycle_platform/pipeline/featurize.py
+++ b/src/ml_lifecycle_platform/pipeline/featurize.py
@@ -64,7 +64,7 @@ def main() -> None:
     train_df.to_csv(train_path, index=False)
     test_df.to_csv(test_path, index=False)
 
-    # Keep it simple + compatible with your train.py which loads this artifact.
+    # Keep this compatible with train.py, which loads this artifact.
     preprocessor = Pipeline(
         steps=[
             ("scale", StandardScaler(with_mean=True, with_std=True)),

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -31,11 +31,7 @@ def _run_step(module: str) -> None:
 
 
 def _latest_train_run_id(experiment_id: str) -> str:
-    """Return the most recent train run id for an experiment.
-
-    MLflow has changed the return type of `search_runs` across versions
-    (DataFrame vs. list[Run]). Handle both to keep the orchestrator stable.
-    """
+    """Return the most recent train run id for an experiment."""
     runs = mlflow.search_runs(
         experiment_ids=[experiment_id],
         filter_string=f"tags.{TAG_STEP} = '{STEP_TRAIN}'",
@@ -43,7 +39,7 @@ def _latest_train_run_id(experiment_id: str) -> str:
         max_results=1,
     )
 
-    # MLflow <=2.x returns a pandas DataFrame.
+    # MLflow <=2.x returns a DataFrame.
     if hasattr(runs, "empty") and hasattr(runs, "iloc"):
         if runs.empty:  # type: ignore[attr-defined]
             raise RuntimeError("No train run found after training step.")

--- a/src/ml_lifecycle_platform/policy/release_policy.py
+++ b/src/ml_lifecycle_platform/policy/release_policy.py
@@ -37,7 +37,7 @@ class PromotionPolicyClient(Protocol):
 
 @dataclass(frozen=True)
 class Violation:
-    """A single policy violation or warning."""
+    """Policy violation or warning."""
 
     code: str
     message: str
@@ -46,11 +46,7 @@ class Violation:
 
 @dataclass(frozen=True)
 class PolicyDecision:
-    """Structured policy outcome for promotion gating.
-
-    - errors: hard blocks (allowed=False)
-    - warnings: allowed can still be True, but operator should be aware
-    """
+    """Result of promotion policy evaluation."""
 
     allowed: bool
     errors: tuple[Violation, ...]
@@ -87,12 +83,7 @@ def evaluate_promotion_policy(
     from_alias: str = ALIAS_CANDIDATE,
     to_alias: str = ALIAS_PROD,
 ) -> PolicyDecision:
-    """Evaluate promotion policy with zero side effects.
-
-    This function must remain PURE:
-      - no set_registered_model_alias
-      - no set_model_version_tag
-    """
+    """Evaluate promotion policy without side effects."""
     errors: list[Violation] = []
     warnings: list[Violation] = []
 
@@ -122,11 +113,10 @@ def evaluate_promotion_policy(
             context=context,
         )
 
-    # Load candidate model version
     candidate = client.get_model_version(model_name, candidate_version)
     candidate_tags = candidate.tags or {}
 
-    # Helpful context for debugging
+    # Debug context.
     context["candidate_tags_subset"] = {
         TAG_GATE: candidate_tags.get(TAG_GATE, ""),
         TAG_RELEASE_STATUS: candidate_tags.get(TAG_RELEASE_STATUS, ""),
@@ -137,7 +127,7 @@ def evaluate_promotion_policy(
         TAG_TRAINING_RUN_ID: candidate_tags.get(TAG_TRAINING_RUN_ID, ""),
     }
 
-    # Policy: must have required metadata tags
+    # Required metadata tags.
     missing = _missing_required_tags(candidate_tags)
     if missing:
         errors.append(
@@ -148,7 +138,7 @@ def evaluate_promotion_policy(
             )
         )
 
-    # Policy: gate must be passed
+    # Gate must pass.
     gate_val = str(candidate_tags.get(TAG_GATE, "")).strip()
     if gate_val != GATE_PASSED:
         errors.append(
@@ -159,7 +149,7 @@ def evaluate_promotion_policy(
             )
         )
 
-    # Policy: release_status must match the from_alias (candidate)
+    # release_status must match the source alias.
     rs_val = str(candidate_tags.get(TAG_RELEASE_STATUS, "")).strip()
     if rs_val != from_alias:
         errors.append(
@@ -170,7 +160,7 @@ def evaluate_promotion_policy(
             )
         )
 
-    # Policy: prevent no-op promotions (candidate already prod)
+    # Block no-op promotions.
     if current_prod_version is not None and str(current_prod_version) == str(
         candidate_version
     ):
@@ -185,7 +175,7 @@ def evaluate_promotion_policy(
             )
         )
 
-    # Warnings (non-blocking) — auditability / traceability
+    # Non-blocking auditability checks.
     if not str(candidate_tags.get(TAG_SOURCE_RUN_ID, "")).strip():
         warnings.append(
             Violation(
@@ -195,7 +185,7 @@ def evaluate_promotion_policy(
             )
         )
     else:
-        # Optional: validate the run exists (auditability)
+        # Best-effort run lookup.
         run_id = str(candidate_tags.get(TAG_SOURCE_RUN_ID, "")).strip()
         try:
             client.get_run(run_id)

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -32,7 +32,7 @@ def _print_decision(decision: PolicyDecision, fmt: str) -> None:
         print(json.dumps(decision.to_dict(), indent=2, sort_keys=True))
         return
 
-    # text format
+    # Text output.
     print(f"allowed={decision.allowed}")
     for v in decision.errors:
         print(f"ERROR {v.code}: {v.message} {v.details}")
@@ -52,14 +52,14 @@ def _try_get_prod_version(client: MlflowClient, model_name: str) -> str | None:
 def apply_promotion(
     client: MlflowClient, model_name: str, candidate_version: str, from_alias: str
 ) -> None:
-    """Apply promotion side effects. Call only after policy allows it."""
+    """Apply promotion side effects after policy allows it."""
     prev_prod_version = _try_get_prod_version(client, model_name)
 
-    # 1) Set aliases
+    # Set aliases.
     client.set_registered_model_alias(model_name, ALIAS_PROD, candidate_version)
     client.set_registered_model_alias(model_name, ALIAS_CHAMPION, candidate_version)
 
-    # 2) Promotion evidence tags on the new prod version
+    # Tag the new prod version.
     client.set_model_version_tag(
         name=model_name,
         version=candidate_version,
@@ -73,7 +73,7 @@ def apply_promotion(
         value=from_alias,
     )
 
-    # 3) Persist previous prod version for deterministic rollback
+    # Store the previous prod version for rollback.
     if prev_prod_version is not None:
         client.set_model_version_tag(
             name=model_name,
@@ -82,7 +82,7 @@ def apply_promotion(
             value=prev_prod_version,
         )
 
-        # Optional: mark old prod release_status as previous_prod (nice audit trail)
+        # Best-effort audit tag on the old prod version.
         try:
             client.set_model_version_tag(
                 name=model_name,
@@ -91,7 +91,7 @@ def apply_promotion(
                 value=RELEASE_STATUS_PREVIOUS_PROD,
             )
         except Exception:
-            # Best-effort only; do not break promotion if we can't tag old prod.
+            # Do not fail promotion if this tag write fails.
             logger.info(
                 "Could not mark old prod version %s as %s",
                 prev_prod_version,
@@ -139,11 +139,11 @@ def main(argv: list[str] | None = None) -> None:
     _print_decision(decision, args.format)
 
     if args.dry_run:
-        # IMPORTANT: no side effects in dry-run
+        # Dry-run must not mutate state.
         raise SystemExit(0 if decision.allowed else 2)
 
     if not decision.allowed:
-        # Not allowed: do not mutate anything
+        # Blocked. Do not mutate state.
         raise SystemExit(2)
 
     candidate_version = str(decision.context["candidate_version"])

--- a/src/ml_lifecycle_platform/registry/register.py
+++ b/src/ml_lifecycle_platform/registry/register.py
@@ -85,7 +85,7 @@ def main() -> None:
 
     mv = mlflow.register_model(model_uri=model_uri, name=model_name)
 
-    # Minimum traceability for the model version.
+    # Minimum traceability tags.
     client.set_model_version_tag(
         model_name, mv.version, TAG_SOURCE_RUN_ID, train_run_id
     )
@@ -94,7 +94,7 @@ def main() -> None:
         model_name, mv.version, TAG_RELEASE_STATUS, ALIAS_CANDIDATE
     )
 
-    # Copy fingerprint/config tags from the training run onto the model version.
+    # Copy fingerprint and config tags from the training run.
     for key in FINGERPRINT_TAG_KEYS:
         value = str(run_tags.get(key, "")).strip()
         if value:

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -12,18 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def rollback_prod(client: MlflowClient, model_name: str) -> None:
-    """Rolls back prod to the previously recorded prod version.
-
-    Contract (strict):
-      - prod alias must exist
-      - current prod version must have TAG_PREVIOUS_PROD_VERSION
-      - rollback flips prod alias to the previous version
-      - after rollback, we set TAG_PREVIOUS_PROD_VERSION on the restored version so the
-        user can "undo" the rollback once (swap back).
-
-    Raises:
-      RuntimeError: if rollback metadata is missing.
-    """
+    """Roll back prod to the recorded previous prod version."""
     current_prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
     tags = current_prod.tags or {}
     prev = str(tags.get(TAG_PREVIOUS_PROD_VERSION, "")).strip()
@@ -36,7 +25,7 @@ def rollback_prod(client: MlflowClient, model_name: str) -> None:
 
     client.set_registered_model_alias(model_name, ALIAS_PROD, prev)
 
-    # Allow a one-step "undo": after rollback to prev, set prev's pointer to the version we came from.
+    # Allow a one-step undo.
     client.set_model_version_tag(
         name=model_name,
         version=prev,

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -34,7 +34,7 @@ from .settings import Settings, get_settings
 logger = logging.getLogger("serving")
 
 
-# Model cache (module-level so tests can monkeypatch)
+# Module-level cache. Tests monkeypatch it.
 model_prod: Any | None = None
 model_candidate: Any | None = None
 prod_version: str | None = None
@@ -42,9 +42,8 @@ candidate_version: str | None = None
 _last_refresh_ts: float = 0.0
 
 
-# App lifecycle
 def _configure_logging(settings: Settings) -> None:
-    # Being called repeatedly, basicConfig is a no-op after first call.
+    # Safe to call more than once.
     logging.basicConfig(level=settings.log_level)
 
 
@@ -60,17 +59,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(lifespan=lifespan)
 
 
-# Middleware
 @app.middleware("http")
 async def request_id_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
-    """Ensure every request has a request-id.
-
-    If client supplies X-Request-Id, keep it for deterministic bucketing.
-    Otherwise generate one.
-    """
+    """Set or preserve the request ID."""
     incoming = request.headers.get(HEADER_REQUEST_ID)
     if incoming and incoming.strip():
         request.state.request_id = incoming.strip()
@@ -89,11 +83,11 @@ async def coarse_metrics_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
-    """Count all requests (bounded labels)."""
+    """Count requests with bounded labels."""
 
     endpoint = request.url.path
 
-    # Avoid self-scrape recursion / noise.
+    # Skip self-scrape noise.
     if endpoint == "/metrics":
         return await call_next(request)
 
@@ -116,7 +110,6 @@ async def coarse_metrics_middleware(
     return response
 
 
-# Schemas
 class PredictRequest(BaseModel):
     rows: list[dict[str, Any]] = Field(
         ..., description="List of feature dicts (one per row)"
@@ -133,15 +126,11 @@ class PredictResponse(BaseModel):
     bucket_seed_source: str | None = None
 
 
-# Registry / model helpers
 class _UnitTestModel:
-    """Minimal model stub for unit tests.
-
-    Keeps /predict behavior stable without requiring MLflow.
-    """
+    """Deterministic stub for unit tests."""
 
     def predict(self, df: pd.DataFrame) -> list[float]:
-        # Return deterministic "probabilities" in [0,1].
+        # Return deterministic probabilities in [0, 1].
         n = len(df)
         return [1.0] * n
 
@@ -151,7 +140,7 @@ def _models_uri(settings: Settings, alias: str) -> str:
 
 
 def _registry_resolves_prod_alias(settings: Settings) -> tuple[bool, str | None]:
-    """Return (ok, detail). Simple MLflow call."""
+    """Return whether the prod alias resolves."""
     if settings.unit_testing:
         return True, None
     if mlflow is None:
@@ -177,14 +166,14 @@ def _get_version(settings: Settings, alias: str) -> str | None:
 
 
 def _load_model(settings: Settings, alias: str) -> Any:
-    # In unit tests, always return a deterministic stub model.
+    # Unit tests always use a deterministic stub.
     if settings.unit_testing:
         return _UnitTestModel()
 
     if mlflow is None:
         raise RuntimeError("mlflow not available in serving image")
 
-    # Defensive: sometimes people accidentally install a stub/namespace package named "mlflow".
+    # Guard against broken or stub MLflow installs.
     pyfunc = getattr(mlflow, "pyfunc", None)
     if pyfunc is None:
         raise RuntimeError("mlflow.pyfunc is missing (mlflow install is broken)")
@@ -198,10 +187,7 @@ def _refresh_models_if_needed(
     force: bool = False,
     load_candidate: bool = False,
 ) -> None:
-    """Populate model_prod/model_candidate and versions.
-
-    Globals are intentional: tests can monkeypatch without MLflow.
-    """
+    """Refresh cached models and versions."""
     global \
         model_prod, \
         model_candidate, \
@@ -250,7 +236,7 @@ def _get_model(
 
 
 def _prod_model_loadable(settings: Settings) -> tuple[bool, str | None]:
-    """Return (ok, detail). Ensures prod model can be used for traffic."""
+    """Return whether the prod model is loadable."""
     try:
         _ = _get_model(settings, ALIAS_PROD, required=True)
         return True, None
@@ -258,10 +244,9 @@ def _prod_model_loadable(settings: Settings) -> tuple[bool, str | None]:
         return False, f"prod model not loadable: {e}"
 
 
-# Health / metrics
 @app.get("/livez")
 def livez() -> dict[str, str]:
-    # No dependencies, no MLflow calls.
+    # No dependencies.
     return {"status": "alive"}
 
 
@@ -319,7 +304,6 @@ def metrics() -> Response:
     return Response(payload, media_type=CONTENT_TYPE_LATEST)
 
 
-# Prediction
 @app.post("/predict", response_model=PredictResponse)
 async def predict(
     request: Request,
@@ -338,7 +322,7 @@ async def predict(
     shadow_mae: float | None = None
 
     try:
-        # Routing decision (deterministic bucket only in canary mode)
+        # Bucket only matters in canary mode.
         if mode == "canary":
             bd = choose_canary_bucket(
                 BucketContext(
@@ -371,13 +355,13 @@ async def predict(
             ALIAS_CANDIDATE if primary_alias == ALIAS_PROD else ALIAS_PROD,
         )
 
-        # Important: ensure candidate is loaded only when needed (candidate traffic or shadow run).
+        # Load candidate only when needed.
         _refresh_models_if_needed(
             settings,
             load_candidate=(primary_alias == ALIAS_CANDIDATE or decision.run_shadow),
         )
 
-        # Primary model must exist for prod/candidate routes.
+        # Primary model must exist.
         model_primary = _get_model(settings, primary_alias, required=True)
         if model_primary is None:
             status_code = 503
@@ -389,7 +373,7 @@ async def predict(
         y_primary = model_primary.predict(df)  # type: ignore[union-attr]
         y_primary_list = [float(x) for x in list(y_primary)]
 
-        # Optional shadow prediction (best-effort, never fails request)
+        # Shadow prediction is best-effort.
         if decision.run_shadow:
             model_shadow = _get_model(settings, shadow_alias, required=False)
             if model_shadow is not None:

--- a/src/ml_lifecycle_platform/serving/constants.py
+++ b/src/ml_lifecycle_platform/serving/constants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-# Serving-side constants (serving is built as a separate image, we don't import from project/*)
+# Serving builds as a separate image. Keep local constants here.
 
 DEFAULT_MODEL_NAME = "breast_cancer_clf"
 

--- a/src/ml_lifecycle_platform/serving/metrics.py
+++ b/src/ml_lifecycle_platform/serving/metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from prometheus_client import Counter, Histogram
 
-# Labels are bounded, we do not label by request_id, model_name, etc.
+# Labels stay bounded. Do not label by request_id, model_name, or similar.
 REQUESTS_TOTAL = Counter(
     "requests_total",
     "Total HTTP requests handled by the serving API.",
@@ -13,7 +13,7 @@ PREDICT_LATENCY_SECONDS = Histogram(
     "predict_latency_seconds",
     "Latency of /predict requests in seconds.",
     labelnames=("mode", "status", "chosen"),
-    # Optional buckets, Prometheus defaults work good for now.
+    # Prometheus defaults are fine for now.
 )
 
 SHADOW_DIFF_MAE = Histogram(

--- a/src/ml_lifecycle_platform/serving/router.py
+++ b/src/ml_lifecycle_platform/serving/router.py
@@ -19,7 +19,7 @@ Alias = Literal["prod", "candidate"]
 
 
 class SeedSource(StrEnum):
-    """Source of entropy used for deterministic bucketing."""
+    """Entropy source for deterministic bucketing."""
 
     REQUEST_ID = "request_id"
     PAYLOAD_HASH = "payload_hash"
@@ -28,11 +28,7 @@ class SeedSource(StrEnum):
 
 @dataclass(frozen=True)
 class RoutingDecision:
-    """Decision for which alias should be used for the response.
-
-    - chosen: the model alias used for the returned prediction
-    - run_shadow: whether we should ALSO run the other model for comparison/logging
-    """
+    """Routing result for one request."""
 
     chosen: Alias
     run_shadow: bool
@@ -40,14 +36,7 @@ class RoutingDecision:
 
 @dataclass(frozen=True)
 class BucketContext:
-    """Inputs for stable bucketing.
-
-    If the client provides a request id, we use it as the primary seed. This is
-    the only way to guarantee a stable bucket across retries.
-
-    If the client does NOT provide a request id, we fall back to the request
-    payload (stable for identical payloads), and finally to a random fallback.
-    """
+    """Inputs for deterministic bucketing."""
 
     request_id: str | None
     client_provided_request_id: bool
@@ -61,30 +50,24 @@ class BucketDecision:
 
 
 def stable_bucket_from_bytes(payload: bytes) -> int:
-    """Returns a stable bucket in [0, 99] for arbitrary bytes."""
+    """Return a stable bucket in [0, 99] for arbitrary bytes."""
     h = hashlib.sha256(payload).hexdigest()
     return int(h, 16) % 100
 
 
 def stable_bucket_from_str(seed: str) -> int:
-    """Returns a stable bucket in [0, 99] for a text seed."""
+    """Return a stable bucket in [0, 99] for a text seed."""
     return stable_bucket_from_bytes(seed.encode("utf-8"))
 
 
 def stable_bucket_from_rows(rows: list[dict[str, Any]]) -> int:
-    """Returns a stable bucket in [0, 99] based on request content."""
+    """Return a stable bucket in [0, 99] from request content."""
     payload = json.dumps(rows, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return stable_bucket_from_bytes(payload)
 
 
 def choose_canary_bucket(ctx: BucketContext) -> BucketDecision:
-    """Choose a bucket using a deterministic seed priority.
-
-    Priority:
-      1) client-provided request id (stable across retries)
-      2) payload hash (stable for identical payload)
-      3) random fallback (should be rare; kept for defensive robustness)
-    """
+    """Choose a bucket from request id, then payload, then random fallback."""
     if ctx.client_provided_request_id and ctx.request_id:
         return BucketDecision(
             bucket=stable_bucket_from_str(ctx.request_id),
@@ -97,7 +80,7 @@ def choose_canary_bucket(ctx: BucketContext) -> BucketDecision:
             seed_source=SeedSource.PAYLOAD_HASH,
         )
     except Exception:
-        # Defensive fallback: if payload isn't JSON-serializable for some reason.
+        # Fallback if the payload is not JSON-serializable.
         seed = secrets.token_hex(16)
         return BucketDecision(
             bucket=stable_bucket_from_str(seed),
@@ -106,23 +89,13 @@ def choose_canary_bucket(ctx: BucketContext) -> BucketDecision:
 
 
 def decide_routing(mode: Mode, canary_pct: int, bucket: int) -> RoutingDecision:
-    """Computes routing decision.
-
-    Rules:
-      - prod: return prod only
-      - candidate: return candidate only
-      - shadow: return prod, but also run candidate (compare/log)
-      - canary: if bucket < canary_pct -> return candidate and also run prod
-               else -> return prod and also run candidate
-
-    Note: we clamp canary_pct to [0, 100] for safety.
-    """
+    """Compute routing for one request."""
     if not (0 <= bucket <= 99):
         raise ValueError(f"bucket must be in [0, 99], got {bucket}")
 
     canary_pct = max(0, min(100, int(canary_pct)))
 
-    # Use serving.constants for alias strings (single source of truth)
+    # Use serving.constants as the single source of truth.
     prod: Alias = cast(Alias, ALIAS_PROD)
     candidate: Alias = cast(Alias, ALIAS_CANDIDATE)
 

--- a/src/ml_lifecycle_platform/serving/settings.py
+++ b/src/ml_lifecycle_platform/serving/settings.py
@@ -20,10 +20,7 @@ from .constants import (
 
 
 class Settings(BaseSettings):
-    """Serving configuration.
-
-    Small and operationally relevant.
-    """
+    """Serving configuration."""
 
     model_config = SettingsConfigDict(extra="ignore")
 
@@ -40,11 +37,11 @@ class Settings(BaseSettings):
 
     log_level: str = Field(default="INFO", validation_alias=ENV_LOG_LEVEL)
 
-    # Used to disable real MLflow loads during unit tests.
+    # Disable real MLflow loads in unit tests.
     unit_testing: bool = Field(default=False, validation_alias=ENV_UNIT_TESTING)
 
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
-    # Cached for stability + to avoid reparsing env vars on each request.
+    # Avoid reparsing env vars on every request.
     return Settings()

--- a/src/ml_lifecycle_platform/serving/smoke_test.py
+++ b/src/ml_lifecycle_platform/serving/smoke_test.py
@@ -10,7 +10,7 @@ SERVE_URL = os.getenv("SERVE_URL", "http://localhost:8000")
 
 
 def _wait_for_service() -> None:
-    """Wait until the service becomes healthy or raise."""
+    """Wait for the service to become healthy."""
     last_status: int | None = None
     last_body: str | None = None
 
@@ -31,11 +31,7 @@ def _wait_for_service() -> None:
 
 
 def _payload() -> dict[str, Any]:
-    """Return a minimal valid prediction payload.
-
-    IMPORTANT: feature names must match the training dataset schema.
-    sklearn breast_cancer uses spaces in column names (e.g. 'mean radius').
-    """
+    """Return a minimal valid prediction payload."""
     return {
         "rows": [
             {
@@ -87,13 +83,13 @@ def _assert_prediction_response(body: dict[str, Any]) -> None:
 def _call(mode: str, *, required: bool) -> None:
     r = requests.post(f"{SERVE_URL}/predict?mode={mode}", json=_payload(), timeout=15)
 
-    # In many deployments, only prod is guaranteed.
+    # Many deployments only guarantee prod.
     if r.status_code == 503 and not required:
         print(f"[smoke] mode={mode} SKIP (503): {r.text[:300]!r}")
         return
 
     if r.status_code >= 400:
-        # Make failures actionable in CI logs.
+        # Keep CI failures actionable.
         try:
             detail = r.json()
         except Exception:
@@ -114,7 +110,7 @@ def main() -> None:
     # prod must always work
     _call("prod", required=True)
 
-    # optional depending on deployment policy
+    # optional by deployment policy
     for mode in ["candidate", "shadow", "canary"]:
         _call(mode, required=False)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import mlflow
 import pytest
 
-# Allow running tests without requiring an editable install (useful for local dev).
+# Allow tests to run without an editable install.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -15,11 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 @pytest.fixture()
 def mlflow_sqlite(tmp_path: Path):
-    """Provide a local MLflow tracking+registry backend for unit tests.
-
-    We use sqlite as a backend store because the MLflow file store does not support
-    the model registry.
-    """
+    """Provide a local MLflow tracking and registry backend for unit tests."""
     db_path = tmp_path / "mlflow.db"
     artifacts = tmp_path / "artifacts"
     artifacts.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/serving/tests/conftest.py
+++ b/tests/unit/serving/tests/conftest.py
@@ -11,20 +11,16 @@ from ml_lifecycle_platform.serving.settings import get_settings
 
 @pytest.fixture()
 def client(monkeypatch: MonkeyPatch) -> Iterator[TestClient]:
-    """
-    Serve the FastAPI app in UNIT_TESTING mode so:
-    - no real MLflow is called
-    - models are deterministic stub models
-    """
+    """Serve the app in UNIT_TESTING mode with deterministic stub models."""
     monkeypatch.setenv("UNIT_TESTING", "1")
 
-    # Ensure settings cache is clean (Settings is cached via lru_cache)
+    # Clear the cached settings.
     get_settings.cache_clear()
 
-    # Import lazily after env is set, so settings pick it up.
+    # Import after env vars are set.
     import ml_lifecycle_platform.serving.app as app_module
 
-    # Ensure global model cache is clean between tests
+    # Clear the global model cache between tests.
     app_module.model_prod = None
     app_module.model_candidate = None
     app_module.prod_version = None

--- a/tests/unit/serving/tests/test_api_contract.py
+++ b/tests/unit/serving/tests/test_api_contract.py
@@ -31,7 +31,7 @@ def test_predict_modes_ok(client: TestClient, mode: str) -> None:
 
 
 def test_predict_invalid_payload_422(client: TestClient) -> None:
-    # send invalid JSON for Pydantic model
+    # Send invalid JSON for the Pydantic model.
     r = client.post(
         "/predict?mode=prod",
         content=b"not-json",
@@ -57,7 +57,7 @@ def test_request_id_header_is_generated_if_missing(client: TestClient) -> None:
         json={"rows": [{"f1": 1.0, "f2": 2.0, "f3": 3.0}]},
     )
     assert r.status_code == 200, r.text
-    # Middleware should add it
+    # Middleware should add it.
     rid = r.headers.get(HEADER_REQUEST_ID)
     assert isinstance(rid, str)
     assert rid != ""

--- a/tests/unit/serving/tests/test_metrics.py
+++ b/tests/unit/serving/tests/test_metrics.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.unit
 
 
 def _parse_labels(label_blob: str) -> dict[str, str]:
-    # a="b",c="d"
+    # Example: a="b",c="d"
     out: dict[str, str] = {}
     if not label_blob.strip():
         return out
@@ -20,7 +20,7 @@ def _parse_labels(label_blob: str) -> dict[str, str]:
 
 
 def _get_counter_value(text: str, metric_name: str, want: dict[str, str]) -> float:
-    # accept any label order
+    # Accept any label order.
     pat = re.compile(rf"^{re.escape(metric_name)}\{{([^}}]*)\}}\s+([0-9eE\.\+\-]+)$")
     for line in text.splitlines():
         m = pat.match(line)
@@ -35,7 +35,7 @@ def _get_counter_value(text: str, metric_name: str, want: dict[str, str]) -> flo
 def test_predict_increments_metrics(client: TestClient) -> None:
     base = client.get("/metrics").text
 
-    # middleware labels: endpoint, mode, status
+    # Middleware labels are endpoint, mode, and status.
     labels = {"endpoint": "/predict", "mode": "prod", "status": "200"}
     base_count = _get_counter_value(base, "requests_total", labels)
 

--- a/tests/unit/serving/tests/test_readiness.py
+++ b/tests/unit/serving/tests/test_readiness.py
@@ -7,8 +7,8 @@ pytestmark = pytest.mark.unit
 
 
 def test_readyz_is_ok_in_unit_testing_mode(client: TestClient) -> None:
-    # In UNIT_TESTING mode, app should be ready immediately.
+    # UNIT_TESTING mode should be ready immediately.
     r = client.get("/readyz")
     assert r.status_code == 200
-    # Endpoint returns plain text in this implementation
+    # This endpoint returns plain text.
     assert r.text.strip() == "ready"

--- a/tests/unit/serving/tests/test_router.py
+++ b/tests/unit/serving/tests/test_router.py
@@ -43,7 +43,7 @@ def test_choose_canary_bucket_falls_back_to_payload_hash_when_no_request_id() ->
 
 
 def test_decide_routing_is_deterministic_given_bucket() -> None:
-    # routing is a pure function of (mode, canary_pct, bucket)
+    # Routing is a pure function of (mode, canary_pct, bucket).
     bucket = 10
     r1 = decide_routing(mode="canary", canary_pct=20, bucket=bucket)
     r2 = decide_routing(mode="canary", canary_pct=20, bucket=bucket)

--- a/tests/unit/test_release_policy.py
+++ b/tests/unit/test_release_policy.py
@@ -29,13 +29,13 @@ class _ModelVersion:
 
 
 class MlflowClientStub:
-    """Tiny stub for policy and promote dry-run tests."""
+    """Small stub for policy and promote dry-run tests."""
 
     def __init__(self) -> None:
         self._aliases: dict[tuple[str, str], str] = {}
         self._versions: dict[tuple[str, str], _ModelVersion] = {}
 
-        # Mutation call tracking
+        # Track mutation calls.
         self.set_registered_model_alias_calls: list[
             tuple[tuple[Any, ...], dict[str, Any]]
         ] = []
@@ -51,7 +51,7 @@ class MlflowClientStub:
     def set_alias(self, model_name: str, alias: str, version: str) -> None:
         self._aliases[(model_name, alias)] = version
 
-    # --- Read APIs used by policy ---
+    # Read APIs used by policy.
     def get_model_version_by_alias(self, model_name: str, alias: str) -> _ModelVersion:
         v = self._aliases[(model_name, alias)]
         return self._versions[(model_name, v)]
@@ -60,10 +60,10 @@ class MlflowClientStub:
         return self._versions[(model_name, version)]
 
     def get_run(self, run_id: str) -> dict[str, str]:
-        # default: pretend it exists
+        # Default: pretend it exists.
         return {"run_id": run_id}
 
-    # --- Write APIs used by apply_promotion (should not be called in dry-run) ---
+    # Write APIs used by apply_promotion. Dry-run must not call them.
     def set_registered_model_alias(self, *args: Any, **kwargs: Any) -> None:
         self.set_registered_model_alias_calls.append((args, kwargs))
 
@@ -149,12 +149,12 @@ def test_dry_run_mode_has_zero_mutations(monkeypatch: pytest.MonkeyPatch) -> Non
     client.put_version("m", "1", tags)
     client.set_alias("m", ALIAS_CANDIDATE, "1")
 
-    # Patch the configured MLflow client helper to return our stub instance.
+    # Return the stub from the configured MLflow client helper.
     import ml_lifecycle_platform.registry.promote as promote_mod
 
     monkeypatch.setattr(promote_mod, "mlflow_client", lambda: client)
 
-    # Run promote in dry-run mode: must exit 0 and must not mutate
+    # Dry-run must exit 0 and must not mutate.
     with pytest.raises(SystemExit) as e:
         promote_main(["--model-name", "m", "--dry-run", "--format", "json"])
     assert e.value.code == 0


### PR DESCRIPTION
## What

- add `docs/architecture/m0-portability-charter.md`
- add `docs/adrs/ADR-0001-portability-surface.md`
- add `docs/adrs/ADR-0002-mlflow-control-plane.md`
- add a local sequence diagram for `train -> evaluate -> register -> promote -> serve`
- add explicit M0 anti-goals
- cross-link the charter from `README.md` and `CONTRIBUTING.md`

## Why

Freeze the M0 target shape before code movement.

Closes #43 

## How

- document the target repo and package shape for `core`, `backends`, `runtime`, `cli`, `configs`, and `deployments`
- limit M0 portability to `ArtifactStore`, `EventStore`, `JobRunner`, and `Secrets`
- keep MLflow as the M0 registry and release-control source of truth
- preserve the current local Docker Compose path

## Testing

- [ ] Unit
- [ ] Integration / E2E
- [x] Manual

Manual checks:
- reviewer check that planned package and file homes are named in the charter
- cross-link check from `README.md` and `CONTRIBUTING.md` into the charter

## Risk

Docs-only change.
No behavior change.
No code movement.
No deployment change.

## Rollback

Revert this docs-only commit.