### PR TITLE
feat: provision Cloud SQL and MLflow staging storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@
 [![E2E](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml/badge.svg)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
 [![Coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)
 
-An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. The current implementation is local-first with a GCP hosted foundation and CI-produced runtime images ready for staged rollout.
+An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. The current implementation is local-first with Terraform-managed GCP foundation and staging infra plus CI-produced runtime images ready for hosted rollout.
 
 Operator and architecture docs live in the handbook:
 
 - [`docs/README.md`](docs/README.md)
+- [`docs/architecture/overview.md`](docs/architecture/overview.md)
 - [`docs/runbooks/gcp-bootstrap.md`](docs/runbooks/gcp-bootstrap.md)
 - [`docs/runbooks/gcp-foundation.md`](docs/runbooks/gcp-foundation.md)
+- [`docs/runbooks/gcp-staging-infra.md`](docs/runbooks/gcp-staging-infra.md)
 - [`docs/architecture/m2-staging-platform.md`](docs/architecture/m2-staging-platform.md)
+- [`docs/reference/configuration.md`](docs/reference/configuration.md)
+- [`docs/reference/gcp-resources.md`](docs/reference/gcp-resources.md)
+- [`docs/reference/release-contract.md`](docs/reference/release-contract.md)
 - [`docs/reference/technology-stack.md`](docs/reference/technology-stack.md)
 
 Starter files for OSS users:

--- a/deployments/gcp/terraform/.terraform.lock.hcl
+++ b/deployments/gcp/terraform/.terraform.lock.hcl
@@ -20,3 +20,23 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:ff0415d8a2e95baa7dcc0cf21d386c9fdb35a641bc2e35cb9b240e1a42e919c4",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/deployments/gcp/terraform/network.tf
+++ b/deployments/gcp/terraform/network.tf
@@ -1,0 +1,49 @@
+locals {
+  staging_network_name                     = "${local.foundation_name_prefix}-staging-vpc"
+  staging_subnetwork_name                  = "${local.foundation_name_prefix}-staging-subnet"
+  staging_subnetwork_cidr                  = "10.42.0.0/24"
+  staging_private_service_range_name       = "${local.foundation_name_prefix}-staging-private-services"
+  staging_private_service_range_prefix_len = 16
+}
+
+resource "google_compute_network" "staging" {
+  project                 = data.google_project.current.project_id
+  name                    = local.staging_network_name
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_compute_subnetwork" "staging" {
+  project                  = data.google_project.current.project_id
+  name                     = local.staging_subnetwork_name
+  region                   = var.region
+  network                  = google_compute_network.staging.id
+  ip_cidr_range            = local.staging_subnetwork_cidr
+  private_ip_google_access = true
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_compute_global_address" "staging_private_services" {
+  project       = data.google_project.current.project_id
+  name          = local.staging_private_service_range_name
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = local.staging_private_service_range_prefix_len
+  network       = google_compute_network.staging.id
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_service_networking_connection" "staging_private_services" {
+  network                 = google_compute_network.staging.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.staging_private_services.name]
+
+  depends_on = [
+    google_project_service.required["servicenetworking.googleapis.com"],
+    google_compute_global_address.staging_private_services,
+  ]
+}

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -86,3 +86,35 @@ output "workload_identity_provider_name" {
   description = "Full workload identity provider name for GitHub Actions auth."
   value       = google_iam_workload_identity_pool_provider.github.name
 }
+
+output "staging_network" {
+  description = "Shared staging VPC and subnet used by later hosted workloads."
+  value = {
+    network_name    = google_compute_network.staging.name
+    network_id      = google_compute_network.staging.id
+    subnetwork_name = google_compute_subnetwork.staging.name
+    subnetwork_id   = google_compute_subnetwork.staging.id
+    subnetwork_cidr = google_compute_subnetwork.staging.ip_cidr_range
+    peering_range   = google_compute_global_address.staging_private_services.name
+    peering_cidr    = google_compute_global_address.staging_private_services.address
+  }
+}
+
+output "mlflow_sql" {
+  description = "Hosted staging SQL contract for MLflow."
+  value = {
+    instance_name   = google_sql_database_instance.mlflow.name
+    connection_name = google_sql_database_instance.mlflow.connection_name
+    private_ip      = google_sql_database_instance.mlflow.private_ip_address
+    database_name   = google_sql_database.mlflow.name
+    database_user   = google_sql_user.mlflow.name
+    artifact_root   = local.mlflow_artifact_root
+  }
+}
+
+output "mlflow_secret_ids" {
+  description = "Secret Manager IDs for hosted staging MLflow runtime configuration."
+  value = {
+    for key, secret in google_secret_manager_secret.mlflow : key => secret.secret_id
+  }
+}

--- a/deployments/gcp/terraform/secrets_mlflow.tf
+++ b/deployments/gcp/terraform/secrets_mlflow.tf
@@ -1,0 +1,48 @@
+locals {
+  mlflow_secret_ids = {
+    db_user                  = "${local.foundation_name_prefix}-mlflow-db-user"
+    db_password              = "${local.foundation_name_prefix}-mlflow-db-password"
+    db_name                  = "${local.foundation_name_prefix}-mlflow-db-name"
+    instance_connection_name = "${local.foundation_name_prefix}-mlflow-instance-connection-name"
+    artifact_root            = "${local.foundation_name_prefix}-mlflow-artifact-root"
+  }
+
+  mlflow_secret_values = {
+    db_user                  = google_sql_user.mlflow.name
+    db_password              = random_password.mlflow_db_password.result
+    db_name                  = google_sql_database.mlflow.name
+    instance_connection_name = google_sql_database_instance.mlflow.connection_name
+    artifact_root            = local.mlflow_artifact_root
+  }
+}
+
+resource "google_secret_manager_secret" "mlflow" {
+  for_each = local.mlflow_secret_ids
+
+  project   = data.google_project.current.project_id
+  secret_id = each.value
+
+  labels = merge(local.common_labels, { purpose = "mlflow_${each.key}" })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "mlflow" {
+  for_each = local.mlflow_secret_values
+
+  secret      = google_secret_manager_secret.mlflow[each.key].id
+  secret_data = each.value
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_mlflow_secret_accessor" {
+  for_each = google_secret_manager_secret.mlflow
+
+  project   = each.value.project
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/deployments/gcp/terraform/sql.tf
+++ b/deployments/gcp/terraform/sql.tf
@@ -1,0 +1,70 @@
+locals {
+  mlflow_sql_instance_name = "${local.foundation_name_prefix}-mlflow-staging"
+  mlflow_database_name     = "mlflow"
+  mlflow_database_user     = "mlflow"
+  mlflow_sql_tier          = "db-custom-1-3840"
+  mlflow_artifact_root = format(
+    "%s/mlflow/",
+    google_storage_bucket.foundation["artifacts"].url,
+  )
+}
+
+resource "random_password" "mlflow_db_password" {
+  length           = 32
+  special          = false
+  min_lower        = 1
+  min_numeric      = 1
+  min_upper        = 1
+  override_special = ""
+}
+
+resource "google_sql_database_instance" "mlflow" {
+  project             = data.google_project.current.project_id
+  name                = local.mlflow_sql_instance_name
+  region              = var.region
+  database_version    = "POSTGRES_16"
+  deletion_protection = true
+
+  settings {
+    edition           = "ENTERPRISE"
+    tier              = local.mlflow_sql_tier
+    availability_type = "ZONAL"
+    disk_autoresize   = true
+    disk_size         = 20
+    disk_type         = "PD_SSD"
+
+    backup_configuration {
+      enabled = true
+    }
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.staging.id
+      enable_private_path_for_google_cloud_services = true
+    }
+  }
+
+  depends_on = [
+    google_project_service.required["sqladmin.googleapis.com"],
+    google_service_networking_connection.staging_private_services,
+  ]
+}
+
+resource "google_sql_database" "mlflow" {
+  project  = data.google_project.current.project_id
+  name     = local.mlflow_database_name
+  instance = google_sql_database_instance.mlflow.name
+}
+
+resource "google_sql_user" "mlflow" {
+  project  = data.google_project.current.project_id
+  name     = local.mlflow_database_user
+  instance = google_sql_database_instance.mlflow.name
+  password = random_password.mlflow_db_password.result
+}
+
+resource "google_project_iam_member" "runtime_cloudsql_client" {
+  project = data.google_project.current.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/deployments/gcp/terraform/terraform.tfvars.example
+++ b/deployments/gcp/terraform/terraform.tfvars.example
@@ -4,9 +4,12 @@ region     = "europe-west1"
 required_services = [
   "artifactregistry.googleapis.com",
   "cloudresourcemanager.googleapis.com",
+  "compute.googleapis.com",
   "iam.googleapis.com",
   "iamcredentials.googleapis.com",
   "secretmanager.googleapis.com",
+  "servicenetworking.googleapis.com",
+  "sqladmin.googleapis.com",
   "storage.googleapis.com",
   "sts.googleapis.com",
 ]

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -26,9 +26,12 @@ variable "required_services" {
   default = [
     "artifactregistry.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "sqladmin.googleapis.com",
     "storage.googleapis.com",
     "sts.googleapis.com",
   ]

--- a/deployments/gcp/terraform/versions.tf
+++ b/deployments/gcp/terraform/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = "= 7.22.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "= 3.7.2"
+    }
   }
 
   backend "gcs" {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Start here if you want to run or change the local platform.
 
 ## Architecture
 
-- [`architecture/overview.md`](./architecture/overview.md): platform shape, control plane, lifecycle
+- [`architecture/overview.md`](./architecture/overview.md): current local and hosted topology, boundaries, and lifecycle
 - [`architecture/local-runtime.md`](./architecture/local-runtime.md): runtime profiles, model specs, serving contract, local paths
 - [`architecture/current-state.md`](./architecture/current-state.md): current M0 scope and non-goals
 - [`architecture/m2-staging-platform.md`](./architecture/m2-staging-platform.md): fixed decisions and execution order for the first hosted GCP staging platform
@@ -21,6 +21,7 @@ Start here if you want to run or change the local platform.
 - [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md): fresh-clone local setup and golden path
 - [`runbooks/gcp-bootstrap.md`](./runbooks/gcp-bootstrap.md): adopt the existing GCP project and Terraform backend
 - [`runbooks/gcp-foundation.md`](./runbooks/gcp-foundation.md): create the first hosted GCP foundation resources
+- [`runbooks/gcp-staging-infra.md`](./runbooks/gcp-staging-infra.md): provision the stateful staging infra for hosted MLflow
 - [`runbooks/gcp-ci-auth.md`](./runbooks/gcp-ci-auth.md): verify GitHub Actions OIDC auth into GCP
 - [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
 - [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
@@ -31,5 +32,8 @@ Start here if you want to run or change the local platform.
 - [`ci.md`](./ci.md): CI lanes and local mapping
 - [`releases.md`](./releases.md): package releases and model release evidence
 - [`reference/technology-stack.md`](./reference/technology-stack.md): primary tools, why they are used, and where they fit
+- [`reference/configuration.md`](./reference/configuration.md): runtime profiles, env vars, serving settings, and hosted staging secrets
+- [`reference/release-contract.md`](./reference/release-contract.md): package, image, and model release identities
+- [`reference/gcp-resources.md`](./reference/gcp-resources.md): current Terraform-managed GCP resource inventory and outputs
 - [`adrs/ADR-0001-portability-surface.md`](./adrs/ADR-0001-portability-surface.md): M0 portability boundary
 - [`adrs/ADR-0002-mlflow-control-plane.md`](./adrs/ADR-0002-mlflow-control-plane.md): MLflow as M0 control plane

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -6,6 +6,7 @@ Last verified: 2026-03-10
 
 This repo is a local-first ML platform with MLflow as the tracking, registry, and release-control system.
 The local runtime is still the main operator path, but the first hosted GCP foundation layer and hosted image publication lane now exist.
+The Terraform root also defines the stateful staging prerequisites for hosted MLflow: private network wiring, Cloud SQL, and staging secret contracts.
 
 Current lifecycle:
 
@@ -53,6 +54,11 @@ models:/<model_name>@prod
   - placeholder secrets
   - runtime and CI service accounts
   - GitHub OIDC federation
+- Terraform-managed staging infra for:
+  - staging VPC and subnet
+  - private service access
+  - Cloud SQL Postgres for hosted MLflow metadata
+  - MLflow staging secrets and outputs for later deploy workflows
 - CI workflows for:
   - GCP auth verification
   - hosted image publication with immutable SHA tags and digest capture

--- a/docs/architecture/m2-staging-platform.md
+++ b/docs/architecture/m2-staging-platform.md
@@ -45,6 +45,8 @@ The intended order is:
 
 Do not skip ahead. Each step depends on the previous one being operationally boring first.
 
+The concrete `UP-16` infra contract is documented in [`../runbooks/gcp-staging-infra.md`](../runbooks/gcp-staging-infra.md).
+
 ## Deploy contracts
 
 Hosted deploys should consume image digests from the publish workflow artifact contract in [`../ci.md`](../ci.md).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,41 +1,70 @@
 # Overview
 
-This repo is a local-first ML platform for one main path:
+This repo currently has one real platform path and one hosted path under construction:
 
 ```text
-ingest -> featurize -> train -> evaluate -> register -> promote -> serve
+local path:
+  ingest -> featurize -> train -> evaluate -> register -> promote -> serve
+
+hosted path today:
+  GitHub Actions -> Artifact Registry
+  Terraform -> GCP foundation + staging infra
 ```
 
-It is intentionally narrow in `M0`:
+The local path is fully operational. The hosted path is only partially operational:
 
-- MLflow is the experiment tracker, model registry, and release-control system.
-- Docker Compose is the local operator path.
-- Runtime profiles select environment-specific endpoints and local paths.
-- Model specs define the data source, trainer, evaluation gate, feature contract, and promotion policy for one model.
+- CI can authenticate to GCP with WIF.
+- CI can publish immutable runtime images to Artifact Registry.
+- Terraform has created the shared staging network, Cloud SQL, and MLflow staging secrets.
+- Hosted MLflow and hosted serving are not deployed yet.
 
-## Main pieces
+## Current topology
 
-| Area | Source of truth | Purpose |
+```text
+developer shell
+  -> mlp CLI / Makefile
+  -> runtime profile + model spec
+  -> Docker Compose
+     -> PostgreSQL
+     -> MinIO
+     -> MLflow server
+     -> pipeline / promote / rollback / serving containers
+
+GitHub Actions
+  -> OIDC + Workload Identity Federation
+  -> Artifact Registry image publish
+
+GCP staging infra
+  -> Artifact Registry (runtime images)
+  -> GCS buckets (artifacts, data)
+  -> Secret Manager
+  -> Cloud SQL Postgres
+  -> staging VPC + subnet + private service access
+```
+
+## Boundaries that matter
+
+| Boundary | Source of truth | Why it exists |
 | --- | --- | --- |
-| Runtime wiring | `configs/env/<env>.yaml` | tracking URIs, model name, model spec path, local artifact paths, Compose settings |
-| Model behavior | `configs/models/*.yaml` | data source, split, preprocessing, trainer, evaluation gate, feature contract, promotion policy |
-| Release state | MLflow registered model versions and aliases | `candidate`, `prod`, `champion` pointers and model-version metadata |
-| Release evidence | MLflow artifacts under `reports/releases/...` | promotion decision, release manifest, rollback target, model card |
-| Serving contract | model spec feature contract plus serving API | request validation and routing behavior for `prod`, `candidate`, `canary`, `shadow` |
+| Runtime wiring | `configs/env/<env>.yaml` plus env overrides | chooses endpoints, paths, compose wiring, model name, and model spec |
+| Model behavior | `configs/models/*.yaml` | chooses data source, trainer, evaluation gate, and serving feature contract |
+| Registry and release state | MLflow model versions and aliases | tracks `candidate`, `prod`, `champion` and release metadata |
+| Hosted infra | `deployments/gcp/terraform/` | keeps resource names, IAM, network, SQL, and secret contracts committed |
+| Hosted runtime images | `Publish Images` workflow artifact and digests | gives deploy workflows immutable container identity |
 
-## How it fits together
+## End-to-end flow
 
 1. The operator selects a runtime profile with `mlp --env <name>` or the Makefile wrappers.
-2. The runtime profile selects the default model name, model spec, tracking URIs, local artifact paths, and Compose file.
-3. The pipeline reads the model spec and produces a training run in MLflow plus local artifacts.
-4. Registration creates a candidate model version and copies minimum lineage tags from the source training run.
-5. Promotion evaluates policy from the model spec, mutates aliases in MLflow, and emits release evidence.
+2. The runtime profile selects MLflow endpoints, model name, model spec, local paths, and Compose settings.
+3. The pipeline reads the model spec and produces a training run plus reproducibility artifacts.
+4. Registration creates a candidate model version and copies minimum lineage tags from the source run.
+5. Promotion evaluates policy from the model spec, mutates MLflow aliases, and writes release evidence.
 6. Serving resolves `models:/<model_name>@prod` or `@candidate` from MLflow and validates requests against the active feature contract from the model spec.
-7. Rollback and reproduce reuse the same release metadata and evidence pattern.
+7. Hosted rollout, once `M2` is finished, will deploy the `serving` and `platform` images by digest while still using MLflow aliases for model selection.
 
 ## Serving contract
 
-Current serving endpoints:
+Current endpoints:
 
 - `GET /livez`
 - `GET /readyz`
@@ -49,12 +78,12 @@ Routing behavior:
 
 - `prod`: always use `@prod`
 - `candidate`: always use `@candidate`
-- `canary`: deterministic bucket chooses primary alias and runs the other alias as shadow
-- `shadow`: serve `@prod` and run `@candidate` best effort
+- `canary`: deterministic bucket chooses the primary alias and runs the other alias as shadow
+- `shadow`: return `@prod` and run `@candidate` best effort
 
 ## Release evidence
 
-Registry workflows emit the same evidence bundle shape:
+Registry workflows emit one shared evidence bundle:
 
 - `promotion_decision.json`
 - `release_manifest.json`
@@ -67,8 +96,10 @@ MLflow stores those artifacts under:
 
 The release manifest is the operator-facing release record. It captures source run ID, dataset fingerprint, config hash, git SHA, current prod version, previous prod version, and policy outcome.
 
-## What this doc does not cover
+## What is intentionally not true yet
 
-- hosted runtime topologies
-- multi-environment deployment flows outside local Compose
-- workflow orchestration beyond the current Makefile and CLI path
+- no hosted MLflow service
+- no hosted serving service
+- no Cloud Run jobs
+- no ALB or custom domain
+- no scheduler-driven orchestration

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,151 @@
+# Configuration
+
+This page is the current config contract for the repo.
+
+It covers what exists today:
+
+- local runtime profiles
+- env var overrides
+- serving-only env vars
+- hosted staging secrets created by Terraform
+
+It does not pretend hosted deploy config already exists. That belongs to later M2 PRs.
+
+## Source of truth order
+
+Local runtime config resolves in this order:
+
+1. explicit profile path via `MLP_PROFILE_PATH`
+2. named profile via `MLP_ENV` or `mlp --env <name>`
+3. env var overrides applied on top of the selected profile
+
+Today the default profile is:
+
+- [`configs/env/local.yaml`](../../configs/env/local.yaml)
+
+The main implementation is:
+
+- [`runtime/profile.py`](../../src/ml_lifecycle_platform/runtime/profile.py)
+- [`cli/main.py`](../../src/ml_lifecycle_platform/cli/main.py)
+- [`serving/settings.py`](../../src/ml_lifecycle_platform/serving/settings.py)
+
+## Runtime profile fields
+
+These fields come from `configs/env/<env>.yaml`.
+
+| Field | Used by | Notes |
+| --- | --- | --- |
+| `environment` | CLI, logs | operator-facing environment name |
+| `tracking_uri` | pipeline, registry, serving bootstrap | MLflow tracking backend |
+| `registry_uri` | pipeline, registry, serving bootstrap | MLflow registry backend |
+| `experiment_name` | pipeline | default experiment destination |
+| `model_name` | register, promote, rollback, serve | default registered model |
+| `model_spec_path` | pipeline, serving | must stay aligned with `model_name` |
+| `log_level` | CLI, serving | current default logging level |
+| `data_dir` | pipeline | local working data path |
+| `artifacts_dir` | pipeline, release evidence mirror | local artifact root |
+| `event_log_path` | local event store | JSONL event log path |
+| `python_executable` | local command execution | Python interpreter passed through runtime |
+| `canary_pct` | serving | `0-100` deterministic canary split |
+| `s3_endpoint_url` | MLflow artifact access | local MinIO / S3-compatible endpoint |
+| `aws_access_key_id` | MLflow artifact access | local object store credential |
+| `aws_secret_access_key` | MLflow artifact access | local object store credential |
+| `compose_file` | Makefile, CLI infra commands | local Docker Compose file |
+| `compose_tracking_uri` | Compose containers | in-network MLflow URL |
+| `compose_registry_uri` | Compose containers | in-network registry URL |
+| `compose_s3_endpoint_url` | Compose containers | in-network MinIO URL |
+| `compose_serve_url` | smoke path | in-network serving URL |
+| `mlflow_host` | local MLflow server | bind host |
+| `mlflow_port` | local MLflow server | bind port |
+| `backend_store_uri` | local MLflow server | metadata backend |
+| `artifact_root` | local MLflow server | artifact store root |
+
+## Env var overrides
+
+These env vars override the selected runtime profile today.
+
+### Common runtime overrides
+
+- `MLP_ENV`
+- `MLP_PROFILE_PATH`
+- `MLFLOW_TRACKING_URI`
+- `MLFLOW_REGISTRY_URI`
+- `EXPERIMENT_NAME`
+- `MODEL_NAME`
+- `MLP_MODEL_SPEC_PATH`
+- `LOG_LEVEL`
+- `MLP_DATA_DIR`
+- `MLP_ARTIFACTS_DIR`
+- `MLP_EVENT_LOG_PATH`
+- `PYTHON_EXECUTABLE`
+- `CANARY_PCT`
+- `BACKEND_STORE_URI`
+- `ARTIFACT_ROOT`
+
+### Local object-store and Compose overrides
+
+- `MLFLOW_S3_ENDPOINT_URL`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `MLP_COMPOSE_FILE`
+- `MLP_COMPOSE_TRACKING_URI`
+- `MLP_COMPOSE_REGISTRY_URI`
+- `MLP_COMPOSE_S3_ENDPOINT_URL`
+- `MLP_COMPOSE_SERVE_URL`
+- `SERVE_URL`
+- `MLFLOW_HOST`
+- `MLFLOW_PORT`
+
+## Serving settings
+
+The serving container has a smaller config surface than the full runtime profile.
+
+| Env var | Default | Used by |
+| --- | --- | --- |
+| `MODEL_NAME` | `breast_cancer_clf` | MLflow alias resolution |
+| `MLP_MODEL_SPEC_PATH` | `configs/models/breast_cancer_demo.yaml` | feature contract loading |
+| `PROD_ALIAS` | `prod` | primary registry alias |
+| `CANDIDATE_ALIAS` | `candidate` | secondary registry alias |
+| `CANARY_PCT` | `10` | deterministic canary split |
+| `MODEL_CACHE_TTL_SEC` | `60.0` | in-process model refresh cache |
+| `LOG_LEVEL` | `INFO` | serving logs |
+| `UNIT_TESTING` | `false` | disables real MLflow model loads in unit tests |
+
+Non-obvious constraint:
+
+- `MODEL_NAME` and `MLP_MODEL_SPEC_PATH` must describe the same model.
+- If they drift, serving fails on startup or request validation with an explicit error.
+
+## Hosted staging secrets
+
+`UP-16` created the active staged MLflow secret contract:
+
+- `mlp-mlflow-db-user`
+- `mlp-mlflow-db-password`
+- `mlp-mlflow-db-name`
+- `mlp-mlflow-instance-connection-name`
+- `mlp-mlflow-artifact-root`
+
+These secrets exist now, but no hosted service consumes them yet.
+
+The current values are intended for later `Cloud Run` wiring:
+
+- DB user: `mlflow`
+- DB name: `mlflow`
+- artifact root: `gs://fpl-project-jelle-mlp-artifacts/mlflow/`
+- instance connection name: from Terraform output `mlflow_sql.connection_name`
+
+Legacy foundation placeholders still exist:
+
+- `mlp-mlflow-tracking-uri`
+- `mlp-mlflow-tracking-username`
+- `mlp-mlflow-tracking-password`
+
+Treat those as reserved foundation names, not the active hosted-staging contract.
+
+## Current operator rules
+
+- Prefer editing committed runtime profiles and model specs over piling on shell-only overrides.
+- Use env var overrides for local experiments, CI, or one-off debugging.
+- Do not introduce a second config layer for hosted deploys when Terraform outputs and Secret Manager already provide the needed contract.
+- Keep model name, model spec, and MLflow aliases aligned. Most serving breakage comes from drifting those independently.

--- a/docs/reference/gcp-resources.md
+++ b/docs/reference/gcp-resources.md
@@ -1,0 +1,143 @@
+# GCP Resources
+
+This page is the committed GCP resource inventory for the current repo state.
+
+It is not a full Google Cloud project inventory. It is the subset this repo owns through Terraform today.
+
+Source of truth:
+
+- [`deployments/gcp/terraform/`](../../deployments/gcp/terraform/)
+
+## Scope today
+
+Managed now:
+
+- Artifact Registry
+- hosted GCS buckets
+- Secret Manager foundation placeholders
+- CI and runtime service accounts
+- GitHub Actions Workload Identity Federation
+- staging VPC and subnet
+- private service access for Cloud SQL
+- Cloud SQL for hosted MLflow metadata
+- active MLflow staging secrets
+
+Not managed yet:
+
+- Cloud Run services
+- Cloud Run jobs
+- ALB or custom domain
+- Cloud Scheduler
+
+## Shared identifiers
+
+| Item | Value |
+| --- | --- |
+| project ID | `fpl-project-jelle` |
+| region | `europe-west1` |
+| Terraform root | `deployments/gcp/terraform/` |
+| Terraform backend bucket | `gs://fpl-tf-state-jelle` |
+
+## Foundation resources
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| Artifact Registry repository | `mlp-images` | hosted runtime images |
+| artifacts bucket | `fpl-project-jelle-mlp-artifacts` | hosted artifacts |
+| data bucket | `fpl-project-jelle-mlp-data` | hosted data files |
+| CI service account | `mlp-ci@fpl-project-jelle.iam.gserviceaccount.com` | GitHub Actions impersonation |
+| runtime service account | `mlp-runtime@fpl-project-jelle.iam.gserviceaccount.com` | hosted workload identity |
+| WIF pool | `github-actions` | GitHub OIDC trust root |
+| WIF provider | `github-oidc` | GitHub repository trust binding |
+
+Reserved foundation secrets:
+
+- `mlp-mlflow-tracking-uri`
+- `mlp-mlflow-tracking-username`
+- `mlp-mlflow-tracking-password`
+
+## Staging infra from UP-16
+
+| Resource | Name | Purpose |
+| --- | --- | --- |
+| VPC | `mlp-staging-vpc` | shared network for hosted staging |
+| subnet | `mlp-staging-subnet` | regional subnet in `europe-west1` |
+| private service range | `mlp-staging-private-services` | private service access |
+| Cloud SQL instance | `mlp-mlflow-staging` | hosted MLflow metadata backend |
+| database | `mlflow` | MLflow metadata DB |
+| DB user | `mlflow` | MLflow DB user |
+| MLflow artifact root | `gs://fpl-project-jelle-mlp-artifacts/mlflow/` | hosted MLflow artifacts |
+
+Active staging secrets:
+
+- `mlp-mlflow-db-user`
+- `mlp-mlflow-db-password`
+- `mlp-mlflow-db-name`
+- `mlp-mlflow-instance-connection-name`
+- `mlp-mlflow-artifact-root`
+
+## IAM contract
+
+Current important bindings:
+
+- `mlp-ci` can push images to Artifact Registry
+- `mlp-runtime` can read the hosted MLflow secrets
+- `mlp-runtime` can write objects to the hosted artifacts and data buckets
+- `mlp-runtime` has `roles/cloudsql.client`
+
+Not granted yet:
+
+- Cloud Run deploy permissions
+- scheduler invoker permissions
+- public ingress configuration
+
+## Useful Terraform outputs
+
+Current outputs operators and later PRs should use:
+
+- `artifact_registry_docker_repository`
+- `foundation_bucket_names`
+- `foundation_secret_ids`
+- `foundation_service_accounts`
+- `staging_network`
+- `mlflow_sql`
+- `mlflow_secret_ids`
+- `workload_identity_provider_name`
+
+Most important current deploy-facing outputs:
+
+### `mlflow_sql`
+
+- `instance_name`
+- `connection_name`
+- `private_ip`
+- `database_name`
+- `database_user`
+- `artifact_root`
+
+### `staging_network`
+
+- `network_name`
+- `network_id`
+- `subnetwork_name`
+- `subnetwork_id`
+- `subnetwork_cidr`
+- `peering_range`
+- `peering_cidr`
+
+## Operator checks
+
+After any Terraform apply, these are the fastest sanity checks:
+
+```bash
+terraform -chdir=deployments/gcp/terraform output
+gcloud artifacts repositories list --location=europe-west1 --project fpl-project-jelle
+gcloud sql instances describe mlp-mlflow-staging --project fpl-project-jelle
+gcloud secrets list --project fpl-project-jelle
+```
+
+Companion runbooks:
+
+- [`../runbooks/gcp-bootstrap.md`](../runbooks/gcp-bootstrap.md)
+- [`../runbooks/gcp-foundation.md`](../runbooks/gcp-foundation.md)
+- [`../runbooks/gcp-staging-infra.md`](../runbooks/gcp-staging-infra.md)

--- a/docs/reference/release-contract.md
+++ b/docs/reference/release-contract.md
@@ -1,0 +1,152 @@
+# Release Contract
+
+This repo has three different release identities.
+
+Do not collapse them into one thing.
+
+## 1. GitHub/package release
+
+Source of truth:
+
+- squash-merged commit history on `master`
+- Release Please
+
+Purpose:
+
+- version the Python package and changelog
+
+Current mechanism:
+
+- PR title carries the Conventional Commit signal
+- Release Please opens or updates the release PR
+- merge of the release PR creates the Git tag and GitHub release
+
+## 2. Model release
+
+Source of truth:
+
+- MLflow model versions and aliases
+- release evidence stored in MLflow artifacts
+
+Purpose:
+
+- decide which model version is `candidate`, `prod`, or `champion`
+
+Current aliases:
+
+- `candidate`
+- `prod`
+- `champion`
+
+Current evidence bundle:
+
+- `promotion_decision.json`
+- `release_manifest.json`
+- `rollback_target.json`
+- `model_card.md`
+
+Artifact path:
+
+- `reports/releases/<operation>/<model_name>/v<version>/`
+
+## 3. Runtime image release
+
+Source of truth:
+
+- `Publish Images` workflow
+- `image-digests.json` artifact
+
+Purpose:
+
+- identify the exact container bits used for hosted deploys
+
+Current published image names:
+
+- `platform`
+- `serving`
+
+Current registry:
+
+- `europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images`
+
+Current publish rule:
+
+- publish immutable Git SHA tags only
+- capture remote digests after push
+- downstream deploys should use digests, not tags
+
+## Current contract
+
+These identities are separate on purpose:
+
+| Identity | Chooses | Current source of truth |
+| --- | --- | --- |
+| package release | versioned repo/package state | Release Please |
+| image release | container filesystem and runtime bits | Artifact Registry digest |
+| model release | served model version and alias state | MLflow alias and version |
+
+This is the key rule for M2:
+
+- image deploy chooses the runtime container
+- MLflow alias chooses the served model
+
+Do not encode model rollout into image tagging.
+
+## Rollback rules
+
+### Package rollback
+
+- handled at the Git/tag/release level
+- unrelated to model alias rollback
+
+### Model rollback
+
+- `rollback` resolves the target from the current prod version's `release_manifest.json`
+- `previous_prod_version` remains a compatibility and one-step-undo field
+
+### Hosted runtime rollback
+
+Not deployed yet, but the contract is already fixed:
+
+- rollback by image digest, not tag
+- model rollback remains an MLflow alias operation
+
+If a hosted deploy fails because of container behavior, roll back the image digest.
+If a hosted deploy fails because of a bad promoted model, roll back the MLflow alias.
+
+Those are different incidents.
+
+## Reproducibility contract
+
+Each training run records:
+
+- model spec
+- dataset fingerprint
+- config hash
+- git SHA
+- `uv.lock` hash
+- probe inputs and expected probabilities
+
+That data answers a different question again:
+
+- "can we rebuild this model version?"
+
+It is not the same as:
+
+- "which image is deployed?"
+- "which model alias is live?"
+
+## What deploy workflows should consume
+
+Today and going forward:
+
+- consume `image-digests.json` for container identity
+- consume MLflow aliases and model versions for model identity
+- do not deploy from mutable tags
+- do not infer model rollout from package release versions
+
+Companion docs:
+
+- [`../ci.md`](../ci.md)
+- [`../releases.md`](../releases.md)
+- [`../adrs/ADR-0002-mlflow-control-plane.md`](../adrs/ADR-0002-mlflow-control-plane.md)

--- a/docs/reference/technology-stack.md
+++ b/docs/reference/technology-stack.md
@@ -4,6 +4,12 @@ This page lists the primary tools the platform uses today.
 
 It does not list every package in `pyproject.toml`. It lists the tools a new engineer needs to understand to run, change, and debug the platform.
 
+Companion references:
+
+- [`configuration.md`](./configuration.md)
+- [`gcp-resources.md`](./gcp-resources.md)
+- [`release-contract.md`](./release-contract.md)
+
 ## Runtime and Serving
 
 ### FastAPI
@@ -189,9 +195,11 @@ What it is:
 
 Why we use it:
 - The local MLflow server needs a real backend store instead of a file-backed metadata DB.
+- Hosted MLflow staging also needs a real managed backend store.
 
 How it is used here:
 - Backs the local MLflow tracking server metadata store in Docker Compose.
+- Will back hosted MLflow metadata in GCP through Cloud SQL Postgres.
 
 Official docs:
 - https://www.postgresql.org/docs/
@@ -240,7 +248,8 @@ How it is used here:
 - Initializes remote state in the existing GCS backend bucket.
 - Manages required GCP project APIs for the shared hosted Terraform root in `deployments/gcp/terraform/`.
 - Manages the current hosted foundation layer: Artifact Registry, buckets, placeholder secrets, service accounts, and GitHub OIDC federation.
-- Will be extended in `M2` for Cloud SQL, Cloud Run services, jobs, and scheduler resources.
+- Manages the current hosted staging infra layer: staging network, private service access, Cloud SQL, and MLflow staging secrets.
+- Will be extended in `M2` for Cloud Run services, jobs, and scheduler resources.
 
 Official docs:
 - https://developer.hashicorp.com/terraform/docs

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,8 @@ This document covers two separate release concepts:
 - model release evidence emitted by the registry workflows
 - hosted runtime image publication for deploy workflows
 
+For the full identity contract across package releases, image digests, and MLflow aliases, see [`reference/release-contract.md`](./reference/release-contract.md).
+
 ## Source of truth
 
 - PRs are squash-merged into `master`

--- a/docs/runbooks/gcp-bootstrap.md
+++ b/docs/runbooks/gcp-bootstrap.md
@@ -148,6 +148,7 @@ The next staged additions are:
 - hosted serving on Cloud Run
 
 See [`../architecture/m2-staging-platform.md`](../architecture/m2-staging-platform.md) for the fixed decisions and implementation order.
+See [`./gcp-staging-infra.md`](./gcp-staging-infra.md) for the concrete `UP-16` stateful infra contract.
 
 ## Debugging
 

--- a/docs/runbooks/gcp-foundation.md
+++ b/docs/runbooks/gcp-foundation.md
@@ -102,6 +102,7 @@ This foundation layer is intentionally enough for:
 - edge and orchestration later
 
 Use the fixed decisions in [`../architecture/m2-staging-platform.md`](../architecture/m2-staging-platform.md) as the default shape unless a later ADR changes them.
+The concrete stateful infra added in `UP-16` is documented in [`./gcp-staging-infra.md`](./gcp-staging-infra.md).
 
 ## Operator flow
 

--- a/docs/runbooks/gcp-staging-infra.md
+++ b/docs/runbooks/gcp-staging-infra.md
@@ -1,0 +1,110 @@
+# GCP Staging Infra
+
+Last verified: 2026-03-10
+
+This runbook covers the stateful hosted staging layer added in `UP-16`.
+
+Current scope:
+
+- staging VPC and subnet
+- private service access for Cloud SQL
+- Cloud SQL Postgres for hosted MLflow metadata
+- MLflow staging secrets in Secret Manager
+- outputs for later hosted deploy workflows
+
+Out of scope here:
+
+- MLflow deployment
+- serving deployment
+- load balancing
+- Cloud Run jobs
+- scheduler
+
+## Resource contract
+
+Committed staging names:
+
+- VPC: `mlp-staging-vpc`
+- subnet: `mlp-staging-subnet`
+- Cloud SQL instance: `mlp-mlflow-staging`
+- database: `mlflow`
+- database user: `mlflow`
+- artifact root: `gs://fpl-project-jelle-mlp-artifacts/mlflow/`
+
+The runtime service account remains:
+
+- `mlp-runtime@<project>.iam.gserviceaccount.com`
+
+## Managed APIs
+
+This layer extends the Terraform root with:
+
+- `compute.googleapis.com`
+- `servicenetworking.googleapis.com`
+- `sqladmin.googleapis.com`
+
+## Secrets added for hosted MLflow staging
+
+- `mlp-mlflow-db-user`
+- `mlp-mlflow-db-password`
+- `mlp-mlflow-db-name`
+- `mlp-mlflow-instance-connection-name`
+- `mlp-mlflow-artifact-root`
+
+These are the active hosted-staging MLflow secrets.
+
+The older placeholder secrets from the foundation layer still exist, but they are not the primary `UP-16` contract.
+
+## Operator flow
+
+From the repo root:
+
+```bash
+make terraform-gcp-fmt
+make terraform-gcp-init
+make terraform-gcp-validate
+make terraform-gcp-plan
+terraform -chdir=deployments/gcp/terraform apply
+```
+
+## Outputs used by later tickets
+
+Most important outputs:
+
+- `staging_network`
+- `mlflow_sql`
+- `mlflow_secret_ids`
+
+These outputs should feed:
+
+- `UP-17` hosted MLflow deploy wiring
+- `UP-18` serving runtime wiring
+
+## Manual verification
+
+After apply:
+
+```bash
+gcloud compute networks describe mlp-staging-vpc --project fpl-project-jelle
+gcloud sql instances describe mlp-mlflow-staging --project fpl-project-jelle
+gcloud sql databases list --instance mlp-mlflow-staging --project fpl-project-jelle
+gcloud secrets list --project fpl-project-jelle
+terraform -chdir=deployments/gcp/terraform output
+```
+
+Check specifically:
+
+- Cloud SQL has private IP only
+- the `mlflow` database exists
+- the new MLflow secrets exist
+- outputs expose enough data for later deploy work
+
+## What comes next
+
+`UP-17` should deploy hosted MLflow on Cloud Run using:
+
+- `mlflow_sql.connection_name`
+- `mlflow_sql.artifact_root`
+- `mlflow_secret_ids`
+
+Do not deploy MLflow or serving from this ticket.


### PR DESCRIPTION
Closes #95

## Summary

Provision the stateful GCP staging prerequisites for hosted MLflow.

This adds the staging network, private service access, Cloud SQL Postgres, MLflow database/user, active MLflow staging secrets, and Terraform outputs needed for later hosted deploy work.

No app resources are deployed yet.

## What changed

- added staging VPC and subnet:
  - `mlp-staging-vpc`
  - `mlp-staging-subnet`
- added private service access for Cloud SQL
- added Cloud SQL Postgres instance:
  - `mlp-mlflow-staging`
- added MLflow database and app user:
  - database: `mlflow`
  - user: `mlflow`
- reused the existing artifacts bucket with MLflow prefix:
  - `gs://fpl-project-jelle-mlp-artifacts/mlflow/`
- added active MLflow staging secrets:
  - `mlp-mlflow-db-user`
  - `mlp-mlflow-db-password`
  - `mlp-mlflow-db-name`
  - `mlp-mlflow-instance-connection-name`
  - `mlp-mlflow-artifact-root`
- granted `mlp-runtime`:
  - `roles/cloudsql.client`
  - `roles/secretmanager.secretAccessor` on the new MLflow staging secrets
- added deploy-facing Terraform outputs:
  - `staging_network`
  - `mlflow_sql`
  - `mlflow_secret_ids`
- updated docs to reflect the current topology, config contract, GCP resource inventory, and release contract

## Why this shape

- keeps stateful infra separate from app deploy
- uses private IP Cloud SQL instead of a public DB path
- reuses the existing hosted artifacts bucket instead of creating more storage
- keeps the hosted MLflow runtime contract explicit through individual secrets and Terraform outputs
- leaves MLflow and serving deployment for later PRs

## Validation

Ran locally:

- `terraform -chdir=deployments/gcp/terraform fmt -check -recursive`
- `terraform -chdir=deployments/gcp/terraform init -backend=false`
- `terraform -chdir=deployments/gcp/terraform validate`
- `terraform -chdir=deployments/gcp/terraform plan -lock=false -input=false`
- `make docs-check`

Applied successfully in `fpl-project-jelle` and verified:

- Cloud SQL instance `mlp-mlflow-staging`
- private IP assigned
- database `mlflow`
- user `mlflow`
- new MLflow staging secrets created with initial versions
- Terraform outputs available for follow-up deploy work

## Non-goals

- no MLflow deploy
- no Cloud Run service
- no serving deploy
- no ALB
- no scheduler
