### PR TITLE
docs: add current operator guide for local and hosted paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,10 @@ Start here if you want to run or change the local platform.
 
 ## Architecture
 
+- [`architecture/how-it-works.md`](./architecture/how-it-works.md): fastest current explanation of the local path, hosted staging path, operator flows, and live boundaries
 - [`architecture/overview.md`](./architecture/overview.md): current local and hosted topology, boundaries, and lifecycle
 - [`architecture/local-runtime.md`](./architecture/local-runtime.md): runtime profiles, model specs, serving contract, local paths
-- [`architecture/current-state.md`](./architecture/current-state.md): current M0 scope and non-goals
+- [`architecture/current-state.md`](./architecture/current-state.md): current implemented scope and non-goals
 - [`architecture/m2-staging-platform.md`](./architecture/m2-staging-platform.md): fixed decisions and execution order for the first hosted GCP staging platform
 
 ## Runbooks
@@ -24,6 +25,8 @@ Start here if you want to run or change the local platform.
 - [`runbooks/gcp-staging-infra.md`](./runbooks/gcp-staging-infra.md): provision the stateful staging infra for hosted MLflow
 - [`runbooks/deploy-mlflow.md`](./runbooks/deploy-mlflow.md): build, deploy, and verify hosted MLflow staging
 - [`runbooks/deploy-serving.md`](./runbooks/deploy-serving.md): deploy the serving API to hosted staging and run authenticated smoke checks
+- [`runbooks/deploy-platform-jobs.md`](./runbooks/deploy-platform-jobs.md): deploy hosted Cloud Run jobs and run them manually
+- [`runbooks/schedule-platform-jobs.md`](./runbooks/schedule-platform-jobs.md): inspect, pause, resume, and verify Cloud Scheduler for hosted jobs
 - [`runbooks/serving-staging-baseline.md`](./runbooks/serving-staging-baseline.md): run the first advisory k6 baseline against hosted serving staging
 - [`runbooks/gcp-ci-auth.md`](./runbooks/gcp-ci-auth.md): verify GitHub Actions OIDC auth into GCP
 - [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion

--- a/docs/architecture/how-it-works.md
+++ b/docs/architecture/how-it-works.md
@@ -1,0 +1,230 @@
+# How It Works Now
+
+Last verified: 2026-03-17
+
+This page is the shortest current explanation of how the repo works in practice.
+
+Use it when you want the operator path and current boundaries without reading every runbook first.
+
+## Two real paths
+
+The repo now has two real operating paths:
+
+### Local path
+
+Used for:
+
+- day-to-day development
+- fast iteration
+- most debugging
+- local end-to-end validation
+
+Shape:
+
+```text
+developer shell
+  -> Makefile / CLI
+  -> Docker Compose
+  -> PostgreSQL + MinIO + MLflow
+  -> pipeline / promote / rollback / reproduce / serving
+```
+
+Main entrypoint:
+
+- [`../runbooks/local-bootstrap.md`](../runbooks/local-bootstrap.md)
+
+## Hosted staging path
+
+Used for:
+
+- published image deployment
+- hosted MLflow validation
+- hosted serving validation
+- hosted platform job execution
+- conservative scheduler-driven maintenance
+
+Shape:
+
+```text
+GitHub Actions
+  -> Workload Identity Federation
+  -> Artifact Registry image publish
+  -> Terraform apply
+
+GCP staging
+  -> Cloud Run MLflow
+  -> Cloud Run serving
+  -> Cloud Run platform jobs
+  -> Cloud Scheduler
+  -> Cloud SQL
+  -> GCS artifacts/data
+  -> Secret Manager
+```
+
+## What is live in staging
+
+Hosted resources currently in use:
+
+- Cloud Run MLflow staging
+- Cloud Run serving staging
+- Cloud Run jobs:
+  - `mlp-maintenance-staging`
+  - `mlp-reproduce-staging`
+  - `mlp-promote-staging`
+  - `mlp-rollback-staging`
+  - `mlp-pipeline-staging`
+- Cloud Scheduler jobs:
+  - `mlp-maintenance-staging-schedule`
+  - `mlp-pipeline-staging-schedule`
+
+Current scheduler stance:
+
+- `maintenance` is enabled
+- `pipeline` exists but is paused
+- `promote` is manual
+- `rollback` is manual
+
+## What remains the control plane
+
+MLflow is still the control plane for model state.
+
+It owns:
+
+- runs
+- model versions
+- aliases
+- release evidence
+
+Container deploys choose runtime bits.
+
+MLflow aliases choose model state.
+
+That separation still matters:
+
+- image identity answers "what code is deployed"
+- alias and version identity answer "what model is active"
+
+## Current operator flows
+
+### 1. Publish images
+
+Use:
+
+- `Publish Images`
+
+Output:
+
+- immutable `platform` and `serving` image refs tagged by Git SHA
+
+### 2. Deploy hosted MLflow
+
+Use:
+
+- [`../runbooks/deploy-mlflow.md`](../runbooks/deploy-mlflow.md)
+
+### 3. Deploy hosted serving
+
+Use:
+
+- [`../runbooks/deploy-serving.md`](../runbooks/deploy-serving.md)
+
+### 4. Deploy hosted platform jobs and scheduler
+
+Use:
+
+- `Deploy Platform Jobs Staging`
+
+This applies the shared Terraform root and preserves:
+
+- current MLflow image
+- current serving image
+- selected `platform` image
+
+Main runbook:
+
+- [`../runbooks/deploy-platform-jobs.md`](../runbooks/deploy-platform-jobs.md)
+
+### 5. Run hosted platform jobs manually
+
+Use:
+
+- `Run Platform Job Staging`
+
+Safe hosted proof order:
+
+1. `maintenance`
+2. `reproduce`
+3. `promote` with `dry_run`
+4. `rollback` with `dry_run`
+5. `pipeline`
+
+### 6. Inspect or operate scheduler
+
+Use:
+
+- [`../runbooks/schedule-platform-jobs.md`](../runbooks/schedule-platform-jobs.md)
+
+Typical checks:
+
+- list scheduler jobs
+- describe scheduler jobs
+- force-run `mlp-maintenance-staging-schedule`
+- verify resulting Cloud Run Job execution
+
+## Manual bootstrap exceptions
+
+Most deploy state is Terraform-managed, but a few permissions are still intentionally manual bootstrap steps.
+
+Current important exceptions:
+
+- Terraform state bucket IAM for `mlp-ci`
+- bucket IAM used during the original bootstrap flow
+- `roles/cloudscheduler.admin` for `mlp-ci`
+
+These are documented in:
+
+- [`../reference/gcp-resources.md`](../reference/gcp-resources.md)
+
+## Current known limitations
+
+### Post-rollback candidate state can be confusing
+
+After rollback:
+
+- the previous `prod` can be restored correctly
+- but the old promoted version may still sit behind `candidate`
+- that version may still carry `release_status=prod`
+
+Result:
+
+- a later `promote --dry-run` can correctly block even when a `candidate` alias exists
+
+This is a model-state hygiene limitation, not a broken Cloud Run Job or scheduler path.
+
+### Scheduler is intentionally conservative
+
+The repo does not currently support:
+
+- scheduled `promote`
+- scheduled `rollback`
+- automatic promotion to `prod`
+
+That is intentional.
+
+## What is not in place yet
+
+Still out of scope:
+
+- public edge / ALB
+- custom domain
+- production rollout
+- scheduled release-control actions
+- additional orchestration beyond conservative maintenance cadence
+
+## Where to read next
+
+- [`./current-state.md`](./current-state.md)
+- [`./m2-staging-platform.md`](./m2-staging-platform.md)
+- [`../runbooks/deploy-platform-jobs.md`](../runbooks/deploy-platform-jobs.md)
+- [`../runbooks/schedule-platform-jobs.md`](../runbooks/schedule-platform-jobs.md)
+- [`../reference/gcp-resources.md`](../reference/gcp-resources.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-This repo currently has one real platform path and one hosted path under construction:
+This repo currently has one real local path and one real hosted staging path:
 
 ```text
 local path:
@@ -9,14 +9,18 @@ local path:
 hosted path today:
   GitHub Actions -> Artifact Registry
   Terraform -> GCP foundation + staging infra
+  Cloud Run -> MLflow + serving + platform jobs
+  Cloud Scheduler -> conservative maintenance cadence
 ```
 
-The local path is fully operational. The hosted path is partially operational:
+The local path is fully operational. The hosted staging path is operational for M2 staging work:
 
 - CI can authenticate to GCP with WIF.
 - CI can publish immutable runtime images to Artifact Registry.
 - Terraform has created the shared staging network, Cloud SQL, and MLflow staging secrets.
-- Hosted MLflow and serving deploy paths are committed, but still operator-driven and staging-only.
+- Hosted MLflow and serving are live on Cloud Run.
+- Hosted platform jobs are deployed on Cloud Run.
+- Cloud Scheduler drives the conservative maintenance cadence.
 
 ## Current topology
 
@@ -40,6 +44,10 @@ GCP staging infra
   -> Secret Manager
   -> Cloud SQL Postgres
   -> staging VPC + subnet + private service access
+  -> Cloud Run MLflow
+  -> Cloud Run serving
+  -> Cloud Run platform jobs
+  -> Cloud Scheduler
 ```
 
 ## Boundaries that matter
@@ -60,7 +68,7 @@ GCP staging infra
 4. Registration creates a candidate model version and copies minimum lineage tags from the source run.
 5. Promotion evaluates policy from the model spec, mutates MLflow aliases, and writes release evidence.
 6. Serving resolves `models:/<model_name>@prod` or `@candidate` from MLflow and validates requests against the active feature contract from the model spec.
-7. Hosted rollout, once `M2` is finished, will deploy the `serving` and `platform` images by digest while still using MLflow aliases for model selection.
+7. Hosted rollout deploys the `serving` and `platform` images by digest while still using MLflow aliases for model selection.
 
 ## Serving contract
 
@@ -99,6 +107,5 @@ The release manifest is the operator-facing release record. It captures source r
 ## What is intentionally not true yet
 
 - no public hosted MLflow or serving edge
-- no Cloud Run jobs
 - no ALB or custom domain
-- no scheduler-driven orchestration
+- no scheduled promotion or rollback


### PR DESCRIPTION
## Summary

Add one operator-facing doc that explains how the repo works now across both the local path and the hosted GCP staging path.

This is a docs-only follow-up after `UP-21` and `UP-22`.
The goal is to make the current repo easier to understand for a new contributor without forcing them to jump between multiple low-level runbooks first.

## What changed

### New doc
- added `docs/architecture/how-it-works.md`

This page explains:
- the local path
- the hosted staging path
- what is currently live in GCP
- the main operator flows
- current manual bootstrap exceptions
- known limitations and intentional boundaries

### Handbook wiring
- updated `docs/README.md`
- linked the new operator-facing doc from the architecture section
- added the hosted jobs and scheduler runbooks to the runbook index

### Stale overview fix
- updated `docs/architecture/overview.md`
- removed outdated statements that said hosted jobs and scheduler did not exist yet
- aligned the overview with the current deployed M2 state

## Why

The repo already had the detailed runbooks and resource inventory, but it was still missing one short “how it works now” page for a reader who wants:

- the real current topology
- the practical operator path
- the current hosted boundaries
- the manual exceptions that still exist

This PR fills that gap without changing any runtime or infrastructure behavior.

## Validation

- `make docs-check`

## Scope boundaries

This PR does not:
- change Terraform
- change workflows
- change runtime behavior
- change release policy
- change deployment state in GCP
