### PR TITLE
feat: add GCP foundation resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ help:
 	@echo "GCP Terraform:"
 	@echo "  make terraform-gcp-fmt       terraform fmt -check for deployments/gcp/terraform"
 	@echo "  make terraform-gcp-init      init remote state against $(TF_STATE_BUCKET)"
+	@echo "  make terraform-gcp-plan      plan the GCP Terraform root"
 	@echo "  make terraform-gcp-validate  validate the GCP Terraform root"
 	@echo ""
 	@echo "Housekeeping:"
@@ -224,7 +225,7 @@ e2e-keep:
 	@$(MLP) e2e --keep-stack
 	@echo "E2E passed (stack kept up). Use 'make logs' or 'make down' when done."
 
-.PHONY: terraform-gcp-fmt terraform-gcp-init terraform-gcp-validate
+.PHONY: terraform-gcp-fmt terraform-gcp-init terraform-gcp-plan terraform-gcp-validate
 terraform-gcp-fmt:
 	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) fmt -check -recursive
 
@@ -232,6 +233,9 @@ terraform-gcp-init:
 	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) init \
 		-backend-config="bucket=$(TF_STATE_BUCKET)" \
 		-backend-config="prefix=$(TF_STATE_PREFIX)"
+
+terraform-gcp-plan:
+	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) plan
 
 terraform-gcp-validate:
 	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) validate

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Operator and architecture docs live in the handbook:
 
 - [`docs/README.md`](docs/README.md)
 - [`docs/runbooks/gcp-bootstrap.md`](docs/runbooks/gcp-bootstrap.md)
+- [`docs/runbooks/gcp-foundation.md`](docs/runbooks/gcp-foundation.md)
 - [`docs/reference/technology-stack.md`](docs/reference/technology-stack.md)
 
 Starter files for OSS users:
@@ -137,6 +138,7 @@ Infra:
 - `make build`
 - `make terraform-gcp-fmt`
 - `make terraform-gcp-init`
+- `make terraform-gcp-plan`
 - `make terraform-gcp-validate`
 
 Registry and serving:

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -1,0 +1,173 @@
+locals {
+  foundation_name_prefix = "mlp"
+  common_labels = {
+    managed_by = "terraform"
+    layer      = "foundation"
+    platform   = local.foundation_name_prefix
+  }
+
+  artifact_registry_repository_id = "${local.foundation_name_prefix}-images"
+  bucket_location                 = upper(var.region)
+  github_repository_full_name     = "${var.github_repository_owner}/${var.github_repository}"
+  workload_identity_pool_id       = "github-actions"
+  workload_identity_provider_id   = "github-oidc"
+
+  buckets = {
+    artifacts = {
+      name = "${var.project_id}-${local.foundation_name_prefix}-artifacts"
+    }
+    data = {
+      name = "${var.project_id}-${local.foundation_name_prefix}-data"
+    }
+  }
+
+  secret_ids = {
+    mlflow_tracking_uri      = "${local.foundation_name_prefix}-mlflow-tracking-uri"
+    mlflow_tracking_username = "${local.foundation_name_prefix}-mlflow-tracking-username"
+    mlflow_tracking_password = "${local.foundation_name_prefix}-mlflow-tracking-password"
+  }
+}
+
+resource "google_artifact_registry_repository" "images" {
+  project       = data.google_project.current.project_id
+  location      = var.region
+  repository_id = local.artifact_registry_repository_id
+  description   = "Docker images for ML lifecycle platform hosted workloads."
+  format        = "DOCKER"
+
+  labels = local.common_labels
+
+  depends_on = [google_project_service.required["artifactregistry.googleapis.com"]]
+}
+
+resource "google_storage_bucket" "foundation" {
+  for_each = local.buckets
+
+  project                     = data.google_project.current.project_id
+  name                        = each.value.name
+  location                    = local.bucket_location
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  force_destroy               = false
+
+  labels = merge(local.common_labels, { purpose = each.key })
+
+  depends_on = [google_project_service.required["storage.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret" "foundation" {
+  for_each = local.secret_ids
+
+  project   = data.google_project.current.project_id
+  secret_id = each.value
+
+  labels = merge(local.common_labels, { purpose = each.key })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
+}
+
+resource "google_service_account" "ci" {
+  project      = data.google_project.current.project_id
+  account_id   = "${local.foundation_name_prefix}-ci"
+  display_name = "ML lifecycle platform CI"
+  description  = "GitHub Actions identity for pushing images and later deploy automation."
+
+  depends_on = [google_project_service.required["iam.googleapis.com"]]
+}
+
+resource "google_service_account" "runtime" {
+  project      = data.google_project.current.project_id
+  account_id   = "${local.foundation_name_prefix}-runtime"
+  display_name = "ML lifecycle platform runtime"
+  description  = "Hosted workload identity for serving and job runtimes."
+
+  depends_on = [google_project_service.required["iam.googleapis.com"]]
+}
+
+resource "google_artifact_registry_repository_iam_member" "ci_writer" {
+  project    = google_artifact_registry_repository.images.project
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.ci.email}"
+}
+
+resource "google_storage_bucket_iam_member" "runtime_bucket_admin" {
+  for_each = google_storage_bucket.foundation
+
+  bucket = each.value.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_secret_accessor" {
+  for_each = google_secret_manager_secret.foundation
+
+  project   = each.value.project
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = data.google_project.current.project_id
+  workload_identity_pool_id = local.workload_identity_pool_id
+  display_name              = "GitHub Actions"
+  description               = "Federated identities for GitHub Actions workflows."
+
+  depends_on = [
+    google_project_service.required["iam.googleapis.com"],
+    google_project_service.required["iamcredentials.googleapis.com"],
+    google_project_service.required["sts.googleapis.com"],
+  ]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = data.google_project.current.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = local.workload_identity_provider_id
+  display_name                       = "GitHub OIDC"
+  description                        = "OIDC provider for GitHub Actions."
+
+  attribute_condition = join(" && ", [
+    "assertion.repository_owner_id == '${var.github_repository_owner_id}'",
+    "assertion.repository_id == '${var.github_repository_id}'",
+  ])
+
+  attribute_mapping = {
+    "google.subject"                = "assertion.sub"
+    "attribute.actor"               = "assertion.actor"
+    "attribute.aud"                 = "assertion.aud"
+    "attribute.ref"                 = "assertion.ref"
+    "attribute.ref_type"            = "assertion.ref_type"
+    "attribute.repository"          = "assertion.repository"
+    "attribute.repository_id"       = "assertion.repository_id"
+    "attribute.repository_owner"    = "assertion.repository_owner"
+    "attribute.repository_owner_id" = "assertion.repository_owner_id"
+  }
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  depends_on = [
+    google_project_service.required["iam.googleapis.com"],
+    google_project_service.required["iamcredentials.googleapis.com"],
+    google_project_service.required["sts.googleapis.com"],
+  ]
+}
+
+resource "google_service_account_iam_member" "ci_workload_identity_user" {
+  service_account_id = google_service_account.ci.name
+  role               = "roles/iam.workloadIdentityUser"
+  member = format(
+    "principalSet://iam.googleapis.com/%s/attribute.repository_id/%s",
+    google_iam_workload_identity_pool.github.name,
+    var.github_repository_id,
+  )
+}

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -12,3 +12,77 @@ output "required_services" {
   description = "Services that this Terraform root keeps enabled."
   value       = sort(tolist(local.managed_services))
 }
+
+output "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for platform images."
+  value       = google_artifact_registry_repository.images.repository_id
+}
+
+output "artifact_registry_repository_name" {
+  description = "Fully qualified Artifact Registry repository resource name."
+  value       = google_artifact_registry_repository.images.id
+}
+
+output "artifact_registry_docker_repository" {
+  description = "Docker push target prefix for platform images."
+  value = format(
+    "%s-docker.pkg.dev/%s/%s",
+    google_artifact_registry_repository.images.location,
+    data.google_project.current.project_id,
+    google_artifact_registry_repository.images.repository_id,
+  )
+}
+
+output "foundation_bucket_names" {
+  description = "Named GCS buckets for hosted artifacts and data."
+  value = {
+    for key, bucket in google_storage_bucket.foundation : key => bucket.name
+  }
+}
+
+output "foundation_bucket_urls" {
+  description = "Named GCS bucket URLs for hosted artifacts and data."
+  value = {
+    for key, bucket in google_storage_bucket.foundation : key => bucket.url
+  }
+}
+
+output "foundation_secret_ids" {
+  description = "Secret Manager secret IDs reserved for hosted runtime configuration."
+  value = {
+    for key, secret in google_secret_manager_secret.foundation : key => secret.secret_id
+  }
+}
+
+output "foundation_service_accounts" {
+  description = "Service account emails for CI and hosted runtime identities."
+  value = {
+    ci      = google_service_account.ci.email
+    runtime = google_service_account.runtime.email
+  }
+}
+
+output "ci_service_account_email" {
+  description = "CI service account email for GitHub Actions federation."
+  value       = google_service_account.ci.email
+}
+
+output "runtime_service_account_email" {
+  description = "Runtime service account email for hosted workloads."
+  value       = google_service_account.runtime.email
+}
+
+output "github_repository_binding" {
+  description = "GitHub repository allowed to federate into the CI service account."
+  value       = local.github_repository_full_name
+}
+
+output "workload_identity_pool_name" {
+  description = "Full workload identity pool resource name."
+  value       = google_iam_workload_identity_pool.github.name
+}
+
+output "workload_identity_provider_name" {
+  description = "Full workload identity provider name for GitHub Actions auth."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}

--- a/deployments/gcp/terraform/terraform.tfvars.example
+++ b/deployments/gcp/terraform/terraform.tfvars.example
@@ -2,6 +2,16 @@ project_id = "fpl-project-jelle"
 region     = "europe-west1"
 
 required_services = [
+  "artifactregistry.googleapis.com",
   "cloudresourcemanager.googleapis.com",
   "iam.googleapis.com",
+  "iamcredentials.googleapis.com",
+  "secretmanager.googleapis.com",
+  "storage.googleapis.com",
+  "sts.googleapis.com",
 ]
+
+github_repository_owner    = "jellewillekes"
+github_repository          = "ml-lifecycle-platform"
+github_repository_owner_id = "94389770"
+github_repository_id       = "1141930340"

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -24,8 +24,13 @@ variable "required_services" {
   description = "Project services enabled and maintained by this bootstrap root."
   type        = list(string)
   default = [
+    "artifactregistry.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "secretmanager.googleapis.com",
+    "storage.googleapis.com",
+    "sts.googleapis.com",
   ]
 
   validation {
@@ -36,5 +41,49 @@ variable "required_services" {
   validation {
     condition     = !contains(var.required_services, "serviceusage.googleapis.com")
     error_message = "required_services must not include serviceusage.googleapis.com; it is managed separately."
+  }
+}
+
+variable "github_repository_owner" {
+  description = "GitHub repository owner allowed to federate into the CI service account."
+  type        = string
+  default     = "jellewillekes"
+
+  validation {
+    condition     = length(trimspace(var.github_repository_owner)) > 0
+    error_message = "github_repository_owner must not be empty."
+  }
+}
+
+variable "github_repository" {
+  description = "GitHub repository name allowed to federate into the CI service account."
+  type        = string
+  default     = "ml-lifecycle-platform"
+
+  validation {
+    condition     = length(trimspace(var.github_repository)) > 0
+    error_message = "github_repository must not be empty."
+  }
+}
+
+variable "github_repository_owner_id" {
+  description = "Stable GitHub owner ID used in the WIF provider condition."
+  type        = string
+  default     = "94389770"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.github_repository_owner_id))
+    error_message = "github_repository_owner_id must contain only digits."
+  }
+}
+
+variable "github_repository_id" {
+  description = "Stable GitHub repository ID used in the WIF provider condition."
+  type        = string
+  default     = "1141930340"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.github_repository_id))
+    error_message = "github_repository_id must contain only digits."
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start here if you want to run or change the local platform.
 
 - [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md): fresh-clone local setup and golden path
 - [`runbooks/gcp-bootstrap.md`](./runbooks/gcp-bootstrap.md): adopt the existing GCP project and Terraform backend
+- [`runbooks/gcp-foundation.md`](./runbooks/gcp-foundation.md): create the first hosted GCP foundation resources
 - [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
 - [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
 - [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model

--- a/docs/runbooks/gcp-foundation.md
+++ b/docs/runbooks/gcp-foundation.md
@@ -1,0 +1,148 @@
+# GCP Foundation
+
+Last verified: 2026-03-09
+
+This runbook creates the first hosted GCP foundation layer on top of the adopted project and Terraform backend from [`gcp-bootstrap.md`](./gcp-bootstrap.md).
+
+Current scope:
+
+- Artifact Registry repository for platform images
+- GCS buckets for hosted artifacts and data
+- Secret Manager placeholders for hosted MLflow connectivity
+- service accounts for CI and runtime workloads
+- GitHub Actions workload identity federation for the repo CI path
+- base IAM bindings for image push, bucket access, and secret access
+
+Out of scope here:
+
+- Cloud Run services or jobs
+- ingress or load balancing
+- hosted MLflow
+- alerting, schedulers, or dashboards
+
+## Naming conventions
+
+Foundation resources use the `mlp` prefix.
+
+Resources created by this root:
+
+- Artifact Registry repository: `mlp-images`
+- buckets:
+  - `${project_id}-mlp-artifacts`
+  - `${project_id}-mlp-data`
+- service accounts:
+  - `mlp-ci@<project>.iam.gserviceaccount.com`
+  - `mlp-runtime@<project>.iam.gserviceaccount.com`
+- Secret Manager placeholders:
+  - `mlp-mlflow-tracking-uri`
+  - `mlp-mlflow-tracking-username`
+  - `mlp-mlflow-tracking-password`
+- workload identity:
+  - pool: `github-actions`
+  - provider: `github-oidc`
+
+## Managed APIs
+
+This ticket extends the bootstrap API set with the hosted-foundation minimum:
+
+- `artifactregistry.googleapis.com`
+- `iamcredentials.googleapis.com`
+- `secretmanager.googleapis.com`
+- `storage.googleapis.com`
+- `sts.googleapis.com`
+
+The bootstrap APIs remain managed too:
+
+- `serviceusage.googleapis.com`
+- `cloudresourcemanager.googleapis.com`
+- `iam.googleapis.com`
+
+## GitHub Actions federation model
+
+CI authentication uses GitHub OIDC through Workload Identity Federation.
+
+This root creates:
+
+- one workload identity pool and provider
+- one CI service account
+- one `roles/iam.workloadIdentityUser` binding from the GitHub repo principal set to that CI service account
+
+The provider condition restricts trust to the current repository by numeric GitHub owner and repository IDs, not just names. That avoids name-reuse issues if the repo or owner name ever changes hands.
+
+Current bound repository:
+
+- `jellewillekes/ml-lifecycle-platform`
+
+## Runtime IAM model
+
+The runtime service account gets only the base permissions needed for later hosted workloads to read secrets and write objects:
+
+- `roles/storage.objectAdmin` on the hosted artifacts and data buckets
+- `roles/secretmanager.secretAccessor` on the hosted MLflow secrets
+
+The CI service account gets:
+
+- `roles/artifactregistry.writer` on the image repository
+
+Nothing in this root grants deploy-time permissions for Cloud Run or broader project admin actions yet.
+
+## Operator flow
+
+From the repo root:
+
+```bash
+make terraform-gcp-fmt
+make terraform-gcp-init
+make terraform-gcp-validate
+make terraform-gcp-plan
+```
+
+Apply when the plan looks correct:
+
+```bash
+terraform -chdir=deployments/gcp/terraform apply
+```
+
+## Outputs for later tickets
+
+After apply, inspect the outputs:
+
+```bash
+terraform -chdir=deployments/gcp/terraform output
+```
+
+Most important outputs for CI and deploy follow-up work:
+
+- `artifact_registry_docker_repository`
+- `foundation_service_accounts`
+- `foundation_bucket_names`
+- `foundation_secret_ids`
+- `workload_identity_provider_name`
+
+Those outputs are enough for:
+
+- GitHub Actions auth through `google-github-actions/auth`
+- pushing Docker images into Artifact Registry
+- wiring later runtime configs to the reserved bucket and secret names
+
+## Manual verification
+
+Check the concrete resources after apply:
+
+```bash
+gcloud artifacts repositories list --location=europe-west1 --project fpl-project-jelle
+gcloud storage buckets list --project fpl-project-jelle
+gcloud secrets list --project fpl-project-jelle
+gcloud iam service-accounts list --project fpl-project-jelle
+gcloud iam workload-identity-pools list --location=global --project fpl-project-jelle
+terraform -chdir=deployments/gcp/terraform output
+```
+
+## Debugging
+
+If Workload Identity Federation fails later in CI:
+
+- wait a few minutes after first apply because pool/provider IAM propagation is not instant
+- confirm the GitHub repository owner ID and repository ID still match reality
+- confirm the workflow uses the full `workload_identity_provider_name` output
+- confirm the workflow impersonates the CI service account email from `foundation_service_accounts`


### PR DESCRIPTION
## Summary

Adds the first hosted GCP foundation layer on top of the adopted project and remote Terraform state.

This provisions the minimum cloud resources needed before CI image publishing and later deploy work:
- Artifact Registry for platform images
- GCS buckets for hosted artifacts and data
- Secret Manager placeholders for hosted runtime configuration
- CI and runtime service accounts
- base IAM bindings
- GitHub Actions Workload Identity Federation for CI auth

## What Changed

- added hosted foundation resources in `deployments/gcp/terraform/`
- added outputs for CI auth, image push, buckets, secrets, and service accounts
- added a `make terraform-gcp-plan` helper target
- documented the resource layout, naming conventions, and operator flow in `docs/runbooks/gcp-foundation.md`

## Scope

This PR does:
- create Artifact Registry, buckets, secrets, service accounts, IAM, and WIF resources
- keep naming conventions explicit and documented
- expose Terraform outputs for later CI and deploy tickets

This PR does not:
- deploy Cloud Run services or jobs
- add ingress or load balancing
- deploy hosted MLflow
- add scheduler, dashboards, or alerts

## Validation

Ran successfully:
- `make terraform-gcp-fmt`
- `make terraform-gcp-init`
- `make terraform-gcp-validate`
- `make terraform-gcp-plan`
- `make docs-check`

Manual verification:
- applied successfully in `fpl-project-jelle`
- verified Artifact Registry, buckets, secrets, service accounts, and workload identity resources in GCP
- final `terraform plan` returns no changes

Closes #81 