### PR TITLE
fix: potential fix for code scanning alert no. 58: Clear-text logging of sensitive information

### DIFF
--- a/src/ml_lifecycle_platform/ci/gcp_auth_verifier.py
+++ b/src/ml_lifecycle_platform/ci/gcp_auth_verifier.py
@@ -215,6 +215,6 @@ def format_success_summary(config: GcpAuthVerificationConfig) -> str:
             f"Verified impersonated service account: {config.service_account}",
             f"Verified Artifact Registry repository: {config.artifact_repository}",
             f"Verified buckets: {config.resolved_artifacts_bucket}, {config.resolved_data_bucket}",
-            "Verified secrets: " + ", ".join(config.secret_ids),
+            f"Verified {len(config.secret_ids)} secret(s).",
         ]
     )


### PR DESCRIPTION
Potential fix for [https://github.com/jellewillekes/ml-lifecycle-platform/security/code-scanning/58](https://github.com/jellewillekes/ml-lifecycle-platform/security/code-scanning/58)

Generally, to fix clear-text logging of sensitive information, either (a) stop logging the sensitive field entirely, or (b) log only a redacted/aggregated/obfuscated version that does not meaningfully reveal the sensitive data. Here, `format_success_summary` is the central place where `config.secret_ids` is turned into text and then printed; we can fix the issue by changing this function so it no longer includes the raw secret IDs in the returned string.

The best minimal-impact fix is to adjust `format_success_summary` in `src/ml_lifecycle_platform/ci/gcp_auth_verifier.py` to avoid listing `config.secret_ids`. We can keep all other lines as-is and replace the last line in the joined list:

- Replace `"Verified secrets: " + ", ".join(config.secret_ids)` with a non-sensitive summary, for example: `f"Verified {len(config.secret_ids)} secret(s)."`. This preserves the functionality of showing that the secrets verification step succeeded, without exposing which secrets they are.

No changes are required in `scripts/verify_gcp_ci_auth.py`; the call `print(format_success_summary(config))` remains valid, and the function signature of `format_success_summary` does not change. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
