### PR TITLE
fix(ci): guard Docker Python version and add PR docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11.7"
+  SUPPORTED_PYTHON_MM: "3.11"
   UV_PYTHON_DOWNLOADS: never
 
 jobs:
@@ -73,6 +74,42 @@ jobs:
           set -euo pipefail
           uv run ruff check --output-format=github .
 
+  docker-python-version-check:
+    name: Docker Python Version Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: hygiene
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Docker runtime Python version
+        run: |
+          set -euo pipefail
+          scripts/check_docker_python_version.sh "${{ env.SUPPORTED_PYTHON_MM }}"
+
+  docker-build:
+    name: Docker Build (platform + serving)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: docker-python-version-check
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build platform image
+        run: |
+          set -euo pipefail
+          docker build --target platform --tag mlp-platform:ci .
+
+      - name: Build serving image
+        run: |
+          set -euo pipefail
+          docker build --target serving --tag mlp-serving:ci .
 
   typecheck:
     name: Typecheck (mypy)
@@ -185,7 +222,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint, typecheck, unit]
+    needs: [lint, typecheck, unit, docker-build]
 
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-# syntax=docker/dockerfile:1.6
-
 # One Dockerfile for the app repo.
 # Use build targets from docker-compose:
 #   - target: platform
 #   - target: serving
 
-FROM python:3.14-slim AS base
+FROM python:3.11-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -16,7 +14,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Practical base: git for registry URIs, curl for healthchecks, uv for locked installs.
+# Base: git for registry URIs, curl for healthchecks, uv for locked installs.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git curl \
   && rm -rf /var/lib/apt/lists/*
@@ -32,14 +30,14 @@ COPY src /app/src
 # Install the package and runtime dependencies from the root lockfile.
 RUN uv sync --frozen --no-dev
 
-# --- Serving image ----------------------------------------------------------
+# Serving image
 FROM base AS serving
 
 EXPOSE 8000
 CMD ["uv", "run", "--no-dev", "uvicorn", "ml_lifecycle_platform.serving.app:app", "--host", "0.0.0.0", "--port", "8000"]
 
-# --- Platform image (pipeline/promote/rollback one-shot jobs) ---------------
+# Platform image (pipeline/promote/rollback one-shot jobs)
 FROM base AS platform
 
-# docker-compose overrides CMD per service; keep a sane default.
+# docker-compose overrides CMD per service.
 CMD ["uv", "run", "--no-dev", "python", "-m", "ml_lifecycle_platform.pipeline.orchestrate"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,6 @@ services:
       retries: 30
 
     # The mlflow_server image already uses ENTRYPOINT ["/start.sh"].
-    # If that changes, use:
-    # command: ["/start.sh"]
 
   pipeline:
     build:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -4,8 +4,8 @@ This repo uses three CI lanes with different scopes:
 
 | Lane | Workflow | Trigger | Scope |
 | --- | --- | --- | --- |
-| Presubmit | `CI` | pull requests | repo hygiene, lint, typecheck, unit tests (usual checks) |
-| Postsubmit | `CI` | push to `master` | repo hygiene, lint, typecheck, unit tests, integration tests |
+| Presubmit | `CI` | pull requests | repo hygiene, docker runtime version guard, docker build (platform + serving), lint, typecheck, unit tests |
+| Postsubmit | `CI` | push to `master` | repo hygiene, docker runtime version guard, docker build (platform + serving), lint, typecheck, unit tests, integration tests |
 | Nightly | `E2E` | schedule + manual dispatch | golden-path verification |
 
 ## Required PR Checks
@@ -14,6 +14,8 @@ Recommended required status checks for `master` branch protection:
 
 - `PR Title` (conventional)
 - `Repo Hygiene`
+- `Docker Runtime Python Guard`
+- `Docker Build (platform + serving)`
 - `Lint (ruff)`
 - `Typecheck (mypy)`
 - `Unit Tests (pytest)`
@@ -25,6 +27,8 @@ Those stay out of the fast presubmit loop, we keep them in merge loop.
 
 - `make test` or `make test-unit`
   Matches the PR unit-test path.
+- `docker build --target platform .` and `docker build --target serving .`
+  Match the PR docker-build safety checks.
 - `make test-integration`
   Matches the push-to-`master` integration path.
 - `make test-e2e`
@@ -57,8 +61,12 @@ When CI fails, use these uploaded artifacts first:
 
 ## Design Notes
 
-- Presubmit is for fast feedback. After repo hygiene passes, lint, typecheck,
-  and unit tests run in parallel.
+- Presubmit is for fast feedback. After repo hygiene passes, docker runtime
+  guard, docker builds, lint, typecheck, and unit tests run in parallel where
+  possible.
+- Docker build checks are intentionally in presubmit so base-image and
+  dependency-resolution breakage is detected before merge rather than waiting
+  for nightly E2E.
 - Integration tests are deterministic but non-blocking for commiting to a PR.
 - Nightly E2E is separate because it validates the golden path (dockerized), not in the fast developer loop.
 - Conventional Commit PR titles matter because squash merges make the PR title

--- a/scripts/check_docker_python_version.sh
+++ b/scripts/check_docker_python_version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_mm="${1:-${SUPPORTED_PYTHON_MM:-}}"
+dockerfile_path="${2:-Dockerfile}"
+
+if [[ -z "${expected_mm}" ]]; then
+  echo "error: expected Python major.minor is required (arg1 or SUPPORTED_PYTHON_MM)." >&2
+  exit 2
+fi
+
+if [[ ! -f "${dockerfile_path}" ]]; then
+  echo "error: Dockerfile not found at ${dockerfile_path}" >&2
+  exit 2
+fi
+
+base_line="$(grep -E '^FROM python:[0-9]+\.[0-9]+-slim AS base$' "${dockerfile_path}" | head -n 1 || true)"
+if [[ -z "${base_line}" ]]; then
+  echo "error: could not find 'FROM python:X.Y-slim AS base' in ${dockerfile_path}" >&2
+  exit 1
+fi
+
+actual_mm="$(echo "${base_line}" | sed -E 's/^FROM python:([0-9]+\.[0-9]+)-slim AS base$/\1/')"
+
+if [[ "${actual_mm}" != "${expected_mm}" ]]; then
+  echo "error: Docker runtime Python mismatch." >&2
+  echo "expected: ${expected_mm}" >&2
+  echo "actual:   ${actual_mm}" >&2
+  echo "source:   ${dockerfile_path}" >&2
+  exit 1
+fi
+
+echo "ok: Dockerfile base Python matches expected ${expected_mm}"

--- a/tests/unit/test_docker_runtime_python_version.py
+++ b/tests/unit/test_docker_runtime_python_version.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _dockerfile_python_mm(dockerfile_text: str) -> str:
+    match = re.search(
+        r"^FROM python:(?P<version>\d+\.\d+)-slim AS base$",
+        dockerfile_text,
+        flags=re.MULTILINE,
+    )
+    assert match is not None, (
+        "Dockerfile must contain a base image line for python:X.Y-slim AS base."
+    )
+    return match.group("version")
+
+
+def _pyproject_supported_mm(pyproject_text: str) -> str:
+    data = tomllib.loads(pyproject_text)
+    requires_python = str(data["project"]["requires-python"])
+    match = re.search(r">=\s*(?P<version>\d+\.\d+)", requires_python)
+    assert match is not None, (
+        "pyproject.toml project.requires-python must include a >=X.Y constraint."
+    )
+    return match.group("version")
+
+
+def test_docker_runtime_python_matches_pyproject_supported_version() -> None:
+    root = _repo_root()
+    dockerfile_text = (root / "Dockerfile").read_text(encoding="utf-8")
+    pyproject_text = (root / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert _dockerfile_python_mm(dockerfile_text) == _pyproject_supported_mm(
+        pyproject_text
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What
- add presubmit Docker runtime Python version check (`scripts/check_docker_python_version.sh`)
- add PR Docker build checks for `platform` and `serving` targets
- pin Docker runtime base image to Python 3.11 to match supported matrix
- add regression unit test to catch Dockerfile/runtime Python drift
- document CI lane updates in `docs/ci.md`

## Why
Nightly E2E should not be the first place Docker/runtime drift is detected.  
This catches version and build breakage at PR time.

Closes #58

## Validation
- `scripts/check_docker_python_version.sh 3.11`
- `uv run pytest tests/unit/test_docker_runtime_python_version.py -q`
- `docker build --target platform --tag mlp-platform:ci .`
- `docker build --target serving --tag mlp-serving:ci .`

## Risk
Low. CI/workflow + Docker/runtime alignment only. No product behavior change.
