### PR TITLE
refactor(runtime): add UP-02 package and deployment structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ PROJECT_NAME := ml-lifecycle-platform
 export GIT_SHA ?= $(shell git rev-parse HEAD 2>/dev/null || echo dev)
 
 UV_PROJECT_DIR := .
+DEPLOYMENTS_LOCAL_DIR ?= deployments/local
+COMPOSE_FILE ?= $(DEPLOYMENTS_LOCAL_DIR)/docker-compose.yml
 
 UV ?= uv
 DOCKER ?= docker
-COMPOSE ?= $(DOCKER) compose
+COMPOSE ?= $(DOCKER) compose -f $(COMPOSE_FILE)
 
 UV_RUN := $(UV) run --project $(UV_PROJECT_DIR)
 PY := $(UV_RUN) python

--- a/deployments/local/docker-compose.yml
+++ b/deployments/local/docker-compose.yml
@@ -1,0 +1,176 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: mlflow
+      POSTGRES_PASSWORD: mlflow
+      POSTGRES_DB: mlflow
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mlflow -d mlflow"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - miniodata:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb -p local/mlflow || true &&
+      mc anonymous set download local/mlflow || true &&
+      echo 'MinIO bucket ready: s3://mlflow' "
+    restart: "no"
+
+  mlflow-server:
+    build:
+      context: ./mlflow_server
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      MLFLOW_HOST: 0.0.0.0
+      MLFLOW_PORT: 5000
+      BACKEND_STORE_URI: postgresql://mlflow:mlflow@postgres:5432/mlflow
+      ARTIFACT_ROOT: s3://mlflow/
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+    ports:
+      - "5050:5000"
+
+    # Use a health endpoint that always exists.
+    # MLflow responds on "/" once it is up.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5000/"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+    # The mlflow_server image already uses ENTRYPOINT ["/start.sh"].
+
+  pipeline:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: platform
+    depends_on:
+      mlflow-server:
+        condition: service_healthy
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow-server:5000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      MODEL_NAME: breast_cancer_clf
+      EXPERIMENT_NAME: breast-cancer-platform
+      GIT_SHA: ${GIT_SHA:-dev}
+    command: ["python", "-m", "ml_lifecycle_platform.pipeline.orchestrate"]
+    restart: "no"
+
+  promote:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: platform
+    depends_on:
+      mlflow-server:
+        condition: service_healthy
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow-server:5000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      MODEL_NAME: breast_cancer_clf
+    command: ["python", "-m", "ml_lifecycle_platform.registry.promote"]
+    restart: "no"
+
+  rollback:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: platform
+    depends_on:
+      mlflow-server:
+        condition: service_healthy
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow-server:5000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      MODEL_NAME: breast_cancer_clf
+    command: ["python", "-m", "ml_lifecycle_platform.registry.rollback"]
+    restart: "no"
+
+  serving:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: serving
+    depends_on:
+      mlflow-server:
+        condition: service_healthy
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow-server:5000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      MODEL_NAME: breast_cancer_clf
+      CANARY_PCT: "10"
+      LOG_LEVEL: "INFO"
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2).read()",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  smoke:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: serving
+    depends_on:
+      serving:
+        condition: service_healthy
+    environment:
+      SERVE_URL: http://serving:8000
+    command: ["python", "-m", "ml_lifecycle_platform.serving.smoke_test"]
+    restart: "no"
+
+volumes:
+  pgdata:
+  miniodata:
+

--- a/deployments/local/mlflow_server/Dockerfile
+++ b/deployments/local/mlflow_server/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+# Keep the runtime small. curl is used for health checks.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pin MLflow to a stable minor line.
+# psycopg2-binary is for the Postgres backend store.
+# boto3 is for S3/MinIO artifacts.
+RUN pip install --no-cache-dir \
+  "mlflow==2.14.*" \
+  psycopg2-binary \
+  boto3
+
+COPY start.sh /start.sh
+RUN chmod +x /start.sh
+
+EXPOSE 5000
+ENTRYPOINT ["/start.sh"]
+

--- a/deployments/local/mlflow_server/start.sh
+++ b/deployments/local/mlflow_server/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -eu
+
+# Defaults
+: "${MLFLOW_HOST:=0.0.0.0}"
+: "${MLFLOW_PORT:=5000}"
+
+# Required config
+: "${BACKEND_STORE_URI:?BACKEND_STORE_URI must be set}"
+: "${ARTIFACT_ROOT:?ARTIFACT_ROOT must be set}"
+
+# Log the resolved config.
+echo "[mlflow-server] starting"
+echo "[mlflow-server] host=${MLFLOW_HOST} port=${MLFLOW_PORT}"
+echo "[mlflow-server] backend_store_uri=${BACKEND_STORE_URI}"
+echo "[mlflow-server] artifact_root=${ARTIFACT_ROOT}"
+if [ -n "${MLFLOW_S3_ENDPOINT_URL:-}" ]; then
+  echo "[mlflow-server] s3_endpoint=${MLFLOW_S3_ENDPOINT_URL}"
+fi
+
+# Do not pass --serve-artifacts.
+# With S3/MinIO, clients upload artifacts directly with boto3.
+exec mlflow server \
+  --host "${MLFLOW_HOST}" \
+  --port "${MLFLOW_PORT}" \
+  --backend-store-uri "${BACKEND_STORE_URI}" \
+  --default-artifact-root "${ARTIFACT_ROOT}"
+

--- a/src/ml_lifecycle_platform/backends/__init__.py
+++ b/src/ml_lifecycle_platform/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package root for runtime adapter implementations."""

--- a/src/ml_lifecycle_platform/cli/__init__.py
+++ b/src/ml_lifecycle_platform/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI package root for canonical command entrypoints."""

--- a/src/ml_lifecycle_platform/cli/main.py
+++ b/src/ml_lifecycle_platform/cli/main.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mlp",
+        description="ML Lifecycle Platform CLI (UP-02 placeholder)",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    pipeline = subparsers.add_parser("pipeline", help="Pipeline commands")
+    pipeline_sub = pipeline.add_subparsers(dest="pipeline_command")
+    pipeline_sub.add_parser("run", help="Run pipeline (placeholder)")
+
+    registry = subparsers.add_parser("registry", help="Registry commands")
+    registry_sub = registry.add_subparsers(dest="registry_command")
+    registry_sub.add_parser("promote", help="Promote candidate (placeholder)")
+    registry_sub.add_parser("rollback", help="Rollback prod (placeholder)")
+    registry_sub.add_parser("reproduce", help="Reproduce model (placeholder)")
+
+    serve = subparsers.add_parser("serve", help="Serving commands")
+    serve_sub = serve.add_subparsers(dest="serve_command")
+    serve_sub.add_parser("api", help="Run serving API (placeholder)")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    print(
+        "UP-02 placeholder CLI. Continue using existing module entrypoints and "
+        "Make targets until runtime wiring lands."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ml_lifecycle_platform/core/__init__.py
+++ b/src/ml_lifecycle_platform/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core platform contracts and shared abstractions."""

--- a/src/ml_lifecycle_platform/core/ports.py
+++ b/src/ml_lifecycle_platform/core/ports.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class ArtifactStore(Protocol):
+    """Portable artifact persistence boundary."""
+
+    def write_bytes(self, path: str, content: bytes) -> None:
+        """Persist raw bytes under a backend-specific path."""
+
+    def read_bytes(self, path: str) -> bytes:
+        """Load raw bytes from a backend-specific path."""
+
+
+@runtime_checkable
+class EventStore(Protocol):
+    """Portable event append/query boundary."""
+
+    def append_event(self, event_type: str, payload: Mapping[str, object]) -> None:
+        """Append a typed event to durable storage."""
+
+
+@runtime_checkable
+class JobRunner(Protocol):
+    """Portable boundary for one-shot control-plane jobs."""
+
+    def run_module(
+        self,
+        module: str,
+        *,
+        args: Sequence[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> int:
+        """Run a Python module and return an exit code."""
+
+
+@runtime_checkable
+class Secrets(Protocol):
+    """Portable secret retrieval boundary."""
+
+    def get(self, name: str, *, default: str | None = None) -> str | None:
+        """Return a secret value by logical name."""
+
+
+@dataclass(frozen=True)
+class RuntimeMetadata:
+    """Runtime identity shared across command paths."""
+
+    environment: str
+    tracking_uri: str
+    registry_uri: str
+    source: str = "bootstrap"

--- a/src/ml_lifecycle_platform/runtime/__init__.py
+++ b/src/ml_lifecycle_platform/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime composition entrypoints."""

--- a/src/ml_lifecycle_platform/runtime/bootstrap.py
+++ b/src/ml_lifecycle_platform/runtime/bootstrap.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from ml_lifecycle_platform.core.ports import RuntimeMetadata
+from ml_lifecycle_platform.runtime.context import RuntimeContext
+
+
+def build_runtime_context() -> RuntimeContext:
+    """Build a default runtime context.
+
+    This is a non-functional wiring placeholder for UP-02.
+    """
+
+    return RuntimeContext(
+        metadata=RuntimeMetadata(
+            environment="local",
+            tracking_uri="http://localhost:5050",
+            registry_uri="http://localhost:5050",
+            source="up-02-placeholder",
+        )
+    )

--- a/src/ml_lifecycle_platform/runtime/context.py
+++ b/src/ml_lifecycle_platform/runtime/context.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ml_lifecycle_platform.core.ports import (
+    ArtifactStore,
+    EventStore,
+    JobRunner,
+    RuntimeMetadata,
+    Secrets,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    """Container for runtime wiring.
+
+    UP-02 keeps this structural only. Concrete adapters are introduced in UP-03.
+    """
+
+    metadata: RuntimeMetadata
+    artifact_store: ArtifactStore | None = None
+    event_store: EventStore | None = None
+    job_runner: JobRunner | None = None
+    secrets: Secrets | None = None


### PR DESCRIPTION
## What

- add package roots for `core`, `backends`, `runtime`, and `cli`
- add `src/ml_lifecycle_platform/core/ports.py` with the initial portable interfaces:
  - `ArtifactStore`
  - `EventStore`
  - `JobRunner`
  - `Secrets`
- add `runtime/context.py` and `runtime/bootstrap.py` with placeholder runtime wiring hooks
- add `cli/main.py` with a placeholder command tree for future canonical entrypoints
- add `deployments/local/` as the stable local deployment layout
- update `Makefile` so existing targets continue to work against the new local deployment path

## Why

This is UP-02 for the M0 portability work.

The goal is to create the structural package/runtime structure without changing current platform behavior. This creates the file and package shape needed for later runtime wiring and local backend work.

Closes #44

## Non-goals

- no local adapter logic yet
- no config profiles yet
- no model-spec behavior yet
- no migration of existing pipeline, registry, or serving logic to runtime context yet

## Compatibility

- current `pipeline/`, `registry/`, and `serving/` entrypoints remain unchanged
- current `make` targets remain the user path
- local Docker commands still work through the same `make` targets
- no end-user behavior change is intended

## Validation

- `uv run python -c "import ml_lifecycle_platform.core, ml_lifecycle_platform.backends, ml_lifecycle_platform.runtime, ml_lifecycle_platform.cli"`
- `make test-all`
- `make build`
- `make up`
- `make down`
- `make e2e`

## Risk

Low. This is a structural refactor only:
- no behavior migration
- no deployment behavior change beyond redirecting `Makefile` to the stable local compose path
- existing behavior modules are left intact

## Rollback

Revert this PR. Existing behavior entrypoints were preserved.
