### PR TITLE
feat(runtime): add local backend adapter interfaces

### DIFF
--- a/src/ml_lifecycle_platform/backends/local/__init__.py
+++ b/src/ml_lifecycle_platform/backends/local/__init__.py
@@ -1,0 +1,1 @@
+"""Local runtime adapter implementations."""

--- a/src/ml_lifecycle_platform/backends/local/artifact_store.py
+++ b/src/ml_lifecycle_platform/backends/local/artifact_store.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class LocalArtifactStore:
+    """File-backed artifact store rooted under the local artifact directory."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def resolve(self, path: str) -> Path:
+        return self._root / path
+
+    def write_bytes(self, path: str, content: bytes) -> None:
+        target = self.resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    def read_bytes(self, path: str) -> bytes:
+        return self.resolve(path).read_bytes()

--- a/src/ml_lifecycle_platform/backends/local/event_store.py
+++ b/src/ml_lifecycle_platform/backends/local/event_store.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping
+
+
+class LocalEventStore:
+    """Append-only JSONL event log for local runtime use."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append_event(self, event_type: str, payload: Mapping[str, object]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event_type": event_type,
+            "payload": dict(payload),
+        }
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, sort_keys=True))
+            fh.write("\n")

--- a/src/ml_lifecycle_platform/backends/local/job_runner.py
+++ b/src/ml_lifecycle_platform/backends/local/job_runner.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Mapping, Sequence
+
+
+class LocalJobRunner:
+    """Run local control-plane steps as Python modules."""
+
+    def __init__(self, python_executable: str | None = None) -> None:
+        self._python_executable = python_executable or sys.executable
+
+    @property
+    def python_executable(self) -> str:
+        return self._python_executable
+
+    def run_module(
+        self,
+        module: str,
+        *,
+        args: Sequence[str] | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> int:
+        command = [self._python_executable, "-m", module, *(args or ())]
+        merged_env = os.environ.copy()
+        if env:
+            merged_env.update(env)
+        completed = subprocess.run(command, check=False, env=merged_env)
+        return int(completed.returncode)

--- a/src/ml_lifecycle_platform/backends/local/secrets.py
+++ b/src/ml_lifecycle_platform/backends/local/secrets.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import os
+
+
+class EnvSecrets:
+    """Env-var backed secrets adapter for the local runtime."""
+
+    def get(self, name: str, *, default: str | None = None) -> str | None:
+        return os.getenv(name, default)

--- a/src/ml_lifecycle_platform/common/config.py
+++ b/src/ml_lifecycle_platform/common/config.py
@@ -1,24 +1,39 @@
-import os
+from pathlib import Path
+
+from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
 
 
 def env(name: str, default: str | None = None) -> str:
-    v = os.getenv(name, default)
+    runtime = get_runtime_context()
+    v = runtime.secrets.get(name, default=default)
     if v is None:
         raise RuntimeError(f"Missing required env var: {name}")
-    return v
+    return str(v)
 
 
 def get_tracking_uri() -> str:
-    return env("MLFLOW_TRACKING_URI", "http://localhost:5050")
+    return get_runtime_context().metadata.tracking_uri
 
 
 def get_registry_uri() -> str:
-    return env("MLFLOW_REGISTRY_URI", get_tracking_uri())
+    return get_runtime_context().metadata.registry_uri
 
 
 def get_experiment_name() -> str:
-    return env("EXPERIMENT_NAME", "breast-cancer-platform")
+    return get_runtime_context().experiment_name
 
 
 def get_model_name() -> str:
-    return env("MODEL_NAME", "breast_cancer_clf")
+    return get_runtime_context().model_name
+
+
+def get_log_level() -> str:
+    return get_runtime_context().log_level
+
+
+def get_data_dir() -> Path:
+    return get_runtime_context().data_dir
+
+
+def get_artifacts_dir() -> Path:
+    return get_runtime_context().artifacts_dir

--- a/src/ml_lifecycle_platform/common/mlflow_utils.py
+++ b/src/ml_lifecycle_platform/common/mlflow_utils.py
@@ -7,10 +7,14 @@ from typing import Any
 import mlflow
 from mlflow.tracking import MlflowClient
 
-from ml_lifecycle_platform.common.config import get_registry_uri, get_tracking_uri
+from ml_lifecycle_platform.runtime.bootstrap import (
+    configure_mlflow,
+    get_runtime_context,
+)
 
 
 def ensure_experiment(name: str) -> str:
+    configure_mlflow()
     exp = mlflow.get_experiment_by_name(name)
     if exp is None:
         return mlflow.create_experiment(name)
@@ -18,12 +22,22 @@ def ensure_experiment(name: str) -> str:
 
 
 def client() -> MlflowClient:
+    configure_mlflow()
+    runtime = get_runtime_context()
     return MlflowClient(
-        tracking_uri=get_tracking_uri(),
-        registry_uri=get_registry_uri(),
+        tracking_uri=runtime.metadata.tracking_uri,
+        registry_uri=runtime.metadata.registry_uri,
     )
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    runtime = get_runtime_context()
+    content = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    try:
+        relative_path = path.relative_to(runtime.artifacts_dir).as_posix()
+    except ValueError:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return
+
+    runtime.artifact_store.write_bytes(relative_path, content)

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import mlflow
 
-from ml_lifecycle_platform.common.config import get_experiment_name, get_tracking_uri
+from ml_lifecycle_platform.common.config import get_experiment_name
 from ml_lifecycle_platform.common.constants import (
     ART_TRAIN_RUN_ID,
     STEP_TRAIN,
     TAG_STEP,
 )
 from ml_lifecycle_platform.common.mlflow_utils import ensure_experiment
+from ml_lifecycle_platform.runtime.bootstrap import (
+    configure_mlflow,
+    get_runtime_context,
+)
 
 ART_DIR = Path("/app/artifacts")
 
@@ -27,7 +30,10 @@ STEP_MODULES = {
 def _run_step(module: str) -> None:
     print(f"[orchestrate] Running step: {module}")
     module_path = STEP_MODULES[module]
-    subprocess.check_call(["python", "-m", module_path])
+    runtime = get_runtime_context()
+    return_code = runtime.job_runner.run_module(module_path)
+    if return_code != 0:
+        raise RuntimeError(f"Step {module} failed with exit code {return_code}.")
 
 
 def _latest_train_run_id(experiment_id: str) -> str:
@@ -59,10 +65,12 @@ def _latest_train_run_id(experiment_id: str) -> str:
 
 
 def main() -> None:
-    mlflow.set_tracking_uri(get_tracking_uri())
+    runtime = get_runtime_context()
+    configure_mlflow(runtime)
     ensure_experiment(get_experiment_name())
     mlflow.set_experiment(get_experiment_name())
-    ART_DIR.mkdir(parents=True, exist_ok=True)
+    art_dir = runtime.artifacts_dir
+    art_dir.mkdir(parents=True, exist_ok=True)
 
     _run_step("ingest")
     _run_step("featurize")
@@ -72,7 +80,7 @@ def main() -> None:
     assert exp is not None
 
     train_run_id = _latest_train_run_id(exp.experiment_id)
-    (ART_DIR / ART_TRAIN_RUN_ID).write_text(str(train_run_id), encoding="utf-8")
+    (art_dir / ART_TRAIN_RUN_ID).write_text(str(train_run_id), encoding="utf-8")
     print(f"[orchestrate] Captured {ART_TRAIN_RUN_ID}={train_run_id}")
 
     _run_step("evaluate")

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -14,7 +14,11 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from sklearn.pipeline import Pipeline
 
-from ml_lifecycle_platform.common.config import get_experiment_name, get_model_name
+from ml_lifecycle_platform.common.config import (
+    get_experiment_name,
+    get_log_level,
+    get_model_name,
+)
 from ml_lifecycle_platform.common.constants import (
     ART_DATASET_FINGERPRINT_JSON,
     ART_PREPROCESSOR,
@@ -51,6 +55,7 @@ from ml_lifecycle_platform.contracts.dataset_fingerprint import (
     write_fingerprint_json,
 )
 from ml_lifecycle_platform.contracts.repro_contract import ReproContract
+from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +193,8 @@ def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
 
 
 def main() -> None:
-    logging.basicConfig(level="INFO")
+    logging.basicConfig(level=get_log_level())
+    configure_mlflow()
 
     experiment_name = get_experiment_name()
     ensure_experiment(experiment_name)

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import sys
 
 from mlflow.tracking import MlflowClient
 
-from ml_lifecycle_platform.common.config import get_model_name
+from ml_lifecycle_platform.common.config import get_log_level, get_model_name
 from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
 from ml_lifecycle_platform.common.constants import (
     ALIAS_CANDIDATE,
@@ -124,7 +123,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> None:
-    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    logging.basicConfig(level=get_log_level())
 
     args = parse_args(sys.argv[1:] if argv is None else argv)
 

--- a/src/ml_lifecycle_platform/registry/register.py
+++ b/src/ml_lifecycle_platform/registry/register.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Final
 
 import mlflow
-from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.config import get_experiment_name, get_model_name
 from ml_lifecycle_platform.common.constants import (
@@ -30,7 +29,9 @@ from ml_lifecycle_platform.common.constants import (
     TAG_SOURCE_RUN_ID,
     TAG_TRAINING_RUN_ID,
 )
+from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
 from ml_lifecycle_platform.common.mlflow_utils import ensure_experiment
+from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +60,14 @@ def _read_required_artifact_text(path: Path, artifact_name: str) -> str:
 
 def main() -> None:
     logging.basicConfig(level="INFO")
+    configure_mlflow()
 
     experiment_name = get_experiment_name()
     ensure_experiment(experiment_name)
     mlflow.set_experiment(experiment_name)
 
     model_name = get_model_name()
-    client = MlflowClient()
+    client = mlflow_client()
 
     train_run_id = _read_required_artifact_text(
         ART_DIR / ART_TRAIN_RUN_ID, ART_TRAIN_RUN_ID

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -14,7 +13,7 @@ import numpy as np
 import pandas as pd
 from mlflow.tracking import MlflowClient
 
-from ml_lifecycle_platform.common.config import get_model_name
+from ml_lifecycle_platform.common.config import get_log_level, get_model_name
 from ml_lifecycle_platform.common.constants import (
     ART_REPRO_CONTRACT_JSON,
     ART_REPRO_REPORT_JSON,
@@ -368,7 +367,7 @@ def reproduce_model(
 
 
 def main(argv: list[str] | None = None) -> None:
-    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    logging.basicConfig(level=get_log_level())
     args = parse_args(sys.argv[1:] if argv is None else argv)
     report_path = Path(args.report_path)
 

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from mlflow.tracking import MlflowClient
 
+from ml_lifecycle_platform.common.config import get_log_level, get_model_name
 from ml_lifecycle_platform.common.constants import ALIAS_PROD, TAG_PREVIOUS_PROD_VERSION
 from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
 
@@ -38,12 +38,8 @@ def rollback_prod(client: MlflowClient, model_name: str) -> None:
     )
 
 
-def get_model_name() -> str:
-    return os.environ.get("MODEL_NAME", "breast_cancer_clf")
-
-
 def main() -> None:
-    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    logging.basicConfig(level=get_log_level())
     rollback_prod(mlflow_client(), get_model_name())
 
 

--- a/src/ml_lifecycle_platform/runtime/bootstrap.py
+++ b/src/ml_lifecycle_platform/runtime/bootstrap.py
@@ -1,20 +1,95 @@
 from __future__ import annotations
 
+from functools import lru_cache
+from pathlib import Path
+import sys
+
+try:
+    import mlflow
+except Exception:  # pragma: no cover
+    mlflow = None  # type: ignore[assignment]
+
+from ml_lifecycle_platform.backends.local.artifact_store import LocalArtifactStore
+from ml_lifecycle_platform.backends.local.event_store import LocalEventStore
+from ml_lifecycle_platform.backends.local.job_runner import LocalJobRunner
+from ml_lifecycle_platform.backends.local.secrets import EnvSecrets
 from ml_lifecycle_platform.core.ports import RuntimeMetadata
 from ml_lifecycle_platform.runtime.context import RuntimeContext
 
+DEFAULT_TRACKING_URI = "http://localhost:5050"
+DEFAULT_EXPERIMENT_NAME = "breast-cancer-platform"
+DEFAULT_MODEL_NAME = "breast_cancer_clf"
+DEFAULT_LOG_LEVEL = "INFO"
+DEFAULT_DATA_DIR = Path("/app/data")
+DEFAULT_ARTIFACTS_DIR = Path("/app/artifacts")
+
+
+def _secret_or_default(
+    secrets: EnvSecrets,
+    name: str,
+    default: str,
+) -> str:
+    return str(secrets.get(name, default=default))
+
 
 def build_runtime_context() -> RuntimeContext:
-    """Build a default runtime context.
+    """Build the local runtime context from environment-backed settings."""
 
-    This is a non-functional wiring placeholder for UP-02.
-    """
+    secrets = EnvSecrets()
+    tracking_uri = _secret_or_default(
+        secrets, "MLFLOW_TRACKING_URI", DEFAULT_TRACKING_URI
+    )
+    registry_uri = _secret_or_default(secrets, "MLFLOW_REGISTRY_URI", tracking_uri)
+    experiment_name = _secret_or_default(
+        secrets, "EXPERIMENT_NAME", DEFAULT_EXPERIMENT_NAME
+    )
+    model_name = _secret_or_default(secrets, "MODEL_NAME", DEFAULT_MODEL_NAME)
+    log_level = _secret_or_default(secrets, "LOG_LEVEL", DEFAULT_LOG_LEVEL)
+
+    data_dir = Path(_secret_or_default(secrets, "MLP_DATA_DIR", str(DEFAULT_DATA_DIR)))
+    artifacts_dir = Path(
+        _secret_or_default(secrets, "MLP_ARTIFACTS_DIR", str(DEFAULT_ARTIFACTS_DIR))
+    )
+    event_log_path = Path(
+        _secret_or_default(
+            secrets,
+            "MLP_EVENT_LOG_PATH",
+            str(artifacts_dir / "runtime-events.jsonl"),
+        )
+    )
+    python_executable = _secret_or_default(secrets, "PYTHON_EXECUTABLE", sys.executable)
 
     return RuntimeContext(
         metadata=RuntimeMetadata(
             environment="local",
-            tracking_uri="http://localhost:5050",
-            registry_uri="http://localhost:5050",
-            source="up-02-placeholder",
-        )
+            tracking_uri=tracking_uri,
+            registry_uri=registry_uri,
+            source="local-runtime-bootstrap",
+        ),
+        model_name=model_name,
+        experiment_name=experiment_name,
+        log_level=log_level,
+        data_dir=data_dir,
+        artifacts_dir=artifacts_dir,
+        artifact_store=LocalArtifactStore(artifacts_dir),
+        event_store=LocalEventStore(event_log_path),
+        job_runner=LocalJobRunner(python_executable=python_executable),
+        secrets=secrets,
     )
+
+
+@lru_cache(maxsize=1)
+def get_runtime_context() -> RuntimeContext:
+    return build_runtime_context()
+
+
+def reset_runtime_context() -> None:
+    get_runtime_context.cache_clear()
+
+
+def configure_mlflow(context: RuntimeContext | None = None) -> None:
+    if mlflow is None:
+        return
+    runtime = context or get_runtime_context()
+    mlflow.set_tracking_uri(runtime.metadata.tracking_uri)
+    mlflow.set_registry_uri(runtime.metadata.registry_uri)

--- a/src/ml_lifecycle_platform/runtime/context.py
+++ b/src/ml_lifecycle_platform/runtime/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from ml_lifecycle_platform.core.ports import (
     ArtifactStore,
@@ -19,7 +20,12 @@ class RuntimeContext:
     """
 
     metadata: RuntimeMetadata
-    artifact_store: ArtifactStore | None = None
-    event_store: EventStore | None = None
-    job_runner: JobRunner | None = None
-    secrets: Secrets | None = None
+    model_name: str
+    experiment_name: str
+    log_level: str
+    data_dir: Path
+    artifacts_dir: Path
+    artifact_store: ArtifactStore
+    event_store: EventStore
+    job_runner: JobRunner
+    secrets: Secrets

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -20,6 +20,9 @@ try:
 except Exception:  # pragma: no cover
     mlflow = None  # type: ignore[assignment]
 
+from ml_lifecycle_platform.common.mlflow_utils import client as get_mlflow_client
+from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
+
 from .constants import ALIAS_CANDIDATE, ALIAS_PROD, HEADER_REQUEST_ID
 from .metrics import PREDICT_LATENCY_SECONDS, REQUESTS_TOTAL, SHADOW_DIFF_MAE
 from .router import (
@@ -51,6 +54,7 @@ def _configure_logging(settings: Settings) -> None:
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     settings = get_settings()
     _configure_logging(settings)
+    configure_mlflow()
     logger.info("serving started")
     yield
     logger.info("serving stopped")
@@ -147,7 +151,7 @@ def _registry_resolves_prod_alias(settings: Settings) -> tuple[bool, str | None]
         return False, "mlflow not available in serving image"
 
     try:
-        client = mlflow.tracking.MlflowClient()
+        client = get_mlflow_client()
         _ = client.get_model_version_by_alias(settings.model_name, settings.prod_alias)
         return True, None
     except Exception as e:
@@ -158,7 +162,7 @@ def _get_version(settings: Settings, alias: str) -> str | None:
     if settings.unit_testing or mlflow is None:
         return None
     try:
-        client = mlflow.tracking.MlflowClient()
+        client = get_mlflow_client()
         mv = client.get_model_version_by_alias(settings.model_name, alias)
         return str(mv.version)
     except Exception:
@@ -178,6 +182,7 @@ def _load_model(settings: Settings, alias: str) -> Any:
     if pyfunc is None:
         raise RuntimeError("mlflow.pyfunc is missing (mlflow install is broken)")
 
+    configure_mlflow()
     return pyfunc.load_model(_models_uri(settings, alias))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import mlflow
 import numpy as np
 import pytest
 
+from ml_lifecycle_platform.runtime.bootstrap import reset_runtime_context
+
 TEST_TIER_MARKERS = ("unit", "integration", "e2e")
 
 
@@ -40,6 +42,15 @@ def pytest_collection_modifyitems(
 def deterministic_test_state() -> None:
     random.seed(0)
     np.random.seed(0)
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_runtime_state() -> Iterator[None]:
+    reset_runtime_context()
+    try:
+        yield
+    finally:
+        reset_runtime_context()
 
 
 @pytest.fixture()

--- a/tests/integration/test_runtime_bootstrap.py
+++ b/tests/integration/test_runtime_bootstrap.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ml_lifecycle_platform.backends.local.artifact_store import LocalArtifactStore
+from ml_lifecycle_platform.backends.local.event_store import LocalEventStore
+from ml_lifecycle_platform.backends.local.job_runner import LocalJobRunner
+from ml_lifecycle_platform.backends.local.secrets import EnvSecrets
+from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
+
+pytestmark = pytest.mark.integration
+
+
+def test_local_runtime_context_uses_local_adapters_and_env_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "data"
+    artifacts_dir = tmp_path / "artifacts"
+    tracking_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", tracking_uri)
+    monkeypatch.setenv("MLFLOW_REGISTRY_URI", tracking_uri)
+    monkeypatch.setenv("EXPERIMENT_NAME", "runtime-bootstrap-exp")
+    monkeypatch.setenv("MODEL_NAME", "runtime-bootstrap-model")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("MLP_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MLP_ARTIFACTS_DIR", str(artifacts_dir))
+
+    runtime = get_runtime_context()
+
+    assert runtime.metadata.environment == "local"
+    assert runtime.metadata.tracking_uri == tracking_uri
+    assert runtime.metadata.registry_uri == tracking_uri
+    assert runtime.experiment_name == "runtime-bootstrap-exp"
+    assert runtime.model_name == "runtime-bootstrap-model"
+    assert runtime.log_level == "DEBUG"
+    assert runtime.data_dir == data_dir
+    assert runtime.artifacts_dir == artifacts_dir
+    assert isinstance(runtime.artifact_store, LocalArtifactStore)
+    assert isinstance(runtime.event_store, LocalEventStore)
+    assert isinstance(runtime.job_runner, LocalJobRunner)
+    assert isinstance(runtime.secrets, EnvSecrets)
+
+    runtime.artifact_store.write_bytes("reports/test.txt", b"ok")
+    assert (artifacts_dir / "reports" / "test.txt").read_text(encoding="utf-8") == "ok"
+
+    runtime.event_store.append_event("runtime_bootstrap_test", {"status": "ok"})
+    event_log = artifacts_dir / "runtime-events.jsonl"
+    payload = json.loads(event_log.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert payload["event_type"] == "runtime_bootstrap_test"
+    assert payload["payload"] == {"status": "ok"}
+
+    assert (
+        runtime.job_runner.run_module(
+            "ml_lifecycle_platform.cli.main",
+            args=["--help"],
+        )
+        == 0
+    )


### PR DESCRIPTION
## What

- add local runtime adapters under `src/ml_lifecycle_platform/backends/local/`:
  - `artifact_store.py`
  - `event_store.py`
  - `job_runner.py`
  - `secrets.py`
- upgrade `runtime/context.py` and `runtime/bootstrap.py` so the local runtime is assembled in one place
- make `common/config.py` a compatibility wrapper over runtime-backed config/secrets access
- make `common/mlflow_utils.py` a compatibility wrapper over runtime-backed MLflow client and artifact writes
- route the existing local orchestration path through the runtime `JobRunner`
- update registry and serving paths to use runtime-backed config/logging and MLflow wiring
- add integration coverage for runtime bootstrap, env resolution, and local adapter behavior

## Why

This is UP-03 for M0.

The goal is to keep the current local MLflow/Postgres/MinIO/Compose flow while moving config, secrets, client creation, and local job execution behind a single runtime assembly point. This reduces direct `common/config.py` and `common/mlflow_utils.py` coupling and sets up the repo for the later profile/CLI work.

Closes #45

## Non-goals

- no hosted backends
- no event replay loop
- no new cloud semantics
- no config profile system yet
- no model-spec behavior yet

## Implementation Notes

- the local runtime is assembled in `src/ml_lifecycle_platform/runtime/bootstrap.py`
- `common/` remains as compatibility wrappers during M0
- existing `pipeline/`, `registry/`, and `serving/` entrypoints remain intact as operator-facing paths
- the local `EventStore` is file-backed and append-only for now
- the local `Secrets` adapter remains env-var backed for compatibility

## Acceptance

- current local behavior is preserved
- runtime wiring is now the path for config/secrets/backend access
- there is one runtime assembly point
- the existing Compose golden path still works

## Validation

- `make check`
- `make test-all`
- `make test-e2e`

## Risk

Moderate but contained.

This PR touches shared wiring used by pipeline, registry, and serving flows, but keeps behavior modules and operator paths intact. The migration is constrained to local runtime assembly plus compatibility wrappers.

## Rollback

Revert this PR. The change is isolated to runtime wiring, local adapters, and compatibility-layer integration.
