### PR TITLE
docs: add platform handbook and local operator runbooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Keep changes small, test-backed, and easy to review.
 Run what applies:
 
 - `make check`
+- `make docs-check` if you changed docs
 - `make test-integration`
 - `make e2e` if you changed Docker, serving, promotion flow, or the local operator path
 
@@ -36,6 +37,7 @@ The PR title becomes the squash commit message and feeds Release Please.
 ## Local workflows
 
 - `make check`
+- `make docs-check`
 - `make test-unit`
 - `make test-integration`
 - `make e2e`
@@ -46,4 +48,11 @@ The PR title becomes the squash commit message and feeds Release Please.
 - Preserve current behavior unless there is a clear bug.
 - If you touch the model lifecycle, validate the demo spec path at minimum.
 
-See [`docs/ci.md`](docs/ci.md) for CI mapping and [`docs/releases.md`](docs/releases.md) for release behavior.
+Start with the handbook in [`docs/README.md`](docs/README.md).
+
+Useful references:
+
+- [`docs/runbooks/local-bootstrap.md`](docs/runbooks/local-bootstrap.md)
+- [`docs/architecture/overview.md`](docs/architecture/overview.md)
+- [`docs/ci.md`](docs/ci.md)
+- [`docs/releases.md`](docs/releases.md)

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ help:
 	@echo "  make test-coverage     run unit tests with coverage report"
 	@echo "  make test-integration  run local integration tests"
 	@echo "  make test-all          run unit + integration tests"
+	@echo "  make docs-check        validate handbook links and local doc paths"
 	@echo "  make fix               format + safe autofix"
 	@echo "  make precommit         run all hooks"
 	@echo "  make install-hooks     install git hooks"
@@ -73,7 +74,7 @@ help:
 	@echo "  make clean             remove local caches"
 	@echo ""
 
-.PHONY: check format lint type test test-unit test-coverage test-integration test-all fix
+.PHONY: check format lint type test test-unit test-coverage test-integration test-all docs-check fix
 check: format lint type test
 	@echo "✅ All checks passed"
 
@@ -103,6 +104,9 @@ test-integration:
 
 test-all:
 	@$(PYTEST) $(PYTEST_ARGS) -m "unit or integration"
+
+docs-check:
+	@$(PY) scripts/check_docs_links.py
 
 fix:
 	@$(RUFF) format .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A production ML platform for training, evaluating, registering, promoting, serving, and reproducing models with MLflow as the control plane. The first implementation is local-first, afterwards connectors to `GCP` and `AWS` will be integraded.
 
+Operator and architecture docs live in the handbook:
+
+- [`docs/README.md`](docs/README.md)
+
 ## What it does
 
 - Runs a simple pipeline: `ingest -> featurize -> train -> evaluate -> register`
@@ -46,6 +50,7 @@ Fast local checks:
 
 ```bash
 make check
+make docs-check
 ```
 
 Bring up local infra:
@@ -220,6 +225,10 @@ configs/
 
 ## More Docs
 
+- [`docs/README.md`](docs/README.md)
+- [`docs/architecture/overview.md`](docs/architecture/overview.md)
+- [`docs/architecture/local-runtime.md`](docs/architecture/local-runtime.md)
+- [`docs/runbooks/local-bootstrap.md`](docs/runbooks/local-bootstrap.md)
 - [`docs/architecture/current-state.md`](docs/architecture/current-state.md)
 - [`docs/ci.md`](docs/ci.md)
 - [`docs/releases.md`](docs/releases.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Handbook
+
+Start here if you want to run or change the local platform.
+
+## Golden path
+
+1. Read [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md).
+2. Follow the commands exactly in order.
+3. Use the other runbooks only when you need a specific registry operation.
+
+## Architecture
+
+- [`architecture/overview.md`](./architecture/overview.md): platform shape, control plane, lifecycle
+- [`architecture/local-runtime.md`](./architecture/local-runtime.md): runtime profiles, model specs, serving contract, local paths
+- [`architecture/current-state.md`](./architecture/current-state.md): current M0 scope and non-goals
+
+## Runbooks
+
+- [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md): fresh-clone local setup and golden path
+- [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
+- [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
+- [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model
+
+## Delivery docs
+
+- [`ci.md`](./ci.md): CI lanes and local mapping
+- [`releases.md`](./releases.md): package releases and model release evidence
+- [`adrs/ADR-0001-portability-surface.md`](./adrs/ADR-0001-portability-surface.md): M0 portability boundary
+- [`adrs/ADR-0002-mlflow-control-plane.md`](./adrs/ADR-0002-mlflow-control-plane.md): MLflow as M0 control plane

--- a/docs/adrs/ADR-0001-portability-surface.md
+++ b/docs/adrs/ADR-0001-portability-surface.md
@@ -32,6 +32,8 @@ Only these four interfaces are allowed as implementation boundaries (seams) in
 Everything else stays concrete in `M0`, including:
 
 - MLflow registry and release-control behavior
+- runtime profile loading from YAML plus env overrides
+- model spec parsing and validation
 - release policy evaluation
 - registry workflows such as register, promote, rollback, and reproduce
 - lineage and reproducibility contracts
@@ -49,12 +51,21 @@ Examples:
 - model artifacts
 - evaluation reports
 - reproducibility payloads
+- mirrored release evidence bundles under the local artifacts directory
+
+Current local implementation:
+
+- file-backed store rooted at `artifacts_dir`
 
 ### `EventStore`
 
 Handles structured platform events.
 
 This does not mean adding a workflow engine or a message bus in `M0`.
+
+Current local implementation:
+
+- append-only JSONL file at `event_log_path`
 
 ### `JobRunner`
 
@@ -63,11 +74,19 @@ Runs bounded jobs and runtime steps.
 This does not mean turning the platform into a full workflow orchestrator in
 `M0`.
 
+Current local implementation:
+
+- Python module execution through the configured `python_executable`
+
 ### `Secrets`
 
 Provides runtime secrets needed by local or hosted backends.
 
 This is not a full redesign of config handling.
+
+Current local implementation:
+
+- environment variable reads
 
 ## Explicit non-interfaces for M0
 

--- a/docs/adrs/ADR-0002-mlflow-control-plane.md
+++ b/docs/adrs/ADR-0002-mlflow-control-plane.md
@@ -33,6 +33,8 @@ In `M0`:
 - MLflow aliases remain the authoritative release pointers
 - MLflow artifacts and model-version tags remain the authoritative promotion,
   rollback, and reproduce evidence
+- release manifests under `reports/releases/...` remain the operator-visible
+  release and rollback records
 - serving continues to resolve models from MLflow aliases
 - policy evaluation continues to read its decision inputs from MLflow metadata
 
@@ -48,6 +50,7 @@ These behaviors stay concrete and MLflow-backed in `M0`:
 - release evidence bundles under `reports/releases/...`
 - rollback via recorded `release_manifest.json` with `previous_prod_version`
   compatibility fallback
+- release evidence path tags on the affected model version
 - source training run linkage
 - dataset fingerprint, config hash, git SHA, and training run metadata checks
 

--- a/docs/architecture/local-runtime.md
+++ b/docs/architecture/local-runtime.md
@@ -1,0 +1,129 @@
+# Local Runtime
+
+This document covers the concrete local runtime path shipped in `M0`.
+
+## Runtime profile resolution
+
+The CLI loads one runtime profile from:
+
+- `configs/env/<env>.yaml` when you run `mlp --env <env> ...`
+- `MLP_PROFILE_PATH` when you want an explicit profile file
+
+Default local path:
+
+- [`configs/env/local.yaml`](../../configs/env/local.yaml)
+
+The selected profile becomes:
+
+- process environment for local Python commands
+- environment passed into Docker Compose services
+- default model name and model spec path
+- local artifact and event-log paths
+
+## Runtime profile fields that matter
+
+| Field | Used by | Why it matters |
+| --- | --- | --- |
+| `tracking_uri` | local Python commands | points MLflow tracking to the active backend |
+| `registry_uri` | local Python commands | points model registry reads and writes |
+| `experiment_name` | pipeline and register flow | decides where local runs land |
+| `model_name` | register, promote, rollback, serve | default registered model name |
+| `model_spec_path` | pipeline and serving | selects data source, training config, feature contract, and promotion policy |
+| `data_dir` | pipeline steps | local working data path |
+| `artifacts_dir` | pipeline and release evidence mirror | local runtime artifact root |
+| `event_log_path` | local `EventStore` | append-only JSONL event path |
+| `compose_file` | `mlp infra`, pipeline, serving, e2e | Docker Compose file used by operator commands |
+| `compose_tracking_uri` | containers | MLflow endpoint inside Compose |
+| `compose_registry_uri` | containers | registry endpoint inside Compose |
+| `compose_serve_url` | smoke and local defaults | serving URL inside Compose |
+
+## Supported env var overrides
+
+Operators can override the shipped profile with environment variables.
+
+Common overrides:
+
+- `MLP_PROFILE_PATH`
+- `MLFLOW_TRACKING_URI`
+- `MLFLOW_REGISTRY_URI`
+- `EXPERIMENT_NAME`
+- `MODEL_NAME`
+- `MLP_MODEL_SPEC_PATH`
+- `LOG_LEVEL`
+- `MLP_DATA_DIR`
+- `MLP_ARTIFACTS_DIR`
+- `MLP_EVENT_LOG_PATH`
+
+Less common local-runtime overrides:
+
+- `MLP_COMPOSE_FILE`
+- `MLP_COMPOSE_TRACKING_URI`
+- `MLP_COMPOSE_REGISTRY_URI`
+- `MLP_COMPOSE_SERVE_URL`
+- `MLFLOW_S3_ENDPOINT_URL`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+## Model spec shape
+
+The runtime profile chooses one model spec. The model spec is the behavior contract for one model.
+
+Important sections:
+
+| Section | Purpose |
+| --- | --- |
+| `source` | chooses `sklearn_demo` or `csv` input |
+| `split` | test split and deterministic seed |
+| `preprocessor` | preprocessing kind |
+| `trainer` | trainer type and hyperparameters |
+| `evaluation` | reported metrics and promotion gate threshold |
+| `feature_contract` | serving request schema |
+| `policy` | promotion policy requirements |
+
+Concrete examples:
+
+- [`configs/models/breast_cancer_demo.yaml`](../../configs/models/breast_cancer_demo.yaml)
+- [`configs/models/local_csv_binary_classifier.yaml`](../../configs/models/local_csv_binary_classifier.yaml)
+
+## Serving contract in local runtime
+
+Serving reads two things:
+
+- the registered model selected by MLflow alias
+- the feature contract from the active model spec
+
+That means:
+
+- changing `MODEL_NAME` without also changing `MLP_MODEL_SPEC_PATH` can break request validation
+- the local serving path should keep model name and model spec aligned
+- the runbooks use the same model name and model spec together when they override defaults
+
+## Release reports in local runtime
+
+Promotion, rollback, and reproduce emit release evidence to MLflow under:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+When the local runtime is active, the platform also mirrors those files under:
+
+- `<artifacts_dir>/reports/releases/...`
+
+The same operations may append structured events to:
+
+- `<event_log_path>`
+
+## Local Docker path
+
+Primary operator entrypoints:
+
+- `make up`
+- `make run-pipeline`
+- `make policy-check`
+- `make promote`
+- `make rollback-prod`
+- `make serve`
+- `make smoke-test`
+- `make reproduce ...`
+- `make down`
+
+The Makefile is the supported operator surface. It wraps the same CLI subcommands shipped in `mlp`.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,74 @@
+# Overview
+
+This repo is a local-first ML platform for one main path:
+
+```text
+ingest -> featurize -> train -> evaluate -> register -> promote -> serve
+```
+
+It is intentionally narrow in `M0`:
+
+- MLflow is the experiment tracker, model registry, and release-control system.
+- Docker Compose is the local operator path.
+- Runtime profiles select environment-specific endpoints and local paths.
+- Model specs define the data source, trainer, evaluation gate, feature contract, and promotion policy for one model.
+
+## Main pieces
+
+| Area | Source of truth | Purpose |
+| --- | --- | --- |
+| Runtime wiring | `configs/env/<env>.yaml` | tracking URIs, model name, model spec path, local artifact paths, Compose settings |
+| Model behavior | `configs/models/*.yaml` | data source, split, preprocessing, trainer, evaluation gate, feature contract, promotion policy |
+| Release state | MLflow registered model versions and aliases | `candidate`, `prod`, `champion` pointers and model-version metadata |
+| Release evidence | MLflow artifacts under `reports/releases/...` | promotion decision, release manifest, rollback target, model card |
+| Serving contract | model spec feature contract plus serving API | request validation and routing behavior for `prod`, `candidate`, `canary`, `shadow` |
+
+## How it fits together
+
+1. The operator selects a runtime profile with `mlp --env <name>` or the Makefile wrappers.
+2. The runtime profile selects the default model name, model spec, tracking URIs, local artifact paths, and Compose file.
+3. The pipeline reads the model spec and produces a training run in MLflow plus local artifacts.
+4. Registration creates a candidate model version and copies minimum lineage tags from the source training run.
+5. Promotion evaluates policy from the model spec, mutates aliases in MLflow, and emits release evidence.
+6. Serving resolves `models:/<model_name>@prod` or `@candidate` from MLflow and validates requests against the active feature contract from the model spec.
+7. Rollback and reproduce reuse the same release metadata and evidence pattern.
+
+## Serving contract
+
+Current serving endpoints:
+
+- `GET /livez`
+- `GET /readyz`
+- `GET /health`
+- `GET /metrics`
+- `GET /metadata/model`
+- `GET /metadata/schema`
+- `POST /predict?mode=prod|candidate|canary|shadow`
+
+Routing behavior:
+
+- `prod`: always use `@prod`
+- `candidate`: always use `@candidate`
+- `canary`: deterministic bucket chooses primary alias and runs the other alias as shadow
+- `shadow`: serve `@prod` and run `@candidate` best effort
+
+## Release evidence
+
+Registry workflows emit the same evidence bundle shape:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+MLflow stores those artifacts under:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+The release manifest is the operator-facing release record. It captures source run ID, dataset fingerprint, config hash, git SHA, current prod version, previous prod version, and policy outcome.
+
+## What this doc does not cover
+
+- hosted runtime topologies
+- multi-environment deployment flows outside local Compose
+- workflow orchestration beyond the current Makefile and CLI path

--- a/docs/runbooks/local-bootstrap.md
+++ b/docs/runbooks/local-bootstrap.md
@@ -1,0 +1,100 @@
+# Local Bootstrap
+
+Use this runbook for a fresh clone and the local golden path.
+
+## Prerequisites
+
+- Python `>=3.11.7`
+- `uv`
+- Docker with Compose
+- a clean shell with Docker running
+
+## Install dependencies
+
+From the repo root:
+
+```bash
+uv sync --dev
+```
+
+Optional fast validation before starting infra:
+
+```bash
+make check
+```
+
+## Start local infrastructure
+
+```bash
+make up
+```
+
+Expected local endpoints:
+
+- MLflow UI: `http://localhost:5050`
+- MinIO Console: `http://localhost:9001`
+
+If startup fails:
+
+- run `make logs`
+- verify Docker is running
+- verify ports `5050`, `9000`, and `9001` are available
+
+## Run the default golden path
+
+Run these commands in order:
+
+```bash
+make run-pipeline
+make policy-check
+make promote
+make serve
+make smoke-test
+make reproduce ALIAS=prod MODEL_NAME=breast_cancer_clf
+```
+
+What each command does:
+
+- `make run-pipeline`: build images, run pipeline, register candidate
+- `make policy-check`: run promotion dry-run and fail fast if policy blocks
+- `make promote`: move candidate to `prod` and `champion`
+- `make serve`: start the serving API
+- `make smoke-test`: call the serving path against the promoted model
+- `make reproduce ...`: rebuild the promoted model from its source training run
+
+## Verify outputs
+
+After the golden path:
+
+- MLflow should contain a training run and a registered model version
+- the registered model should resolve `@prod`
+- serving should answer `GET /health`
+- `reproduce_report.json` should exist in the repo root unless you override `REPORT=...`
+- release evidence should exist in MLflow under `reports/releases/...`
+
+Quick checks:
+
+```bash
+curl -fsS http://localhost:8000/health
+curl -fsS http://localhost:8000/metadata/model
+```
+
+## Run the CSV-backed spec
+
+```bash
+MODEL_SPEC=configs/models/local_csv_binary_classifier.yaml make run-pipeline
+uv run mlp --env local registry promote --model-name local_csv_binary_clf
+MODEL_NAME=local_csv_binary_clf MLP_MODEL_SPEC_PATH=configs/models/local_csv_binary_classifier.yaml make serve
+MODEL_NAME=local_csv_binary_clf MLP_MODEL_SPEC_PATH=configs/models/local_csv_binary_classifier.yaml make smoke-test
+make reproduce ALIAS=prod MODEL_NAME=local_csv_binary_clf REPORT=reproduce_csv.json
+```
+
+Keep model name and model spec aligned when you override one of them.
+
+## Tear down
+
+```bash
+make down
+```
+
+This removes local Compose state and volumes.

--- a/docs/runbooks/promotion.md
+++ b/docs/runbooks/promotion.md
@@ -1,0 +1,75 @@
+# Promotion
+
+Use this runbook to move the current candidate to `prod`.
+
+## Preconditions
+
+- local infra is running when you use the Docker-backed Makefile path
+- a candidate model version exists for the target model
+- the candidate has the metadata required by the model spec policy
+
+## Dry-run the policy
+
+Default model from the active runtime profile:
+
+```bash
+make policy-check
+```
+
+Explicit model:
+
+```bash
+uv run mlp --env local registry promote --model-name breast_cancer_clf --dry-run --format json
+```
+
+Success means the command exits `0` and prints `allowed: true` in JSON output.
+
+## Apply promotion
+
+Default model:
+
+```bash
+make promote
+```
+
+Explicit model:
+
+```bash
+uv run mlp --env local registry promote --model-name breast_cancer_clf
+```
+
+## What promotion changes
+
+- moves `@prod` to the candidate version
+- moves `@champion` to the same version
+- sets `release_status=prod` on the promoted model version
+- records `promoted_from_alias=candidate`
+- records `previous_prod_version` when an older prod version existed
+- emits release evidence under `reports/releases/promote/<model_name>/v<version>/`
+
+## Evidence to inspect
+
+Promotion writes:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+The promoted model version also records the artifact paths in tags:
+
+- `release_reports_path`
+- `promotion_decision_path`
+- `release_manifest_path`
+- `rollback_target_path`
+- `model_card_path`
+
+## Common failure cases
+
+- no candidate alias exists
+- gate status is not `passed`
+- required metadata tags are missing
+- policy blocks noop promotion
+- a model-spec policy override requires extra reproducibility evidence or metrics
+
+If promotion fails, rerun the dry-run command with `--format json` and inspect the returned violations.

--- a/docs/runbooks/reproduce.md
+++ b/docs/runbooks/reproduce.md
@@ -1,0 +1,60 @@
+# Reproduce
+
+Use this runbook to rebuild a registered model from its source training run.
+
+## Select the target model version
+
+Pick exactly one selector:
+
+- `--alias <alias>`
+- `--model-version <version>`
+
+Examples:
+
+```bash
+make reproduce ALIAS=prod MODEL_NAME=breast_cancer_clf
+```
+
+```bash
+uv run mlp --env local registry reproduce --model-name breast_cancer_clf --model-version 1 --report-path reproduce_report.json --format json
+```
+
+## Outputs
+
+Reproduce writes two outputs:
+
+- a local JSON report at `--report-path`
+- a release evidence bundle in MLflow under `reports/releases/reproduce/<model_name>/v<version>/`
+
+The local report is the direct command result. The MLflow bundle keeps the same evidence shape used by promotion and rollback.
+
+## What reproduce verifies
+
+- the registered model version has `source_run_id`
+- the current checkout git SHA matches the source training run
+- the current `uv.lock` hash matches the source training run
+- the logged repro contract reproduces the config hash
+- downloaded training inputs reproduce the dataset fingerprint
+- probe predictions match the logged expected outputs
+
+## Common failure cases
+
+Current failure reasons include:
+
+- `missing_source_run_id`
+- `missing_repro_contract`
+- `git_sha_mismatch`
+- `env_lock_mismatch`
+- `config_hash_mismatch`
+- `dataset_fingerprint_mismatch`
+- `prediction_parity_failed`
+
+The command exits non-zero and writes a failed report when one of these checks fails.
+
+## Verify success
+
+After a successful run:
+
+- the local report has `status: matched`
+- `reports/releases/reproduce/.../release_manifest.json` exists in MLflow
+- the manifest records the same source run ID and model version you selected

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,48 @@
+# Rollback
+
+Use this runbook to move `@prod` back to the recorded previous prod version.
+
+## Preconditions
+
+- the target model has a current `@prod`
+- the current prod was previously promoted with rollback metadata recorded
+
+## Run rollback
+
+Default model:
+
+```bash
+make rollback-prod
+```
+
+Explicit model:
+
+```bash
+uv run mlp --env local registry rollback --model-name breast_cancer_clf
+```
+
+## How target resolution works
+
+Rollback resolves in this order:
+
+1. current prod model version tag `release_manifest_path`
+2. current prod version's `release_manifest.json`
+3. `previous_prod_version` tag fallback for older versions
+
+The manifest is the primary operator-facing rollback record.
+
+## What rollback changes
+
+- moves `@prod` to the recorded previous prod version
+- updates `previous_prod_version` on the rollback target to allow one-step undo
+- emits release evidence under `reports/releases/rollback/<model_name>/v<current_prod_version>/`
+
+## Verify rollback
+
+Verify after the command:
+
+- `@prod` points to the expected version in MLflow
+- `rollback_target.json` records the resolved target version
+- `release_manifest.json` records the before and after prod versions
+
+If rollback fails because no previous prod exists, inspect the current prod model version tags and confirm `release_manifest_path` or `previous_prod_version` is present.

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC_FILES = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "CONTRIBUTING.md",
+    *sorted((REPO_ROOT / "docs").rglob("*.md")),
+]
+LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+
+def _should_skip(target: str) -> bool:
+    return (
+        target.startswith("http://")
+        or target.startswith("https://")
+        or target.startswith("mailto:")
+        or target.startswith("#")
+    )
+
+
+def _normalize_target(raw: str) -> str:
+    target = raw.strip()
+    if " " in target and not target.startswith("<"):
+        target = target.split(" ", 1)[0]
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1]
+    return target.split("#", 1)[0]
+
+
+def main() -> int:
+    failures: list[str] = []
+    for doc_file in DOC_FILES:
+        content = doc_file.read_text(encoding="utf-8")
+        for match in LINK_RE.finditer(content):
+            raw_target = match.group(1).strip()
+            if _should_skip(raw_target):
+                continue
+            target = _normalize_target(raw_target)
+            if not target:
+                continue
+            resolved = (doc_file.parent / target).resolve()
+            if not resolved.exists():
+                failures.append(
+                    f"{doc_file.relative_to(REPO_ROOT)} -> missing path: {raw_target}"
+                )
+
+    if failures:
+        print("Docs link/path check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Docs link/path check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add the first platform handbook for the local M0 runtime.

## What changed

- add handbook index in `docs/README.md`
- add architecture docs for platform overview and local runtime shape
- add runbooks for:
  - local bootstrap
  - promotion
  - rollback
  - reproduce
- update ADR-0001 and ADR-0002 with implementation-specific M0 decisions
- update `README.md` and `CONTRIBUTING.md` to point to the handbook
- add `make docs-check` and a lightweight doc link/path checker

## Why

The repo had CI and release docs, but not enough platform documentation for a new engineer to run the local golden path and understand how runtime profiles, model specs, serving, and release evidence fit together.

This change keeps the docs concrete:
- no speculative hosted docs
- no large design essay
- no duplication of README detail into multiple places
- commands copied from the current Makefile and CLI surface

## Validation

- `make docs-check`
- `make check`
- verified documented CLI entrypoints with:
  - `uv run --project . mlp --env local infra --help`
  - `uv run --project . mlp --env local pipeline run --help`
  - `uv run --project . mlp --env local registry promote --help`
  - `uv run --project . mlp --env local registry rollback --help`
  - `uv run --project . mlp --env local registry reproduce --help`
  - `uv run --project . mlp --env local serve api --help`
  - `uv run --project . mlp --env local serve smoke --help`
  - `uv run --project . mlp --env local e2e --help`

## Notes

- this PR documents the current local M0 behavior only
- `make e2e` was not rerun in this doc-focused pass
- the handbook is intended to stay last after behavior-changing M0 work

closes #51 