### PR TITLE
feat: add GCP Terraform bootstrap root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,15 @@ artifacts/
 data/
 reproduce_report.json
 reproduce_*.json
+
+# Terraform local state
+.terraform/
+**/.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+deployments/gcp/terraform/terraform.tfvars

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ export GIT_SHA ?= $(shell git rev-parse HEAD 2>/dev/null || echo dev)
 UV_PROJECT_DIR := .
 DEPLOYMENTS_LOCAL_DIR ?= deployments/local
 COMPOSE_FILE ?= $(DEPLOYMENTS_LOCAL_DIR)/docker-compose.yml
+DEPLOYMENTS_GCP_TERRAFORM_DIR ?= deployments/gcp/terraform
 
 UV ?= uv
 DOCKER ?= docker
 COMPOSE ?= $(DOCKER) compose -f $(COMPOSE_FILE)
+TERRAFORM ?= terraform
 MLP_ENV_NAME ?= local
 MODEL ?=
 MODEL_SPEC ?=
@@ -27,6 +29,11 @@ RUFF := $(PY) -m ruff
 MYPY := $(PY) -m mypy
 PYTEST := $(PY) -m pytest
 PRECOMMIT := $(PY) -m pre_commit
+
+TF_STATE_BUCKET ?= fpl-tf-state-jelle
+TF_STATE_PREFIX ?= ml-lifecycle-platform/gcp/bootstrap
+export TF_VAR_project_id ?= fpl-project-jelle
+export TF_VAR_region ?= europe-west1
 
 MYPY_CONFIG ?= mypy.ini
 MYPY_PATHS ?= src tests
@@ -69,6 +76,11 @@ help:
 	@echo "  make test-e2e          run the golden path without automatic teardown"
 	@echo "  make e2e               pipeline -> gate -> promote -> serve -> smoke"
 	@echo "  make e2e-keep          like e2e, but keep stack up"
+	@echo ""
+	@echo "GCP Terraform:"
+	@echo "  make terraform-gcp-fmt       terraform fmt -check for deployments/gcp/terraform"
+	@echo "  make terraform-gcp-init      init remote state against $(TF_STATE_BUCKET)"
+	@echo "  make terraform-gcp-validate  validate the GCP Terraform root"
 	@echo ""
 	@echo "Housekeeping:"
 	@echo "  make clean             remove local caches"
@@ -211,6 +223,18 @@ e2e:
 e2e-keep:
 	@$(MLP) e2e --keep-stack
 	@echo "E2E passed (stack kept up). Use 'make logs' or 'make down' when done."
+
+.PHONY: terraform-gcp-fmt terraform-gcp-init terraform-gcp-validate
+terraform-gcp-fmt:
+	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) fmt -check -recursive
+
+terraform-gcp-init:
+	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) init \
+		-backend-config="bucket=$(TF_STATE_BUCKET)" \
+		-backend-config="prefix=$(TF_STATE_PREFIX)"
+
+terraform-gcp-validate:
+	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) validate
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An ML platform for training, evaluating, registering, promoting, serving, and re
 Operator and architecture docs live in the handbook:
 
 - [`docs/README.md`](docs/README.md)
+- [`docs/runbooks/gcp-bootstrap.md`](docs/runbooks/gcp-bootstrap.md)
 - [`docs/reference/technology-stack.md`](docs/reference/technology-stack.md)
 
 Starter files for OSS users:
@@ -134,6 +135,9 @@ Infra:
 - `make down`
 - `make logs`
 - `make build`
+- `make terraform-gcp-fmt`
+- `make terraform-gcp-init`
+- `make terraform-gcp-validate`
 
 Registry and serving:
 

--- a/deployments/gcp/terraform/.terraform.lock.hcl
+++ b/deployments/gcp/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.22.0"
+  constraints = "7.22.0"
+  hashes = [
+    "h1:B+5SNVoCQlMcaJvssp6LxcrxqewC1gYMgM8zTFqPuy0=",
+    "zh:167f86ebef8fe59a5c5e49d9627912f8f51ab474d3c677daba58b4d1a8b7e989",
+    "zh:314e1ab9ca6b0410660c651960243c7db26b60f00285bc5cda0c3dee63bf4ab8",
+    "zh:35768100a1f5ff315c3185f99f0aad4ce660018c5a018c722d84fa8e362b0542",
+    "zh:3fb613ab80c06b301aa7d626de56b88dc783da808a0b7a810c97762bf4da7491",
+    "zh:453f7ab7fe1315f0caac9cc00bb70220f7b31082d2ee03edb63a4883fd5512b6",
+    "zh:5e21fce93fd735f3eee9cf7b7bccf6829f117a9369714ea120280e98bf2a2628",
+    "zh:a883031feca659d62cf4a776f3a99c4b5e48d83704cb24128a0ca3a88c3cc74d",
+    "zh:b6d114fd146fedf5b5b455308c8fdef155b7ae090b57e9e1510fe7a50fa3fe2d",
+    "zh:f11baebd88b7c25dd2b88c82898be920d907ab1435a918f5cf8f8c70ecfb9533",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f62ab43c4d37e73818b9019b83fa9a8d6da12eb7e4570ca18b275ce871de74a3",
+    "zh:ff0415d8a2e95baa7dcc0cf21d386c9fdb35a641bc2e35cb9b240e1a42e919c4",
+  ]
+}

--- a/deployments/gcp/terraform/main.tf
+++ b/deployments/gcp/terraform/main.tf
@@ -1,0 +1,29 @@
+locals {
+  bootstrap_service = "serviceusage.googleapis.com"
+  required_services = setsubtract(toset(var.required_services), toset([local.bootstrap_service]))
+  managed_services  = setunion(toset([local.bootstrap_service]), local.required_services)
+}
+
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+resource "google_project_service" "serviceusage" {
+  project = data.google_project.current.project_id
+  service = local.bootstrap_service
+
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "required" {
+  for_each = local.required_services
+
+  project = data.google_project.current.project_id
+  service = each.value
+
+  disable_dependent_services = false
+  disable_on_destroy         = false
+
+  depends_on = [google_project_service.serviceusage]
+}

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "project_number" {
+  description = "Numeric project identifier for the adopted GCP project."
+  value       = data.google_project.current.number
+}
+
+output "project_id" {
+  description = "GCP project targeted by this Terraform root."
+  value       = data.google_project.current.project_id
+}
+
+output "required_services" {
+  description = "Services that this Terraform root keeps enabled."
+  value       = sort(tolist(local.managed_services))
+}

--- a/deployments/gcp/terraform/providers.tf
+++ b/deployments/gcp/terraform/providers.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project               = var.project_id
+  region                = var.region
+  user_project_override = true
+}

--- a/deployments/gcp/terraform/terraform.tfvars.example
+++ b/deployments/gcp/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+project_id = "fpl-project-jelle"
+region     = "europe-west1"
+
+required_services = [
+  "cloudresourcemanager.googleapis.com",
+  "iam.googleapis.com",
+]

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "project_id" {
+  description = "Existing GCP project ID to adopt as the bootstrap target."
+  type        = string
+  default     = "fpl-project-jelle"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID."
+  }
+}
+
+variable "region" {
+  description = "Default region for future regional GCP resources."
+  type        = string
+  default     = "europe-west1"
+
+  validation {
+    condition     = length(trimspace(var.region)) > 0
+    error_message = "region must not be empty."
+  }
+}
+
+variable "required_services" {
+  description = "Project services enabled and maintained by this bootstrap root."
+  type        = list(string)
+  default = [
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+  ]
+
+  validation {
+    condition     = length(var.required_services) == length(distinct(var.required_services))
+    error_message = "required_services must not contain duplicates."
+  }
+
+  validation {
+    condition     = !contains(var.required_services, "serviceusage.googleapis.com")
+    error_message = "required_services must not include serviceusage.googleapis.com; it is managed separately."
+  }
+}

--- a/deployments/gcp/terraform/versions.tf
+++ b/deployments/gcp/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = "~> 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "= 7.22.0"
+    }
+  }
+
+  backend "gcs" {}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Start here if you want to run or change the local platform.
 ## Runbooks
 
 - [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md): fresh-clone local setup and golden path
+- [`runbooks/gcp-bootstrap.md`](./runbooks/gcp-bootstrap.md): adopt the existing GCP project and Terraform backend
 - [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
 - [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
 - [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model

--- a/docs/reference/technology-stack.md
+++ b/docs/reference/technology-stack.md
@@ -227,6 +227,38 @@ Official docs:
 
 ## Local Infrastructure
 
+### Terraform
+
+What it is:
+- Infrastructure as code tool.
+
+Why we use it:
+- Hosted infrastructure should be explicit, reviewable, and reproducible.
+- Existing GCP bootstrap state should move out of shell history and into committed config.
+
+How it is used here:
+- Initializes remote state in the existing GCS backend bucket.
+- Enables and tracks required GCP project APIs for the hosted bootstrap root in `deployments/gcp/terraform/`.
+
+Official docs:
+- https://developer.hashicorp.com/terraform/docs
+
+### Google Cloud CLI
+
+What it is:
+- Command-line interface for Google Cloud.
+
+Why we use it:
+- Terraform uses ADC, so operators need a boring way to authenticate and verify project access.
+- It is the fastest way to inspect enabled APIs and confirm backend bucket access during bootstrap.
+
+How it is used here:
+- Establishes user auth and ADC for Terraform.
+- Verifies access to the adopted project and Terraform backend bucket.
+
+Official docs:
+- https://cloud.google.com/sdk/docs
+
 ### Docker
 
 What it is:

--- a/docs/runbooks/gcp-bootstrap.md
+++ b/docs/runbooks/gcp-bootstrap.md
@@ -1,0 +1,140 @@
+# GCP Bootstrap
+
+Last verified: 2026-03-09
+
+This runbook adopts the existing Google Cloud project and the existing Terraform state bucket as the M1 bootstrap foundation.
+
+Current adopted identifiers:
+
+- project ID: `fpl-project-jelle`
+- Terraform state bucket: `fpl-tf-state-jelle`
+- Terraform state prefix: `ml-lifecycle-platform/gcp/bootstrap`
+
+What this root does:
+
+- targets the existing GCP project
+- initializes remote Terraform state in the existing GCS bucket
+- enables the required project APIs from Terraform
+
+What this root does not do:
+
+- create or rename the project
+- create, rename, or manage the backend state bucket in the same state
+- deploy Cloud Run, load balancing, or runtime resources yet
+
+## Why the backend bucket is not a Terraform resource here
+
+The remote state bucket is intentionally external to this Terraform root.
+
+Managing the backend bucket from the same state that depends on that bucket creates a bootstrap loop and an easy foot-gun. The boring approach is to treat `fpl-tf-state-jelle` as pre-existing platform infrastructure and only consume it as the backend.
+
+## Prerequisites
+
+- Terraform `1.5.7`
+- Google Cloud SDK with both user auth and ADC configured
+- access to project `fpl-project-jelle`
+- access to bucket `gs://fpl-tf-state-jelle`
+
+Authenticate once on a new machine:
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project fpl-project-jelle
+gcloud auth application-default set-quota-project fpl-project-jelle
+```
+
+Quick access checks:
+
+```bash
+gcloud projects describe fpl-project-jelle
+gcloud storage buckets describe gs://fpl-tf-state-jelle
+```
+
+## Clean checkout flow
+
+From the repo root:
+
+```bash
+make terraform-gcp-fmt
+make terraform-gcp-init
+make terraform-gcp-validate
+terraform -chdir=deployments/gcp/terraform plan
+```
+
+That flow uses committed defaults:
+
+- `TF_STATE_BUCKET=fpl-tf-state-jelle`
+- `TF_STATE_PREFIX=ml-lifecycle-platform/gcp/bootstrap`
+- `TF_VAR_project_id=fpl-project-jelle`
+- `TF_VAR_region=europe-west1`
+
+Override them only when you intentionally need a different target:
+
+```bash
+TF_VAR_region=europe-west1 make terraform-gcp-init
+TF_VAR_region=europe-west1 terraform -chdir=deployments/gcp/terraform plan
+```
+
+## Optional local overrides
+
+If you do not want to use environment variables, create a local, untracked `deployments/gcp/terraform/terraform.tfvars` from the example:
+
+```bash
+cp deployments/gcp/terraform/terraform.tfvars.example deployments/gcp/terraform/terraform.tfvars
+```
+
+Then edit the file if you need a different region or service list.
+
+## API management model
+
+This root is intentionally narrow.
+
+Managed APIs today:
+
+- `serviceusage.googleapis.com`
+- `cloudresourcemanager.googleapis.com`
+- `iam.googleapis.com`
+
+These are the minimum boring APIs needed for project-level bootstrap and the next round of IAM work.
+
+We are not using the authoritative `google_project_services` resource yet because that would disable every API not listed here. That is a bad default while the project may still contain old manual experiments.
+
+## Pre-adoption cleanup
+
+If the project still contains old APIs or resources, inventory them before the first apply:
+
+```bash
+gcloud services list --enabled --project fpl-project-jelle
+```
+
+Delete stale resources manually before expanding this Terraform root. Do not try to make this first bootstrap root authoritative for the whole project on day one.
+
+## First apply
+
+After the plan looks correct:
+
+```bash
+terraform -chdir=deployments/gcp/terraform apply
+```
+
+Expected result:
+
+- Terraform state lives in `gs://fpl-tf-state-jelle/ml-lifecycle-platform/gcp/bootstrap`
+- Terraform tracks required API enablement for project `fpl-project-jelle`
+
+## Debugging
+
+Common checks:
+
+```bash
+terraform -chdir=deployments/gcp/terraform state pull
+terraform -chdir=deployments/gcp/terraform providers
+gcloud services list --enabled --project fpl-project-jelle
+```
+
+If `terraform init` fails on the backend:
+
+- confirm your ADC credentials are valid
+- confirm you can read `gs://fpl-tf-state-jelle`
+- confirm the bucket name is unchanged and globally unique


### PR DESCRIPTION
## Summary

Adopts the existing GCP project and existing GCS Terraform state bucket as the initial hosted bootstrap foundation.

This adds a simple Terraform root under `deployments/gcp/terraform/`, pins Terraform/provider versions, configures the remote GCS backend, and manages required GCP API enablement from code. It also documents the exact clean-checkout operator flow for initializing and validating the adopted project.

## What Changed

- added `deployments/gcp/terraform/`
- pinned Terraform and Google provider versions
- configured Terraform to use the existing GCS backend bucket
- defined project ID, region, and required services as committed Terraform inputs
- added Make targets for Terraform `fmt`, `init`, and `validate`
- added a GCP bootstrap runbook and linked it from the README/docs index
- added Terraform local state patterns to `.gitignore`

## Scope

This PR does:
- adopt existing project `fpl-project-jelle`
- adopt existing backend bucket `fpl-tf-state-jelle`
- manage required project APIs from Terraform
- document the operator bootstrap flow from a clean checkout

This PR does not:
- rename the project ID
- rename or create the backend state bucket
- add Cloud Run, LB, or other runtime resources
- add CI deploy logic

## Design Notes

- The backend bucket is intentionally treated as pre-existing infrastructure, not a resource in this same Terraform state.
- API management uses `google_project_service` resources, not an authoritative `google_project_services` set, to avoid disabling unknown existing APIs in a project that may still contain older manual setup.

## Validation

Ran successfully:
- `make terraform-gcp-fmt`
- `make terraform-gcp-init`
- `make terraform-gcp-validate`
- `terraform -chdir=deployments/gcp/terraform plan`
- `make docs-check`

Manual verification:
- backend init succeeded against `fpl-tf-state-jelle`
- Terraform plan resolved project `fpl-project-jelle`
- API enablement is driven by Terraform config

## Follow-ups
- expand the GCP root with IAM and hosted runtime resources in separate PRs
