### PR TITLE
feat: add release evidence bundles for promote rollback and reproduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A production ML platform for training, evaluating, registering, promoting, servi
 - Runs a simple pipeline: `ingest -> featurize -> train -> evaluate -> register`
 - Registers gated models into MLflow
 - Promotes by alias: `candidate -> prod -> champion`
+- Emits explicit release evidence for promote, rollback, and reproduce flows
 - Serves `prod`, `candidate`, `canary`, and `shadow`
 - Captures reproducibility metadata: dataset fingerprint, config hash, git SHA, env lock hash
 - Rebuilds a registered model from its source training run
@@ -110,6 +111,47 @@ Golden path:
 - `make e2e`
 - `make e2e-keep`
 
+## Release Evidence
+
+Promotion, rollback, and reproduce emit a machine-readable evidence bundle.
+
+Each bundle includes:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+The bundle records:
+
+- source run ID
+- dataset fingerprint
+- config hash
+- git SHA
+- current prod version
+- previous prod version
+- policy outcome
+
+MLflow stores those artifacts under:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+The active model version also records stable artifact-path tags:
+
+- `release_reports_path`
+- `promotion_decision_path`
+- `release_manifest_path`
+- `rollback_target_path`
+- `model_card_path`
+
+Operational behavior:
+
+- `promote` writes the release evidence bundle to the promoted version's source run
+- `rollback` resolves the rollback target from the recorded `release_manifest.json` and falls back to `previous_prod_version` only for compatibility
+- `reproduce` still writes `reproduce_report.json` and also emits the same release evidence pattern
+
+When the local runtime profile is active, the same bundle is mirrored under the configured local artifacts directory and a release event is appended to the local file-backed event log when available.
+
 ## Serving
 
 Serving API:
@@ -149,6 +191,11 @@ Reproduce from the registry:
 ```bash
 uv run mlp --env local registry reproduce --model-name breast_cancer_clf --alias prod --report-path reproduce_report.json --format json
 ```
+
+The command writes:
+
+- the requested local `reproduce_report.json`
+- a release evidence bundle in MLflow under `reports/releases/reproduce/...`
 
 ## Repository Layout
 

--- a/docs/adrs/ADR-0002-mlflow-control-plane.md
+++ b/docs/adrs/ADR-0002-mlflow-control-plane.md
@@ -12,7 +12,8 @@ The repo already uses MLflow as the release-control system:
 - aliases `candidate`, `prod`, and `champion` define release state
 - promotion policy reads MLflow model-version metadata
 - promotion mutates MLflow aliases and tags
-- rollback uses MLflow alias metadata such as `previous_prod_version`
+- promotion, rollback, and reproduce write release evidence artifacts into MLflow
+- rollback resolves from recorded release manifests and can fall back to `previous_prod_version`
 - serving resolves `models:/<name>@prod`
 
 That is already reflected in the Makefile workflows, Docker Compose runtime,
@@ -30,8 +31,8 @@ In `M0`:
 
 - MLflow registered model versions remain the authoritative release records
 - MLflow aliases remain the authoritative release pointers
-- MLflow model-version tags remain the authoritative promotion and rollback
-  metadata
+- MLflow artifacts and model-version tags remain the authoritative promotion,
+  rollback, and reproduce evidence
 - serving continues to resolve models from MLflow aliases
 - policy evaluation continues to read its decision inputs from MLflow metadata
 
@@ -44,7 +45,9 @@ These behaviors stay concrete and MLflow-backed in `M0`:
 
 - `candidate -> prod -> champion` alias flow
 - promotion dry-run and allow-or-block decisions
-- rollback via `previous_prod_version`
+- release evidence bundles under `reports/releases/...`
+- rollback via recorded `release_manifest.json` with `previous_prod_version`
+  compatibility fallback
 - source training run linkage
 - dataset fingerprint, config hash, git SHA, and training run metadata checks
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -34,7 +34,11 @@ models:/<model_name>@prod
   - `prod`
   - `champion`
 - dry-run promotion policy
-- rollback by alias mutation
+- explicit release evidence bundles for:
+  - `promote`
+  - `rollback`
+  - `reproduce`
+- rollback by alias mutation with manifest-recorded previous prod resolution
 - FastAPI serving with:
   - `prod`
   - `candidate`
@@ -59,6 +63,33 @@ models:/<model_name>@prod
 - default runtime profile: [`configs/env/local.yaml`](../../configs/env/local.yaml)
 - default model spec: [`configs/models/breast_cancer_demo.yaml`](../../configs/models/breast_cancer_demo.yaml)
 - alternate CSV spec: [`configs/models/local_csv_binary_classifier.yaml`](../../configs/models/local_csv_binary_classifier.yaml)
+
+## Release evidence
+
+Registry operations emit a shared evidence bundle:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+MLflow stores the bundle under:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+The release manifest records:
+
+- source run ID
+- dataset fingerprint
+- config hash
+- git SHA
+- current prod version
+- previous prod version
+- policy outcome
+
+Rollback resolves its target from the promoted version's recorded `release_manifest.json`
+and only falls back to `previous_prod_version` for compatibility with older model
+versions that do not yet have a manifest.
 
 ## Non-goals of the current repo
 

--- a/docs/architecture/m0-portability-charter.md
+++ b/docs/architecture/m0-portability-charter.md
@@ -31,6 +31,7 @@ Everything else stays concrete in `M0`.
 - local Compose remains the default developer and operator path
 - alias-based releases stay `candidate -> prod -> champion`
 - promotion stays policy-gated
+- release evidence stays MLflow-backed
 - rollback stays alias mutation, not retraining
 
 ## What this avoids

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,11 @@
 
 This repo uses Release Please.
 
+This document covers two separate release concepts:
+
+- GitHub/package releases managed by Release Please
+- model release evidence emitted by the registry workflows
+
 ## Source of truth
 
 - PRs are squash-merged into `master`
@@ -57,3 +62,44 @@ If Release Please says a tag already exists, check:
 - `.release-please-manifest.json`
 
 Those three files should agree with the published release.
+
+## Model release evidence
+
+Registry operations also emit ML release evidence into MLflow.
+
+Covered operations:
+
+- `promote`
+- `rollback`
+- `reproduce`
+
+Each operation writes the same bundle shape:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+Artifact path:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+The manifest is the operator-facing release record and includes:
+
+- source run ID
+- dataset fingerprint
+- config hash
+- git SHA
+- current prod version
+- previous prod version
+- policy outcome
+
+Rollback behavior:
+
+- rollback resolves the target from the current prod version's recorded `release_manifest.json`
+- `previous_prod_version` remains as a compatibility and one-step-undo tag
+
+Local runtime behavior:
+
+- the same bundle is mirrored under the configured local artifacts directory
+- a release event may also be appended to the local file-backed `EventStore`

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -6,6 +6,7 @@ MODEL_REF_SCHEMA_VERSION = "model_ref/v1"
 FEATURE_STATS_SCHEMA_VERSION = "feature_stats/v1"
 REPRO_CONTRACT_SCHEMA_VERSION = "repro_contract/v1"
 MODEL_SPEC_SCHEMA_VERSION = "model_spec/v1"
+RELEASE_REPORT_SCHEMA_VERSION = "release_reports/v1"
 
 # MLflow tag keys
 TAG_STEP = "step"
@@ -32,6 +33,11 @@ TAG_GATE = "gate"
 TAG_RELEASE_STATUS = "release_status"
 TAG_PROMOTED_FROM_ALIAS = "promoted_from_alias"
 TAG_PREVIOUS_PROD_VERSION = "previous_prod_version"
+TAG_RELEASE_REPORTS_PATH = "release_reports_path"
+TAG_PROMOTION_DECISION_PATH = "promotion_decision_path"
+TAG_RELEASE_MANIFEST_PATH = "release_manifest_path"
+TAG_ROLLBACK_TARGET_PATH = "rollback_target_path"
+TAG_MODEL_CARD_PATH = "model_card_path"
 
 # MLflow tag values
 GATE_PASSED = "passed"
@@ -59,11 +65,16 @@ ART_REPRO_PROBE_INPUTS_CSV = "probe_inputs.csv"
 ART_REPRO_EXPECTED_PREDICTIONS_JSON = "expected_predictions.json"
 ART_REPRO_REPORT_JSON = "reproduce_report.json"
 ART_UV_LOCK = "uv.lock"
+ART_PROMOTION_DECISION_JSON = "promotion_decision.json"
+ART_RELEASE_MANIFEST_JSON = "release_manifest.json"
+ART_ROLLBACK_TARGET_JSON = "rollback_target.json"
+ART_MODEL_CARD_MD = "model_card.md"
 
 # Artifact paths inside MLflow
 MLFLOW_ARTIFACT_PATH_REPORTS = "reports"
 MLFLOW_ARTIFACT_PATH_MODEL = "model"
 MLFLOW_ARTIFACT_PATH_REPRO = "repro"
+MLFLOW_ARTIFACT_PATH_RELEASES = "reports/releases"
 
 # Aliases
 ALIAS_CANDIDATE = "candidate"

--- a/src/ml_lifecycle_platform/core/release_reports.py
+++ b/src/ml_lifecycle_platform/core/release_reports.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from ml_lifecycle_platform.common.constants import (
+    ART_MODEL_CARD_MD,
+    ART_PROMOTION_DECISION_JSON,
+    ART_RELEASE_MANIFEST_JSON,
+    ART_ROLLBACK_TARGET_JSON,
+    RELEASE_REPORT_SCHEMA_VERSION,
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class PolicyOutcome:
+    status: str
+    allowed: bool | None
+    errors: tuple[dict[str, Any], ...] = ()
+    warnings: tuple[dict[str, Any], ...] = ()
+    context: dict[str, Any] = field(default_factory=dict)
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "allowed": self.allowed,
+            "errors": [dict(item) for item in self.errors],
+            "warnings": [dict(item) for item in self.warnings],
+            "context": dict(self.context),
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_policy_decision(cls, decision: Any) -> PolicyOutcome:
+        return cls(
+            status="evaluated",
+            allowed=bool(decision.allowed),
+            errors=tuple(v.__dict__ for v in decision.errors),
+            warnings=tuple(v.__dict__ for v in decision.warnings),
+            context=dict(decision.context),
+        )
+
+    @classmethod
+    def not_evaluated(
+        cls,
+        *,
+        reason: str,
+        context: dict[str, Any] | None = None,
+    ) -> PolicyOutcome:
+        return cls(
+            status="not_evaluated",
+            allowed=None,
+            context={} if context is None else dict(context),
+            reason=reason,
+        )
+
+
+@dataclass(frozen=True)
+class OperationResult:
+    status: str
+    code: str | None = None
+    message: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "code": self.code,
+            "message": self.message,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class PromotionDecisionReport:
+    generated_at: str
+    operation: str
+    model_name: str
+    model_version: str
+    source_run_id: str
+    policy_outcome: PolicyOutcome
+    result: OperationResult
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RELEASE_REPORT_SCHEMA_VERSION,
+            "generated_at": self.generated_at,
+            "operation": self.operation,
+            "model_name": self.model_name,
+            "model_version": self.model_version,
+            "source_run_id": self.source_run_id,
+            "policy_outcome": self.policy_outcome.to_dict(),
+            "result": self.result.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ReleaseManifest:
+    generated_at: str
+    operation: str
+    model_name: str
+    model_version: str
+    source_run_id: str
+    dataset_fingerprint: str | None
+    config_hash: str | None
+    git_sha: str | None
+    current_prod_version: str | None
+    previous_prod_version: str | None
+    policy_outcome: PolicyOutcome
+    result: OperationResult
+    metrics: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RELEASE_REPORT_SCHEMA_VERSION,
+            "generated_at": self.generated_at,
+            "operation": self.operation,
+            "model_name": self.model_name,
+            "model_version": self.model_version,
+            "source_run_id": self.source_run_id,
+            "dataset_fingerprint": self.dataset_fingerprint,
+            "config_hash": self.config_hash,
+            "git_sha": self.git_sha,
+            "current_prod_version": self.current_prod_version,
+            "previous_prod_version": self.previous_prod_version,
+            "policy_outcome": self.policy_outcome.to_dict(),
+            "result": self.result.to_dict(),
+            "metrics": dict(self.metrics),
+        }
+
+    @classmethod
+    def from_json(cls, payload: str) -> ReleaseManifest:
+        raw = json.loads(payload)
+        if not isinstance(raw, dict):
+            raise ValueError("Release manifest payload must be a JSON object.")
+        policy = raw.get("policy_outcome")
+        result = raw.get("result")
+        if not isinstance(policy, dict):
+            raise ValueError("Release manifest is missing policy_outcome.")
+        if not isinstance(result, dict):
+            raise ValueError("Release manifest is missing result.")
+        metrics = raw.get("metrics", {})
+        if not isinstance(metrics, dict):
+            raise ValueError("Release manifest metrics must be a JSON object.")
+        return cls(
+            generated_at=str(raw.get("generated_at", "")),
+            operation=str(raw.get("operation", "")),
+            model_name=str(raw.get("model_name", "")),
+            model_version=str(raw.get("model_version", "")),
+            source_run_id=str(raw.get("source_run_id", "")),
+            dataset_fingerprint=_optional_str(raw.get("dataset_fingerprint")),
+            config_hash=_optional_str(raw.get("config_hash")),
+            git_sha=_optional_str(raw.get("git_sha")),
+            current_prod_version=_optional_str(raw.get("current_prod_version")),
+            previous_prod_version=_optional_str(raw.get("previous_prod_version")),
+            policy_outcome=PolicyOutcome(
+                status=str(policy.get("status", "")),
+                allowed=_optional_bool(policy.get("allowed")),
+                errors=_tuple_of_dicts(policy.get("errors")),
+                warnings=_tuple_of_dicts(policy.get("warnings")),
+                context=_dict_or_empty(policy.get("context")),
+                reason=_optional_str(policy.get("reason")),
+            ),
+            result=OperationResult(
+                status=str(result.get("status", "")),
+                code=_optional_str(result.get("code")),
+                message=_optional_str(result.get("message")),
+                details=_dict_or_empty(result.get("details")),
+            ),
+            metrics={str(key): float(value) for key, value in metrics.items()},
+        )
+
+
+@dataclass(frozen=True)
+class RollbackTargetReport:
+    generated_at: str
+    operation: str
+    model_name: str
+    model_version: str
+    source_run_id: str
+    current_prod_version: str | None
+    previous_prod_version: str | None
+    target_version: str | None
+    target_source_run_id: str | None
+    result: OperationResult
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RELEASE_REPORT_SCHEMA_VERSION,
+            "generated_at": self.generated_at,
+            "operation": self.operation,
+            "model_name": self.model_name,
+            "model_version": self.model_version,
+            "source_run_id": self.source_run_id,
+            "current_prod_version": self.current_prod_version,
+            "previous_prod_version": self.previous_prod_version,
+            "target_version": self.target_version,
+            "target_source_run_id": self.target_source_run_id,
+            "result": self.result.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class ReleaseReportBundle:
+    decision: PromotionDecisionReport
+    manifest: ReleaseManifest
+    rollback_target: RollbackTargetReport
+    model_card: str
+
+    def file_contents(self) -> dict[str, bytes]:
+        return {
+            ART_PROMOTION_DECISION_JSON: json.dumps(
+                self.decision.to_dict(), indent=2, sort_keys=True
+            ).encode("utf-8"),
+            ART_RELEASE_MANIFEST_JSON: json.dumps(
+                self.manifest.to_dict(), indent=2, sort_keys=True
+            ).encode("utf-8"),
+            ART_ROLLBACK_TARGET_JSON: json.dumps(
+                self.rollback_target.to_dict(), indent=2, sort_keys=True
+            ).encode("utf-8"),
+            ART_MODEL_CARD_MD: self.model_card.encode("utf-8"),
+        }
+
+
+def render_model_card(bundle: ReleaseReportBundle) -> str:
+    manifest = bundle.manifest
+    lines = [
+        f"# Model Card: {manifest.model_name} v{manifest.model_version}",
+        "",
+        f"- Operation: `{manifest.operation}`",
+        f"- Result: `{manifest.result.status}`",
+        f"- Source run: `{manifest.source_run_id}`",
+        f"- Current prod: `{manifest.current_prod_version or 'n/a'}`",
+        f"- Previous prod: `{manifest.previous_prod_version or 'n/a'}`",
+        f"- Dataset fingerprint: `{manifest.dataset_fingerprint or 'n/a'}`",
+        f"- Config hash: `{manifest.config_hash or 'n/a'}`",
+        f"- Git SHA: `{manifest.git_sha or 'n/a'}`",
+        "",
+        "## Policy Outcome",
+        "",
+        f"- Status: `{bundle.decision.policy_outcome.status}`",
+        f"- Allowed: `{bundle.decision.policy_outcome.allowed}`",
+    ]
+    if bundle.decision.policy_outcome.reason:
+        lines.append(f"- Reason: `{bundle.decision.policy_outcome.reason}`")
+    if manifest.metrics:
+        lines.extend(["", "## Metrics", ""])
+        for key, value in sorted(manifest.metrics.items()):
+            lines.append(f"- {key}: `{value}`")
+    return "\n".join(lines) + "\n"
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _tuple_of_dicts(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, list):
+        return ()
+    items: list[dict[str, Any]] = []
+    for entry in value:
+        if isinstance(entry, dict):
+            items.append(dict(entry))
+    return tuple(items)

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import sys
+from typing import Any
 
 from mlflow.tracking import MlflowClient
 
@@ -18,19 +19,34 @@ from ml_lifecycle_platform.common.constants import (
     ALIAS_CHAMPION,
     ALIAS_PROD,
     RELEASE_STATUS_PREVIOUS_PROD,
+    TAG_CONFIG_HASH,
+    TAG_DATASET_FINGERPRINT,
+    TAG_GIT_SHA,
     TAG_PREVIOUS_PROD_VERSION,
     TAG_PROMOTED_FROM_ALIAS,
     TAG_RELEASE_STATUS,
+    TAG_SOURCE_RUN_ID,
 )
 from ml_lifecycle_platform.core.model_specs import (
     PolicySpec,
     default_policy_spec,
     load_model_spec,
 )
+from ml_lifecycle_platform.core.release_reports import (
+    OperationResult,
+    PolicyOutcome,
+    PromotionDecisionReport,
+    ReleaseManifest,
+    ReleaseReportBundle,
+    RollbackTargetReport,
+    render_model_card,
+    utc_now_iso,
+)
 from ml_lifecycle_platform.policy.release_policy import (
     PolicyDecision,
     evaluate_promotion_policy,
 )
+from ml_lifecycle_platform.registry.release_evidence import emit_release_evidence
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +85,117 @@ def _try_get_prod_version(client: MlflowClient, model_name: str) -> str | None:
     return str(prod.version)
 
 
+def _model_version_source_run_id(model_version: Any) -> str:
+    return str((model_version.tags or {}).get(TAG_SOURCE_RUN_ID, "")).strip()
+
+
+def _source_run_metrics(client: MlflowClient, run_id: str) -> dict[str, float]:
+    try:
+        run = client.get_run(run_id)
+    except Exception:
+        return {}
+    metrics = getattr(getattr(run, "data", None), "metrics", {}) or {}
+    return {str(key): float(value) for key, value in metrics.items()}
+
+
+def _build_promotion_bundle(
+    *,
+    client: MlflowClient,
+    decision: PolicyDecision,
+    model_name: str,
+    candidate_version: str,
+    current_prod_version: str | None,
+    previous_prod_version: str | None,
+) -> tuple[str, ReleaseReportBundle]:
+    candidate = client.get_model_version(model_name, candidate_version)
+    candidate_tags = candidate.tags or {}
+    source_run_id = _model_version_source_run_id(candidate)
+    if not source_run_id:
+        raise RuntimeError(
+            "Promotion evidence emission requires source_run_id on the candidate "
+            f"model version. Expected tag '{TAG_SOURCE_RUN_ID}'."
+        )
+
+    target_source_run_id: str | None = None
+    if previous_prod_version is not None:
+        try:
+            previous_prod = client.get_model_version(model_name, previous_prod_version)
+            target_source_run_id = _model_version_source_run_id(previous_prod) or None
+        except Exception:
+            target_source_run_id = None
+
+    generated_at = utc_now_iso()
+    policy_outcome = PolicyOutcome.from_policy_decision(decision)
+    result = OperationResult(
+        status="succeeded",
+        code="promotion_applied",
+        message="Candidate alias promoted to prod and champion.",
+        details={
+            "from_alias": str(decision.context.get("from_alias", "")),
+            "to_alias": str(decision.context.get("to_alias", "")),
+        },
+    )
+    manifest = ReleaseManifest(
+        generated_at=generated_at,
+        operation="promote",
+        model_name=model_name,
+        model_version=candidate_version,
+        source_run_id=source_run_id,
+        dataset_fingerprint=str(candidate_tags.get(TAG_DATASET_FINGERPRINT, "")).strip()
+        or None,
+        config_hash=str(candidate_tags.get(TAG_CONFIG_HASH, "")).strip() or None,
+        git_sha=str(candidate_tags.get(TAG_GIT_SHA, "")).strip() or None,
+        current_prod_version=current_prod_version,
+        previous_prod_version=previous_prod_version,
+        policy_outcome=policy_outcome,
+        result=result,
+        metrics=_source_run_metrics(client, source_run_id),
+    )
+    bundle = ReleaseReportBundle(
+        decision=PromotionDecisionReport(
+            generated_at=generated_at,
+            operation="promote",
+            model_name=model_name,
+            model_version=candidate_version,
+            source_run_id=source_run_id,
+            policy_outcome=policy_outcome,
+            result=result,
+        ),
+        manifest=manifest,
+        rollback_target=RollbackTargetReport(
+            generated_at=generated_at,
+            operation="promote",
+            model_name=model_name,
+            model_version=candidate_version,
+            source_run_id=source_run_id,
+            current_prod_version=current_prod_version,
+            previous_prod_version=previous_prod_version,
+            target_version=previous_prod_version,
+            target_source_run_id=target_source_run_id,
+            result=OperationResult(
+                status="recorded",
+                code="rollback_target_recorded",
+                message="Rollback target recorded from the previous prod version.",
+                details={},
+            ),
+        ),
+        model_card="",
+    )
+    return source_run_id, ReleaseReportBundle(
+        decision=bundle.decision,
+        manifest=bundle.manifest,
+        rollback_target=bundle.rollback_target,
+        model_card=render_model_card(bundle),
+    )
+
+
 def apply_promotion(
-    client: MlflowClient, model_name: str, candidate_version: str, from_alias: str
+    client: MlflowClient,
+    *,
+    model_name: str,
+    candidate_version: str,
+    from_alias: str,
+    decision: PolicyDecision,
 ) -> None:
     """Promote one candidate version and record rollback metadata."""
 
@@ -123,6 +248,25 @@ def apply_promotion(
         ALIAS_CHAMPION,
     )
 
+    source_run_id, bundle = _build_promotion_bundle(
+        client=client,
+        decision=decision,
+        model_name=model_name,
+        candidate_version=candidate_version,
+        current_prod_version=candidate_version,
+        previous_prod_version=prev_prod_version,
+    )
+    emit_release_evidence(
+        client,
+        source_run_id=source_run_id,
+        operation="promote",
+        model_name=model_name,
+        model_version=candidate_version,
+        bundle=bundle,
+        tag_target_version=candidate_version,
+        event_type="release.promoted",
+    )
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -168,6 +312,7 @@ def main(argv: list[str] | None = None) -> None:
         model_name=args.model_name,
         candidate_version=candidate_version,
         from_alias=args.from_alias,
+        decision=decision,
     )
 
 

--- a/src/ml_lifecycle_platform/registry/release_evidence.py
+++ b/src/ml_lifecycle_platform/registry/release_evidence.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mlflow.tracking import MlflowClient
+
+from ml_lifecycle_platform.common.constants import (
+    ART_MODEL_CARD_MD,
+    ART_PROMOTION_DECISION_JSON,
+    ART_RELEASE_MANIFEST_JSON,
+    ART_ROLLBACK_TARGET_JSON,
+    MLFLOW_ARTIFACT_PATH_RELEASES,
+    TAG_MODEL_CARD_PATH,
+    TAG_PROMOTION_DECISION_PATH,
+    TAG_RELEASE_MANIFEST_PATH,
+    TAG_RELEASE_REPORTS_PATH,
+    TAG_ROLLBACK_TARGET_PATH,
+)
+from ml_lifecycle_platform.core.release_reports import (
+    ReleaseManifest,
+    ReleaseReportBundle,
+)
+from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EmittedEvidencePaths:
+    root_path: str
+    promotion_decision_path: str
+    release_manifest_path: str
+    rollback_target_path: str
+    model_card_path: str
+
+
+def artifact_root(*, operation: str, model_name: str, model_version: str) -> str:
+    safe_model_name = model_name.replace("/", "_")
+    safe_version = model_version.replace("/", "_")
+    return (
+        f"{MLFLOW_ARTIFACT_PATH_RELEASES}/{operation}/{safe_model_name}/v{safe_version}"
+    )
+
+
+def emit_release_evidence(
+    client: MlflowClient,
+    *,
+    source_run_id: str,
+    operation: str,
+    model_name: str,
+    model_version: str,
+    bundle: ReleaseReportBundle,
+    tag_target_version: str | None = None,
+    event_type: str | None = None,
+) -> EmittedEvidencePaths:
+    root_path = artifact_root(
+        operation=operation,
+        model_name=model_name,
+        model_version=model_version,
+    )
+    with tempfile.TemporaryDirectory(prefix="release-evidence-") as tmpdir:
+        tmp_path = Path(tmpdir)
+        file_contents = bundle.file_contents()
+        for file_name, content in file_contents.items():
+            local_file = tmp_path / file_name
+            local_file.write_bytes(content)
+            client.log_artifact(
+                run_id=source_run_id,
+                local_path=str(local_file),
+                artifact_path=root_path,
+            )
+
+    emitted = EmittedEvidencePaths(
+        root_path=root_path,
+        promotion_decision_path=f"{root_path}/{ART_PROMOTION_DECISION_JSON}",
+        release_manifest_path=f"{root_path}/{ART_RELEASE_MANIFEST_JSON}",
+        rollback_target_path=f"{root_path}/{ART_ROLLBACK_TARGET_JSON}",
+        model_card_path=f"{root_path}/{ART_MODEL_CARD_MD}",
+    )
+
+    _mirror_local_bundle(root_path=root_path, file_contents=file_contents)
+
+    if tag_target_version is not None:
+        _set_report_tags(
+            client=client,
+            model_name=model_name,
+            model_version=tag_target_version,
+            emitted=emitted,
+        )
+
+    if event_type is not None:
+        _append_event(
+            event_type=event_type,
+            bundle=bundle,
+            emitted=emitted,
+        )
+    return emitted
+
+
+def load_release_manifest(
+    client: MlflowClient,
+    *,
+    source_run_id: str,
+    manifest_path: str,
+    work_dir: Path,
+) -> ReleaseManifest:
+    downloaded = Path(
+        client.download_artifacts(
+            run_id=source_run_id,
+            path=manifest_path,
+            dst_path=str(work_dir),
+        )
+    )
+    return ReleaseManifest.from_json(downloaded.read_text(encoding="utf-8"))
+
+
+def _mirror_local_bundle(*, root_path: str, file_contents: dict[str, bytes]) -> None:
+    runtime = get_runtime_context()
+    for file_name, content in file_contents.items():
+        relative_path = f"{root_path}/{file_name}"
+        try:
+            runtime.artifact_store.write_bytes(relative_path, content)
+        except Exception:
+            logger.warning(
+                "Could not mirror release evidence locally: %s", relative_path
+            )
+
+
+def _set_report_tags(
+    client: MlflowClient,
+    *,
+    model_name: str,
+    model_version: str,
+    emitted: EmittedEvidencePaths,
+) -> None:
+    tags = {
+        TAG_RELEASE_REPORTS_PATH: emitted.root_path,
+        TAG_PROMOTION_DECISION_PATH: emitted.promotion_decision_path,
+        TAG_RELEASE_MANIFEST_PATH: emitted.release_manifest_path,
+        TAG_ROLLBACK_TARGET_PATH: emitted.rollback_target_path,
+        TAG_MODEL_CARD_PATH: emitted.model_card_path,
+    }
+    for key, value in tags.items():
+        client.set_model_version_tag(
+            name=model_name,
+            version=model_version,
+            key=key,
+            value=value,
+        )
+
+
+def _append_event(
+    *,
+    event_type: str,
+    bundle: ReleaseReportBundle,
+    emitted: EmittedEvidencePaths,
+) -> None:
+    runtime = get_runtime_context()
+    payload: dict[str, Any] = {
+        "model_name": bundle.manifest.model_name,
+        "model_version": bundle.manifest.model_version,
+        "operation": bundle.manifest.operation,
+        "source_run_id": bundle.manifest.source_run_id,
+        "current_prod_version": bundle.manifest.current_prod_version,
+        "previous_prod_version": bundle.manifest.previous_prod_version,
+        "result_status": bundle.manifest.result.status,
+        "artifact_root": emitted.root_path,
+    }
+    try:
+        runtime.event_store.append_event(event_type, payload)
+    except Exception:
+        logger.warning("Could not append release evidence event: %s", event_type)

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -17,6 +17,10 @@ from ml_lifecycle_platform.common.config import get_log_level, get_model_name
 from ml_lifecycle_platform.common.constants import (
     ART_REPRO_CONTRACT_JSON,
     ART_REPRO_REPORT_JSON,
+    TAG_CONFIG_HASH,
+    TAG_DATASET_FINGERPRINT,
+    TAG_GIT_SHA,
+    TAG_PREVIOUS_PROD_VERSION,
     TAG_SOURCE_RUN_ID,
 )
 from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
@@ -30,12 +34,23 @@ from ml_lifecycle_platform.contracts.dataset_fingerprint import (
     get_git_sha,
 )
 from ml_lifecycle_platform.contracts.repro_contract import ReproContract
+from ml_lifecycle_platform.core.release_reports import (
+    OperationResult,
+    PolicyOutcome,
+    PromotionDecisionReport,
+    ReleaseManifest,
+    ReleaseReportBundle,
+    RollbackTargetReport,
+    render_model_card,
+    utc_now_iso,
+)
 from ml_lifecycle_platform.core.model_specs import model_spec_from_dict
 from ml_lifecycle_platform.pipeline.train import (
     config_hash_for_spec,
     load_training_inputs,
     train_from_inputs,
 )
+from ml_lifecycle_platform.registry.release_evidence import emit_release_evidence
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +193,138 @@ def _print_report(report: dict[str, Any], fmt: str) -> None:
         print(f"reason={report['reason']}")
     for name, value in report.get("checks", {}).items():
         print(f"{name}={value}")
+
+
+def _resolve_current_prod_version(client: MlflowClient, model_name: str) -> str | None:
+    try:
+        prod = client.get_model_version_by_alias(model_name, "prod")
+    except Exception:
+        return None
+    return str(prod.version)
+
+
+def _emit_reproduce_evidence(
+    client: MlflowClient,
+    *,
+    model_name: str,
+    model_version: str | None,
+    alias: str | None,
+    report: dict[str, Any],
+) -> None:
+    try:
+        model_version_info = _resolve_model_version(
+            client,
+            model_name,
+            model_version=model_version,
+            alias=alias,
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve model version for reproduce evidence emission."
+        )
+        return
+
+    tags = model_version_info.tags or {}
+    source_run_id = str(tags.get(TAG_SOURCE_RUN_ID, "")).strip()
+    if not source_run_id:
+        logger.warning(
+            "Skipping reproduce evidence emission: source_run_id is missing."
+        )
+        return
+
+    metrics = report.get("checks", {}).get("metrics", {})
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    generated_at = utc_now_iso()
+    policy_outcome = PolicyOutcome.not_evaluated(
+        reason="reproduce does not run promotion policy evaluation",
+        context={"selector_alias": alias, "selector_model_version": model_version},
+    )
+    result = OperationResult(
+        status=str(report.get("status", "failed")),
+        code=_optional_text(report.get("reason")),
+        message=_optional_text(report.get("message")),
+        details=_report_details(report),
+    )
+    rollback_target = str(tags.get(TAG_PREVIOUS_PROD_VERSION, "")).strip() or None
+    manifest = ReleaseManifest(
+        generated_at=generated_at,
+        operation="reproduce",
+        model_name=model_name,
+        model_version=str(model_version_info.version),
+        source_run_id=source_run_id,
+        dataset_fingerprint=str(tags.get(TAG_DATASET_FINGERPRINT, "")).strip() or None,
+        config_hash=str(tags.get(TAG_CONFIG_HASH, "")).strip() or None,
+        git_sha=str(tags.get(TAG_GIT_SHA, "")).strip() or None,
+        current_prod_version=_resolve_current_prod_version(client, model_name),
+        previous_prod_version=rollback_target,
+        policy_outcome=policy_outcome,
+        result=result,
+        metrics={str(key): float(value) for key, value in metrics.items()},
+    )
+    bundle = ReleaseReportBundle(
+        decision=PromotionDecisionReport(
+            generated_at=generated_at,
+            operation="reproduce",
+            model_name=model_name,
+            model_version=str(model_version_info.version),
+            source_run_id=source_run_id,
+            policy_outcome=policy_outcome,
+            result=result,
+        ),
+        manifest=manifest,
+        rollback_target=RollbackTargetReport(
+            generated_at=generated_at,
+            operation="reproduce",
+            model_name=model_name,
+            model_version=str(model_version_info.version),
+            source_run_id=source_run_id,
+            current_prod_version=manifest.current_prod_version,
+            previous_prod_version=manifest.previous_prod_version,
+            target_version=rollback_target,
+            target_source_run_id=None,
+            result=OperationResult(
+                status="recorded",
+                code="reproduce_context_recorded",
+                message="Rollback context mirrored into reproduce evidence.",
+                details={},
+            ),
+        ),
+        model_card="",
+    )
+    emit_release_evidence(
+        client,
+        source_run_id=source_run_id,
+        operation="reproduce",
+        model_name=model_name,
+        model_version=str(model_version_info.version),
+        bundle=ReleaseReportBundle(
+            decision=bundle.decision,
+            manifest=bundle.manifest,
+            rollback_target=bundle.rollback_target,
+            model_card=render_model_card(bundle),
+        ),
+        tag_target_version=str(model_version_info.version),
+        event_type="release.reproduced",
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _report_details(report: dict[str, Any]) -> dict[str, Any]:
+    details = report.get("details")
+    if isinstance(details, dict):
+        return dict(details)
+    checks = report.get("checks")
+    if isinstance(checks, dict):
+        return {"checks": dict(checks)}
+    return {}
 
 
 def reproduce_model(
@@ -374,15 +521,23 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=get_log_level())
     args = parse_args(sys.argv[1:] if argv is None else argv)
     report_path = Path(args.report_path)
+    client = mlflow_client()
 
     try:
         report = reproduce_model(
-            mlflow_client(),
+            client,
             model_name=args.model_name,
             model_version=args.model_version,
             alias=args.alias,
         )
         _write_report(report_path, report)
+        _emit_reproduce_evidence(
+            client,
+            model_name=args.model_name,
+            model_version=args.model_version,
+            alias=args.alias,
+            report=report,
+        )
         _print_report(report, args.format)
         raise SystemExit(0)
     except ReproduceFailure as exc:
@@ -393,6 +548,13 @@ def main(argv: list[str] | None = None) -> None:
             "details": exc.details,
         }
         _write_report(report_path, report)
+        _emit_reproduce_evidence(
+            client,
+            model_name=args.model_name,
+            model_version=args.model_version,
+            alias=args.alias,
+            report=report,
+        )
         _print_report(report, args.format)
         raise SystemExit(2)
 

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -1,40 +1,195 @@
 from __future__ import annotations
 
 import logging
+import tempfile
+from pathlib import Path
+from typing import Any
 
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.config import get_log_level, get_model_name
-from ml_lifecycle_platform.common.constants import ALIAS_PROD, TAG_PREVIOUS_PROD_VERSION
+from ml_lifecycle_platform.common.constants import (
+    ALIAS_PROD,
+    TAG_CONFIG_HASH,
+    TAG_DATASET_FINGERPRINT,
+    TAG_GIT_SHA,
+    TAG_PREVIOUS_PROD_VERSION,
+    TAG_RELEASE_MANIFEST_PATH,
+    TAG_SOURCE_RUN_ID,
+)
 from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
+from ml_lifecycle_platform.core.release_reports import (
+    OperationResult,
+    PolicyOutcome,
+    PromotionDecisionReport,
+    ReleaseManifest,
+    ReleaseReportBundle,
+    RollbackTargetReport,
+    render_model_card,
+    utc_now_iso,
+)
+from ml_lifecycle_platform.registry.release_evidence import (
+    emit_release_evidence,
+    load_release_manifest,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _source_run_id(model_version: Any) -> str:
+    return str((model_version.tags or {}).get(TAG_SOURCE_RUN_ID, "")).strip()
+
+
+def _run_metrics(client: MlflowClient, run_id: str) -> dict[str, float]:
+    try:
+        run = client.get_run(run_id)
+    except Exception:
+        return {}
+    metrics = getattr(getattr(run, "data", None), "metrics", {}) or {}
+    return {str(key): float(value) for key, value in metrics.items()}
+
+
+def _previous_prod_from_manifest(
+    client: MlflowClient,
+    *,
+    current_prod: Any,
+) -> tuple[str | None, str]:
+    tags = current_prod.tags or {}
+    manifest_path = str(tags.get(TAG_RELEASE_MANIFEST_PATH, "")).strip()
+    source_run_id = _source_run_id(current_prod)
+    if not manifest_path or not source_run_id:
+        return None, "tag_fallback"
+    with tempfile.TemporaryDirectory(prefix="rollback-manifest-") as tmpdir:
+        try:
+            manifest = load_release_manifest(
+                client,
+                source_run_id=source_run_id,
+                manifest_path=manifest_path,
+                work_dir=Path(tmpdir),
+            )
+        except Exception as exc:
+            logger.warning("Could not read release manifest for rollback: %s", exc)
+            return None, "tag_fallback"
+    return manifest.previous_prod_version, "manifest"
 
 
 def rollback_prod(client: MlflowClient, model_name: str) -> None:
     """Roll back prod to the recorded previous prod version."""
     current_prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
-    tags = current_prod.tags or {}
-    prev = str(tags.get(TAG_PREVIOUS_PROD_VERSION, "")).strip()
+    current_tags = current_prod.tags or {}
+    current_source_run_id = _source_run_id(current_prod)
 
-    if not prev:
+    previous_prod, resolution_source = _previous_prod_from_manifest(
+        client,
+        current_prod=current_prod,
+    )
+    if not previous_prod:
+        previous_prod = str(current_tags.get(TAG_PREVIOUS_PROD_VERSION, "")).strip()
+
+    if not previous_prod:
         raise RuntimeError(
             "Rollback blocked: current prod does not have a previous prod recorded. "
-            f"Expected tag '{TAG_PREVIOUS_PROD_VERSION}' on current prod model version."
+            "Expected release_manifest.json or "
+            f"tag '{TAG_PREVIOUS_PROD_VERSION}' on current prod model version."
         )
 
-    client.set_registered_model_alias(model_name, ALIAS_PROD, prev)
+    target = client.get_model_version(model_name, previous_prod)
+    target_source_run_id = _source_run_id(target) or None
+
+    client.set_registered_model_alias(model_name, ALIAS_PROD, previous_prod)
 
     # Allow a one-step undo.
     client.set_model_version_tag(
         name=model_name,
-        version=prev,
+        version=previous_prod,
         key=TAG_PREVIOUS_PROD_VERSION,
         value=str(current_prod.version),
     )
 
     logger.info(
-        "Rolled back %s prod -> v%s (from v%s)", model_name, prev, current_prod.version
+        "Rolled back %s prod -> v%s (from v%s)",
+        model_name,
+        previous_prod,
+        current_prod.version,
+    )
+
+    if not current_source_run_id:
+        raise RuntimeError(
+            "Rollback evidence emission requires source_run_id on the current prod "
+            f"model version. Expected tag '{TAG_SOURCE_RUN_ID}'."
+        )
+
+    generated_at = utc_now_iso()
+    policy_outcome = PolicyOutcome.not_evaluated(
+        reason="rollback does not run promotion policy evaluation",
+        context={"resolution_source": resolution_source},
+    )
+    result = OperationResult(
+        status="succeeded",
+        code="rollback_applied",
+        message="Prod alias moved to the recorded previous prod version.",
+        details={"resolution_source": resolution_source},
+    )
+    manifest = ReleaseManifest(
+        generated_at=generated_at,
+        operation="rollback",
+        model_name=model_name,
+        model_version=str(current_prod.version),
+        source_run_id=current_source_run_id,
+        dataset_fingerprint=str(current_tags.get(TAG_DATASET_FINGERPRINT, "")).strip()
+        or None,
+        config_hash=str(current_tags.get(TAG_CONFIG_HASH, "")).strip() or None,
+        git_sha=str(current_tags.get(TAG_GIT_SHA, "")).strip() or None,
+        current_prod_version=str(previous_prod),
+        previous_prod_version=str(current_prod.version),
+        policy_outcome=policy_outcome,
+        result=result,
+        metrics=_run_metrics(client, current_source_run_id),
+    )
+    bundle = ReleaseReportBundle(
+        decision=PromotionDecisionReport(
+            generated_at=generated_at,
+            operation="rollback",
+            model_name=model_name,
+            model_version=str(current_prod.version),
+            source_run_id=current_source_run_id,
+            policy_outcome=policy_outcome,
+            result=result,
+        ),
+        manifest=manifest,
+        rollback_target=RollbackTargetReport(
+            generated_at=generated_at,
+            operation="rollback",
+            model_name=model_name,
+            model_version=str(current_prod.version),
+            source_run_id=current_source_run_id,
+            current_prod_version=str(current_prod.version),
+            previous_prod_version=str(previous_prod),
+            target_version=str(previous_prod),
+            target_source_run_id=target_source_run_id,
+            result=OperationResult(
+                status="resolved",
+                code="rollback_target_resolved",
+                message="Rollback target resolved before alias mutation.",
+                details={"resolution_source": resolution_source},
+            ),
+        ),
+        model_card="",
+    )
+    emit_release_evidence(
+        client,
+        source_run_id=current_source_run_id,
+        operation="rollback",
+        model_name=model_name,
+        model_version=str(current_prod.version),
+        bundle=ReleaseReportBundle(
+            decision=bundle.decision,
+            manifest=bundle.manifest,
+            rollback_target=bundle.rollback_target,
+            model_card=render_model_card(bundle),
+        ),
+        tag_target_version=str(current_prod.version),
+        event_type="release.rolled_back",
     )
 
 

--- a/tests/integration/test_registry_flow.py
+++ b/tests/integration/test_registry_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import mlflow
 import pytest
@@ -13,27 +15,33 @@ from ml_lifecycle_platform.common.constants import (
     ALIAS_CHAMPION,
     ALIAS_PROD,
     ART_GATE_OK,
+    ART_PROMOTION_DECISION_JSON,
+    ART_RELEASE_MANIFEST_JSON,
+    ART_ROLLBACK_TARGET_JSON,
     ART_REGISTERED_VERSION,
     ART_TRAIN_RUN_ID,
     GATE_PASSED,
     MLFLOW_ARTIFACT_PATH_MODEL,
+    TAG_PREVIOUS_PROD_VERSION,
     TAG_CONFIG_HASH,
     TAG_DATASET_FINGERPRINT,
     TAG_GATE,
     TAG_GIT_SHA,
     TAG_MODEL_NAME,
+    TAG_RELEASE_MANIFEST_PATH,
     TAG_PROMOTED_FROM_ALIAS,
     TAG_RELEASE_STATUS,
     TAG_SOURCE_RUN_ID,
     TAG_TRAINING_RUN_ID,
 )
 from ml_lifecycle_platform.registry.promote import main as promote_main
+from ml_lifecycle_platform.registry.release_evidence import artifact_root
+from ml_lifecycle_platform.registry.rollback import rollback_prod
 
 pytestmark = pytest.mark.integration
 
 
-def _create_training_run() -> str:
-    model_name = "integration_registry_model"
+def _create_training_run(model_name: str = "integration_registry_model") -> str:
     model = DummyClassifier(strategy="most_frequent")
     model.fit([[0.0], [1.0], [0.0], [1.0]], [0, 1, 0, 1])
 
@@ -48,6 +56,16 @@ def _create_training_run() -> str:
         return run_id
 
 
+def _download_json_artifact(
+    client: MlflowClient,
+    *,
+    run_id: str,
+    artifact_path: str,
+) -> dict[str, Any]:
+    downloaded = client.download_artifacts(run_id=run_id, path=artifact_path)
+    return json.loads(Path(downloaded).read_text(encoding="utf-8"))
+
+
 def test_register_then_promote_flow_uses_local_mlflow_registry(
     mlflow_sqlite: str,
     tmp_path: Path,
@@ -55,16 +73,19 @@ def test_register_then_promote_flow_uses_local_mlflow_registry(
 ) -> None:
     experiment_name = "integration-registry-flow"
     model_name = "integration_registry_model"
-    artifact_root = tmp_path / "mlflow-artifacts"
-    artifact_root.mkdir(parents=True, exist_ok=True)
+    artifact_root_path = tmp_path / "mlflow-artifacts"
+    artifact_root_path.mkdir(parents=True, exist_ok=True)
 
-    mlflow.create_experiment(experiment_name, artifact_location=artifact_root.as_uri())
+    mlflow.create_experiment(
+        experiment_name,
+        artifact_location=artifact_root_path.as_uri(),
+    )
     mlflow.set_experiment(experiment_name)
 
     monkeypatch.setenv("EXPERIMENT_NAME", experiment_name)
     monkeypatch.setenv("MODEL_NAME", model_name)
 
-    train_run_id = _create_training_run()
+    train_run_id = _create_training_run(model_name)
 
     art_dir = tmp_path / "pipeline-artifacts"
     art_dir.mkdir(parents=True, exist_ok=True)
@@ -98,3 +119,101 @@ def test_register_then_promote_flow_uses_local_mlflow_registry(
     assert str(champion.version) == str(candidate.version)
     assert promoted.tags[TAG_RELEASE_STATUS] == ALIAS_PROD
     assert promoted.tags[TAG_PROMOTED_FROM_ALIAS] == ALIAS_CANDIDATE
+    assert promoted.tags[TAG_RELEASE_MANIFEST_PATH] == (
+        f"{artifact_root(operation='promote', model_name=model_name, model_version=str(candidate.version))}/"
+        f"{ART_RELEASE_MANIFEST_JSON}"
+    )
+
+    release_root = artifact_root(
+        operation="promote",
+        model_name=model_name,
+        model_version=str(candidate.version),
+    )
+    manifest = _download_json_artifact(
+        client,
+        run_id=train_run_id,
+        artifact_path=f"{release_root}/{ART_RELEASE_MANIFEST_JSON}",
+    )
+    decision = _download_json_artifact(
+        client,
+        run_id=train_run_id,
+        artifact_path=f"{release_root}/{ART_PROMOTION_DECISION_JSON}",
+    )
+    rollback_target = _download_json_artifact(
+        client,
+        run_id=train_run_id,
+        artifact_path=f"{release_root}/{ART_ROLLBACK_TARGET_JSON}",
+    )
+
+    assert manifest["model_name"] == model_name
+    assert manifest["model_version"] == str(candidate.version)
+    assert manifest["current_prod_version"] == str(candidate.version)
+    assert manifest["previous_prod_version"] is None
+    assert decision["policy_outcome"]["allowed"] is True
+    assert rollback_target["target_version"] is None
+
+
+def test_rollback_uses_manifest_recorded_previous_prod(
+    mlflow_sqlite: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    experiment_name = "integration-rollback-flow"
+    model_name = "integration_rollback_model"
+    artifact_root_path = tmp_path / "mlflow-artifacts"
+    artifact_root_path.mkdir(parents=True, exist_ok=True)
+
+    mlflow.create_experiment(
+        experiment_name,
+        artifact_location=artifact_root_path.as_uri(),
+    )
+    mlflow.set_experiment(experiment_name)
+
+    monkeypatch.setenv("EXPERIMENT_NAME", experiment_name)
+    monkeypatch.setenv("MODEL_NAME", model_name)
+
+    art_dir = tmp_path / "pipeline-artifacts"
+    art_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(register_mod, "ART_DIR", art_dir)
+
+    first_run_id = _create_training_run(model_name)
+    (art_dir / ART_TRAIN_RUN_ID).write_text(first_run_id, encoding="utf-8")
+    (art_dir / ART_GATE_OK).write_text("true", encoding="utf-8")
+    register_mod.main()
+    promote_main(["--model-name", model_name, "--format", "json"])
+
+    client = MlflowClient()
+    first_prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
+    assert str(first_prod.version) == "1"
+
+    second_run_id = _create_training_run(model_name)
+    (art_dir / ART_TRAIN_RUN_ID).write_text(second_run_id, encoding="utf-8")
+    register_mod.main()
+    promote_main(["--model-name", model_name, "--format", "json"])
+
+    second_prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
+    assert str(second_prod.version) == "2"
+
+    release_root = artifact_root(
+        operation="promote",
+        model_name=model_name,
+        model_version=str(second_prod.version),
+    )
+    manifest = _download_json_artifact(
+        client,
+        run_id=second_run_id,
+        artifact_path=f"{release_root}/{ART_RELEASE_MANIFEST_JSON}",
+    )
+    assert manifest["previous_prod_version"] == "1"
+
+    client.set_model_version_tag(
+        name=model_name,
+        version=str(second_prod.version),
+        key=TAG_PREVIOUS_PROD_VERSION,
+        value="999",
+    )
+
+    rollback_prod(client, model_name)
+
+    rolled_back = client.get_model_version_by_alias(model_name, ALIAS_PROD)
+    assert str(rolled_back.version) == "1"

--- a/tests/integration/test_reproduce.py
+++ b/tests/integration/test_reproduce.py
@@ -20,18 +20,21 @@ from ml_lifecycle_platform.common.constants import (
     ALIAS_CHAMPION,
     ALIAS_PROD,
     ART_GATE_OK,
+    ART_RELEASE_MANIFEST_JSON,
     ART_REGISTERED_VERSION,
     ART_REPRO_REPORT_JSON,
     ART_TRAIN_RUN_ID,
     STEP_TRAIN,
     TAG_DETERMINISTIC_SEED,
     TAG_ENV_LOCK_HASH,
+    TAG_RELEASE_MANIFEST_PATH,
     TAG_PROMOTED_FROM_ALIAS,
     TAG_REPRO_SCHEMA_VERSION,
     TAG_RELEASE_STATUS,
     TAG_SOURCE_RUN_ID,
     TAG_STEP,
 )
+from ml_lifecycle_platform.registry.release_evidence import artifact_root
 
 pytestmark = pytest.mark.integration
 
@@ -177,6 +180,25 @@ def test_reproduce_from_registered_model_version_matches_training_run(
     assert report["status"] == "matched"
     assert report["checks"]["prediction_parity"]["matched"] is True
     assert report["checks"]["env_lock_hash"]["matched"] is True
+
+    client = MlflowClient()
+    reproduced = client.get_model_version(model_name, version)
+    release_root = artifact_root(
+        operation="reproduce",
+        model_name=model_name,
+        model_version=version,
+    )
+    assert reproduced.tags[TAG_RELEASE_MANIFEST_PATH] == (
+        f"{release_root}/{ART_RELEASE_MANIFEST_JSON}"
+    )
+    manifest_path = client.download_artifacts(
+        run_id=reproduced.tags[TAG_SOURCE_RUN_ID],
+        path=f"{release_root}/{ART_RELEASE_MANIFEST_JSON}",
+    )
+    manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    assert manifest["operation"] == "reproduce"
+    assert manifest["model_version"] == version
+    assert manifest["result"]["status"] == "matched"
 
 
 def test_reproduce_fails_with_precise_reason_when_env_lock_does_not_match(

--- a/tests/unit/test_release_reports.py
+++ b/tests/unit/test_release_reports.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ml_lifecycle_platform.core.release_reports import (
+    OperationResult,
+    PolicyOutcome,
+    PromotionDecisionReport,
+    ReleaseManifest,
+    ReleaseReportBundle,
+    RollbackTargetReport,
+    render_model_card,
+)
+from ml_lifecycle_platform.registry.release_evidence import artifact_root
+
+pytestmark = pytest.mark.unit
+
+
+def _bundle() -> ReleaseReportBundle:
+    policy_outcome = PolicyOutcome.not_evaluated(reason="unit-test")
+    result = OperationResult(status="succeeded", code="ok", message="all good")
+    bundle = ReleaseReportBundle(
+        decision=PromotionDecisionReport(
+            generated_at="2026-03-09T00:00:00+00:00",
+            operation="promote",
+            model_name="demo_model",
+            model_version="7",
+            source_run_id="run-123",
+            policy_outcome=policy_outcome,
+            result=result,
+        ),
+        manifest=ReleaseManifest(
+            generated_at="2026-03-09T00:00:00+00:00",
+            operation="promote",
+            model_name="demo_model",
+            model_version="7",
+            source_run_id="run-123",
+            dataset_fingerprint="fp-123",
+            config_hash="cfg-123",
+            git_sha="deadbeef",
+            current_prod_version="7",
+            previous_prod_version="6",
+            policy_outcome=policy_outcome,
+            result=result,
+            metrics={"test_accuracy": 0.91},
+        ),
+        rollback_target=RollbackTargetReport(
+            generated_at="2026-03-09T00:00:00+00:00",
+            operation="promote",
+            model_name="demo_model",
+            model_version="7",
+            source_run_id="run-123",
+            current_prod_version="7",
+            previous_prod_version="6",
+            target_version="6",
+            target_source_run_id="run-122",
+            result=result,
+        ),
+        model_card="",
+    )
+    return ReleaseReportBundle(
+        decision=bundle.decision,
+        manifest=bundle.manifest,
+        rollback_target=bundle.rollback_target,
+        model_card=render_model_card(bundle),
+    )
+
+
+def test_release_manifest_round_trips_from_json() -> None:
+    bundle = _bundle()
+
+    manifest = ReleaseManifest.from_json(json.dumps(bundle.manifest.to_dict()))
+
+    assert manifest.model_name == "demo_model"
+    assert manifest.previous_prod_version == "6"
+    assert manifest.policy_outcome.reason == "unit-test"
+    assert manifest.metrics["test_accuracy"] == pytest.approx(0.91)
+
+
+def test_release_bundle_writes_expected_artifact_names() -> None:
+    files = _bundle().file_contents()
+
+    assert sorted(files) == [
+        "model_card.md",
+        "promotion_decision.json",
+        "release_manifest.json",
+        "rollback_target.json",
+    ]
+
+
+def test_model_card_contains_operator_facing_fields() -> None:
+    model_card = _bundle().model_card
+
+    assert "# Model Card: demo_model v7" in model_card
+    assert "- Current prod: `7`" in model_card
+    assert "- Previous prod: `6`" in model_card
+    assert "- Dataset fingerprint: `fp-123`" in model_card
+
+
+def test_artifact_root_is_stable() -> None:
+    assert artifact_root(
+        operation="promote", model_name="demo_model", model_version="7"
+    ) == ("reports/releases/promote/demo_model/v7")


### PR DESCRIPTION
## Summary

Add explicit release evidence bundles for `promote`, `rollback`, and `reproduce`.

## What changed

- add shared release report schemas in `core/release_reports.py`
- add shared MLflow/event evidence emitter in `registry/release_evidence.py`
- emit `promotion_decision.json`, `release_manifest.json`, `rollback_target.json`, and `model_card.md`
- log release evidence to MLflow under `reports/releases/<operation>/<model_name>/v<version>/`
- tag model versions with stable artifact paths
- make rollback resolve from recorded `release_manifest.json` with `previous_prod_version` fallback
- align reproduce with the same evidence pattern
- update README and architecture/release ADR docs
- add unit and integration coverage for serialization, promotion artifact emission, and manifest-driven rollback

## Why

Promotion already emitted partial structured output, but operators did not have a complete machine-readable evidence bundle across promote, rollback, and reproduce flows.

This change makes release evidence explicit, stable, and operator-visible without adding a second control plane.

## Validation

- `make check`
- `make test-integration`
- `make test-all`

## Rollback / Compatibility

- rollback now prefers the recorded `release_manifest.json`
- older versions without a manifest still work via `previous_prod_version`
- no hosted event sink or external observability dependency added
