### PR TITLE
ci: grant OIDC permission to image publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,4 +261,7 @@ jobs:
     name: Publish Images
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: integration
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-images.yml


### PR DESCRIPTION
Fix the `CI` reusable workflow call for image publishing.

The `publish-images` reusable workflow needs `id-token: write` for GCP Workload Identity Federation, but the caller job in `ci.yml` did not grant it. GitHub rejected the workflow before execution.

## Change

- add `permissions.id-token: write` to the `publish-images` job in `.github/workflows/ci.yml`

## Why

Reusable workflows cannot elevate permissions beyond what the caller allows. The caller must explicitly grant OIDC token access when the called workflow uses GCP auth.

## Validation

- validated workflow YAML locally
- this should unblock `CI` on `master`
