### PR TITLE
feat: make hosted staging golden path deterministic

### DIFF
--- a/.github/workflows/deploy-mlflow-staging.yml
+++ b/.github/workflows/deploy-mlflow-staging.yml
@@ -1,7 +1,25 @@
 name: Deploy MLflow Staging
 
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      mlflow_image:
+        description: Digest-pinned Artifact Registry ref for the hosted MLflow image to deploy.
+        required: true
+        type: string
+    outputs:
+      mlflow_image:
+        description: Deployed MLflow image pinned by digest.
+        value: ${{ jobs.deploy.outputs.mlflow_image }}
+      service_url:
+        description: Hosted MLflow service URL after deploy.
+        value: ${{ jobs.deploy.outputs.service_url }}
+  workflow_dispatch:
+    inputs:
+      mlflow_image:
+        description: Digest-pinned Artifact Registry ref for the hosted MLflow image to deploy.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,7 +33,6 @@ env:
   GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
   GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
   GCP_REGION: europe-west1
-  ARTIFACT_REGISTRY_REPOSITORY: mlp-images
 
 jobs:
   deploy:
@@ -25,6 +42,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      mlflow_image: ${{ steps.service.outputs.service_image }}
+      service_url: ${{ steps.service.outputs.service_url }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -52,6 +72,26 @@ jobs:
             exit 1
           fi
 
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_MLFLOW_IMAGE: ${{ inputs.mlflow_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mlflow_image="${INPUT_MLFLOW_IMAGE}"
+          if [[ -z "${mlflow_image}" ]]; then
+            echo "Provide mlflow_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${mlflow_image}" != *@sha256:* ]]; then
+            echo "mlflow_image must be pinned by digest, for example .../mlflow@sha256:..."
+            exit 1
+          fi
+
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -66,6 +106,21 @@ jobs:
         with:
           version: ">= 363.0.0"
           project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Verify MLflow image exists in Artifact Registry
+        env:
+          MLFLOW_IMAGE: ${{ steps.context.outputs.mlflow_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="$(
+            gcloud artifacts docker images describe "${MLFLOW_IMAGE}" \
+              --format='value(image_summary.digest)'
+          )"
+          if [[ -z "${digest}" ]]; then
+            echo "Failed to resolve MLflow image digest from Artifact Registry."
+            exit 1
+          fi
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -90,82 +145,6 @@ jobs:
         run: |
           set -euo pipefail
           uv sync --frozen --group dev
-
-      - id: context
-        name: Resolve deploy context
-        env:
-          GIT_SHA: ${{ github.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          repository="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}"
-          mlflow_ref="${repository}/mlflow:${GIT_SHA}"
-
-          echo "git_sha=${GIT_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "repository=${repository}" >> "${GITHUB_OUTPUT}"
-          echo "mlflow_ref=${mlflow_ref}" >> "${GITHUB_OUTPUT}"
-
-      - name: Build hosted MLflow image
-        env:
-          GIT_SHA: ${{ steps.context.outputs.git_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker build \
-            --file deployments/gcp/mlflow/Dockerfile \
-            --tag "mlp-mlflow:${GIT_SHA}" \
-            deployments/gcp/mlflow
-
-      - name: Smoke test hosted MLflow image
-        env:
-          GIT_SHA: ${{ steps.context.outputs.git_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker run --rm --entrypoint mlflow "mlp-mlflow:${GIT_SHA}" --version
-
-      - name: Log in to Artifact Registry
-        env:
-          REGISTRY_HOST: ${{ env.GCP_REGION }}-docker.pkg.dev
-        shell: bash
-        run: |
-          set -euo pipefail
-          gcloud auth print-access-token | docker login \
-            --username oauth2accesstoken \
-            --password-stdin \
-            "https://${REGISTRY_HOST}"
-
-      - name: Push hosted MLflow image
-        env:
-          GIT_SHA: ${{ steps.context.outputs.git_sha }}
-          MLFLOW_REF: ${{ steps.context.outputs.mlflow_ref }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker tag "mlp-mlflow:${GIT_SHA}" "${MLFLOW_REF}"
-          docker push "${MLFLOW_REF}"
-
-      - id: capture
-        name: Capture hosted MLflow image digest
-        env:
-          MLFLOW_REF: ${{ steps.context.outputs.mlflow_ref }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mlflow_digest="$(
-            gcloud artifacts docker images describe "${MLFLOW_REF}" \
-              --format='value(image_summary.digest)'
-          )"
-
-          if [[ -z "${mlflow_digest}" ]]; then
-            echo "Failed to resolve MLflow image digest from Artifact Registry."
-            exit 1
-          fi
-
-          echo "mlflow_digest=${mlflow_digest}" >> "${GITHUB_OUTPUT}"
-          echo "mlflow_image=${MLFLOW_REF%@*}@${mlflow_digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Terraform init
         shell: bash
@@ -197,7 +176,7 @@ jobs:
 
       - name: Terraform apply hosted MLflow staging
         env:
-          TF_VAR_mlflow_image: ${{ steps.capture.outputs.mlflow_image }}
+          TF_VAR_mlflow_image: ${{ steps.context.outputs.mlflow_image }}
           TF_VAR_serving_image: ${{ steps.serving.outputs.service_image }}
           TF_VAR_platform_image: ${{ steps.platform.outputs.platform_image }}
         shell: bash
@@ -206,17 +185,15 @@ jobs:
           terraform -chdir=deployments/gcp/terraform apply -auto-approve -input=false
 
       - id: service
-        name: Resolve hosted MLflow service URL
+        name: Resolve hosted MLflow service contract
         shell: bash
         run: |
           set -euo pipefail
-
-          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-service.json"
-          terraform -chdir=deployments/gcp/terraform output -json mlflow_service > "${MLFLOW_SERVICE_JSON}"
-
-          service_url="$(python3 -c 'import json, sys; value = json.load(open(sys.argv[1], encoding="utf-8")); print(value["uri"] if value is not None else (_ for _ in ()).throw(SystemExit("mlflow_service output is null; deploy did not create the service.")))' "${MLFLOW_SERVICE_JSON}")"
-
-          echo "service_url=${service_url}" >> "${GITHUB_OUTPUT}"
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-mlflow-staging" \
+            --github-output "${GITHUB_OUTPUT}"
 
       - name: Mint identity token for Cloud Run
         id: token
@@ -243,7 +220,7 @@ jobs:
 
       - name: Write workflow summary
         env:
-          MLFLOW_IMAGE: ${{ steps.capture.outputs.mlflow_image }}
+          MLFLOW_IMAGE: ${{ steps.service.outputs.service_image }}
           SERVICE_URL: ${{ steps.service.outputs.service_url }}
         shell: bash
         run: |

--- a/.github/workflows/deploy-platform-jobs-staging.yml
+++ b/.github/workflows/deploy-platform-jobs-staging.yml
@@ -1,12 +1,24 @@
 name: Deploy Platform Jobs Staging
 
 on:
+  workflow_call:
+    inputs:
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the hosted platform image to deploy.
+        required: true
+        type: string
+    outputs:
+      platform_image:
+        description: Deployed platform image pinned by digest.
+        value: ${{ jobs.deploy.outputs.platform_image }}
+      job_names:
+        description: Comma-separated deployed Cloud Run Job names.
+        value: ${{ jobs.deploy.outputs.job_names }}
   workflow_dispatch:
     inputs:
-      git_sha:
-        description: Optional Git SHA for a platform image previously published by Publish Images. Uses the selected workflow commit SHA when empty.
-        required: false
-        default: ""
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the hosted platform image to deploy.
+        required: true
         type: string
 
 permissions:
@@ -21,7 +33,6 @@ env:
   GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
   GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
   GCP_REGION: europe-west1
-  ARTIFACT_REGISTRY_REPOSITORY: mlp-images
 
 jobs:
   deploy:
@@ -31,6 +42,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      platform_image: ${{ steps.context.outputs.platform_image }}
+      job_names: ${{ steps.jobs.outputs.job_names }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -52,6 +66,26 @@ jobs:
             exit 1
           fi
 
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_PLATFORM_IMAGE: ${{ inputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          platform_image="${INPUT_PLATFORM_IMAGE}"
+          if [[ -z "${platform_image}" ]]; then
+            echo "Provide platform_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${platform_image}" != *@sha256:* ]]; then
+            echo "platform_image must be pinned by digest, for example .../platform@sha256:..."
+            exit 1
+          fi
+
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -67,42 +101,25 @@ jobs:
           version: ">= 363.0.0"
           project_id: ${{ env.GCP_PROJECT_ID }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-        with:
-          terraform_version: 1.5.7
-
-      - id: platform_context
-        name: Resolve published platform image
+      - name: Verify platform image exists in Artifact Registry
         env:
-          INPUT_GIT_SHA: ${{ inputs.git_sha }}
-          WORKFLOW_GIT_SHA: ${{ github.sha }}
+          PLATFORM_IMAGE: ${{ steps.context.outputs.platform_image }}
         shell: bash
         run: |
           set -euo pipefail
-
-          repository="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}"
-          git_sha="${INPUT_GIT_SHA:-}"
-          if [[ -z "${git_sha}" ]]; then
-            git_sha="${WORKFLOW_GIT_SHA}"
-          fi
-
-          platform_ref="${repository}/platform:${git_sha}"
-          if ! platform_digest="$(
-            gcloud artifacts docker images describe "${platform_ref}" \
+          digest="$(
+            gcloud artifacts docker images describe "${PLATFORM_IMAGE}" \
               --format='value(image_summary.digest)'
-          )"; then
-            echo "Publish Images has not published platform:${git_sha} yet. Run Publish Images first or provide an explicit git_sha."
-            exit 1
-          fi
-
-          if [[ -z "${platform_digest}" ]]; then
+          )"
+          if [[ -z "${digest}" ]]; then
             echo "Failed to resolve platform image digest from Artifact Registry."
             exit 1
           fi
 
-          echo "git_sha=${git_sha}" >> "${GITHUB_OUTPUT}"
-          echo "platform_image=${platform_ref%@*}@${platform_digest}" >> "${GITHUB_OUTPUT}"
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: 1.5.7
 
       - name: Terraform init
         shell: bash
@@ -156,7 +173,7 @@ jobs:
         env:
           TF_VAR_mlflow_image: ${{ steps.mlflow.outputs.mlflow_image }}
           TF_VAR_serving_image: ${{ steps.serving.outputs.serving_image }}
-          TF_VAR_platform_image: ${{ steps.platform_context.outputs.platform_image }}
+          TF_VAR_platform_image: ${{ steps.context.outputs.platform_image }}
         shell: bash
         run: |
           set -euo pipefail
@@ -183,8 +200,7 @@ jobs:
 
       - name: Write workflow summary
         env:
-          PLATFORM_IMAGE: ${{ steps.platform_context.outputs.platform_image }}
-          GIT_SHA: ${{ steps.platform_context.outputs.git_sha }}
+          PLATFORM_IMAGE: ${{ steps.context.outputs.platform_image }}
           JOB_NAMES: ${{ steps.jobs.outputs.job_names }}
         shell: bash
         run: |
@@ -193,6 +209,5 @@ jobs:
             echo "## Hosted platform jobs staging"
             echo
             echo "- Platform image: \`${PLATFORM_IMAGE}\`"
-            echo "- Git SHA: \`${GIT_SHA}\`"
             echo "- Jobs: \`${JOB_NAMES}\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-serving-staging.yml
+++ b/.github/workflows/deploy-serving-staging.yml
@@ -1,10 +1,23 @@
 name: Deploy Serving Staging
 
 on:
+  workflow_call:
+    inputs:
+      serving_image:
+        description: Digest-pinned Artifact Registry ref for the hosted serving image to deploy.
+        required: true
+        type: string
+    outputs:
+      serving_image:
+        description: Deployed serving image pinned by digest.
+        value: ${{ jobs.deploy.outputs.serving_image }}
+      service_url:
+        description: Hosted serving service URL after deploy.
+        value: ${{ jobs.deploy.outputs.service_url }}
   workflow_dispatch:
     inputs:
-      git_sha:
-        description: Git SHA for a serving image previously published by Publish Images.
+      serving_image:
+        description: Digest-pinned Artifact Registry ref for the hosted serving image to deploy.
         required: true
         type: string
 
@@ -20,7 +33,6 @@ env:
   GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
   GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
   GCP_REGION: europe-west1
-  ARTIFACT_REGISTRY_REPOSITORY: mlp-images
 
 jobs:
   deploy:
@@ -30,6 +42,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      serving_image: ${{ steps.service.outputs.service_image }}
+      service_url: ${{ steps.service.outputs.service_url }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -57,6 +72,26 @@ jobs:
             exit 1
           fi
 
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_SERVING_IMAGE: ${{ inputs.serving_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          serving_image="${INPUT_SERVING_IMAGE}"
+          if [[ -z "${serving_image}" ]]; then
+            echo "Provide serving_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${serving_image}" != *@sha256:* ]]; then
+            echo "serving_image must be pinned by digest, for example .../serving@sha256:..."
+            exit 1
+          fi
+
+          echo "serving_image=${serving_image}" >> "${GITHUB_OUTPUT}"
+
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -71,6 +106,21 @@ jobs:
         with:
           version: ">= 363.0.0"
           project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Verify serving image exists in Artifact Registry
+        env:
+          SERVING_IMAGE: ${{ steps.context.outputs.serving_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="$(
+            gcloud artifacts docker images describe "${SERVING_IMAGE}" \
+              --format='value(image_summary.digest)'
+          )"
+          if [[ -z "${digest}" ]]; then
+            echo "Failed to resolve serving image digest from Artifact Registry."
+            exit 1
+          fi
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -95,42 +145,6 @@ jobs:
         run: |
           set -euo pipefail
           uv sync --frozen --group dev
-
-      - id: context
-        name: Resolve deploy context
-        env:
-          GIT_SHA: ${{ github.event.inputs.git_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          repository="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}"
-          serving_ref="${repository}/serving:${GIT_SHA}"
-
-          echo "git_sha=${GIT_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "repository=${repository}" >> "${GITHUB_OUTPUT}"
-          echo "serving_ref=${serving_ref}" >> "${GITHUB_OUTPUT}"
-
-      - id: capture
-        name: Resolve serving image digest
-        env:
-          SERVING_REF: ${{ steps.context.outputs.serving_ref }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          serving_digest="$(
-            gcloud artifacts docker images describe "${SERVING_REF}" \
-              --format='value(image_summary.digest)'
-          )"
-
-          if [[ -z "${serving_digest}" ]]; then
-            echo "Failed to resolve serving image digest from Artifact Registry."
-            exit 1
-          fi
-
-          echo "serving_digest=${serving_digest}" >> "${GITHUB_OUTPUT}"
-          echo "serving_image=${SERVING_REF%@*}@${serving_digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Terraform init
         shell: bash
@@ -206,7 +220,7 @@ jobs:
         continue-on-error: true
         env:
           TF_VAR_mlflow_image: ${{ steps.mlflow.outputs.mlflow_image }}
-          TF_VAR_serving_image: ${{ steps.capture.outputs.serving_image }}
+          TF_VAR_serving_image: ${{ steps.context.outputs.serving_image }}
           TF_VAR_platform_image: ${{ steps.platform.outputs.platform_image }}
         shell: bash
         run: |
@@ -280,5 +294,5 @@ jobs:
             echo
             echo "- Image: \`${SERVING_IMAGE}\`"
             echo "- Service URL: \`${SERVICE_URL}\`"
-            echo "- Verification: authenticated smoke test passed"
+            echo "- Verification: authenticated smoke passed"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/hosted-golden-path-staging.yml
+++ b/.github/workflows/hosted-golden-path-staging.yml
@@ -54,100 +54,19 @@ jobs:
     with:
       platform_image: ${{ needs.publish-images.outputs.platform_image }}
 
-  validate-preconditions:
-    name: Validate Preconditions
-    needs: [deploy-mlflow, deploy-serving, deploy-platform-jobs]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+  seed-staging-fixture:
+    name: Seed Staging Fixture
+    needs: [publish-images, deploy-mlflow, deploy-serving, deploy-platform-jobs]
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Validate required GitHub Actions variables
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=()
-          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
-            if [[ -z "${!var_name:-}" ]]; then
-              missing+=("${var_name}")
-            fi
-          done
-          if (( ${#missing[@]} > 0 )); then
-            printf 'Missing required GitHub Actions variable(s): %s\n' "${missing[*]}"
-            exit 1
-          fi
-
-      - id: auth
-        name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          create_credentials_file: true
-          project_id: ${{ env.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
-          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11.7"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            uv.lock
-            pyproject.toml
-
-      - name: Sync (locked)
-        shell: bash
-        run: |
-          set -euo pipefail
-          uv sync --frozen --group dev
-
-      - name: Mint identity token for hosted MLflow
-        id: token
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          project_id: ${{ env.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
-          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
-          token_format: id_token
-          id_token_audience: ${{ needs.deploy-mlflow.outputs.service_url }}
-          id_token_include_email: true
-
-      - id: alias
-        name: Verify staged prod alias exists
-        continue-on-error: true
-        env:
-          MLFLOW_TRACKING_TOKEN: ${{ steps.token.outputs.id_token }}
-          MLFLOW_TRACKING_URI: ${{ needs.deploy-mlflow.outputs.service_url }}
-          MLFLOW_REGISTRY_URI: ${{ needs.deploy-mlflow.outputs.service_url }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          uv run python scripts/verify_hosted_model_alias.py \
-            --tracking-uri "${MLFLOW_TRACKING_URI}" \
-            --model-name "breast_cancer_clf" \
-            --alias "prod"
-
-      - name: Fail with explicit staging-model guidance
-        if: steps.alias.outcome == 'failure'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Hosted golden path precondition failed: staged MLflow does not currently resolve breast_cancer_clf@prod."
-          echo "Run the 'Seed Hosted Staging Model' workflow with the published platform_image digest first, then rerun the hosted golden path."
-          exit 1
+    uses: ./.github/workflows/seed-staging-model.yml
+    with:
+      platform_image: ${{ needs.publish-images.outputs.platform_image }}
 
   maintenance:
     name: Run Maintenance
-    needs: validate-preconditions
+    needs: seed-staging-fixture
     permissions:
       contents: read
       id-token: write
@@ -285,7 +204,7 @@ jobs:
       - deploy-mlflow
       - deploy-serving
       - deploy-platform-jobs
-      - validate-preconditions
+      - seed-staging-fixture
       - maintenance
       - reproduce
       - promote-dry-run
@@ -315,7 +234,7 @@ jobs:
             echo "| deploy-mlflow | \`${{ needs.deploy-mlflow.result }}\` |"
             echo "| deploy-serving | \`${{ needs.deploy-serving.result }}\` |"
             echo "| deploy-platform-jobs | \`${{ needs.deploy-platform-jobs.result }}\` |"
-            echo "| validate-preconditions | \`${{ needs.validate-preconditions.result }}\` |"
+            echo "| seed-staging-fixture | \`${{ needs.seed-staging-fixture.result }}\` |"
             echo "| maintenance | \`${{ needs.maintenance.result }}\` |"
             echo "| reproduce | \`${{ needs.reproduce.result }}\` |"
             echo "| promote-dry-run | \`${{ needs.promote-dry-run.result }}\` |"

--- a/.github/workflows/hosted-golden-path-staging.yml
+++ b/.github/workflows/hosted-golden-path-staging.yml
@@ -1,0 +1,325 @@
+name: Hosted Golden Path Staging
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-golden-path-staging-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
+  GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
+  GCP_REGION: europe-west1
+
+jobs:
+  publish-images:
+    name: Publish Images
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-images.yml
+
+  deploy-mlflow:
+    name: Deploy MLflow
+    needs: publish-images
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-mlflow-staging.yml
+    with:
+      mlflow_image: ${{ needs.publish-images.outputs.mlflow_image }}
+
+  deploy-serving:
+    name: Deploy Serving
+    needs: [publish-images, deploy-mlflow]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-serving-staging.yml
+    with:
+      serving_image: ${{ needs.publish-images.outputs.serving_image }}
+
+  deploy-platform-jobs:
+    name: Deploy Platform Jobs
+    needs: [publish-images, deploy-mlflow, deploy-serving]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-platform-jobs-staging.yml
+    with:
+      platform_image: ${{ needs.publish-images.outputs.platform_image }}
+
+  validate-preconditions:
+    name: Validate Preconditions
+    needs: [deploy-mlflow, deploy-serving, deploy-platform-jobs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate required GitHub Actions variables
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions variable(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11.7"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Sync (locked)
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv sync --frozen --group dev
+
+      - name: Mint identity token for hosted MLflow
+        id: token
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ needs.deploy-mlflow.outputs.service_url }}
+          id_token_include_email: true
+
+      - id: alias
+        name: Verify staged prod alias exists
+        continue-on-error: true
+        env:
+          MLFLOW_TRACKING_TOKEN: ${{ steps.token.outputs.id_token }}
+          MLFLOW_TRACKING_URI: ${{ needs.deploy-mlflow.outputs.service_url }}
+          MLFLOW_REGISTRY_URI: ${{ needs.deploy-mlflow.outputs.service_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/verify_hosted_model_alias.py \
+            --tracking-uri "${MLFLOW_TRACKING_URI}" \
+            --model-name "breast_cancer_clf" \
+            --alias "prod"
+
+      - name: Fail with explicit staging-model guidance
+        if: steps.alias.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Hosted golden path precondition failed: staged MLflow does not currently resolve breast_cancer_clf@prod."
+          echo "Run the 'Seed Hosted Staging Model' workflow with the published platform_image digest first, then rerun the hosted golden path."
+          exit 1
+
+  maintenance:
+    name: Run Maintenance
+    needs: validate-preconditions
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/run-platform-job-staging.yml
+    with:
+      job_name: maintenance
+      execution_mode: default
+
+  reproduce:
+    name: Run Reproduce
+    needs: maintenance
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/run-platform-job-staging.yml
+    with:
+      job_name: reproduce
+      execution_mode: default
+
+  promote-dry-run:
+    name: Run Promote Dry Run
+    needs: reproduce
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/run-platform-job-staging.yml
+    with:
+      job_name: promote
+      execution_mode: dry_run
+
+  rollback-dry-run:
+    name: Run Rollback Dry Run
+    needs: promote-dry-run
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/run-platform-job-staging.yml
+    with:
+      job_name: rollback
+      execution_mode: dry_run
+
+  pipeline:
+    name: Run Pipeline
+    needs: rollback-dry-run
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/run-platform-job-staging.yml
+    with:
+      job_name: pipeline
+      execution_mode: default
+
+  serving-smoke:
+    name: Serving Smoke
+    needs: [deploy-serving, pipeline]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate required GitHub Actions variables
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions variable(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11.7"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Sync (locked)
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv sync --frozen --group dev
+
+      - name: Mint identity token for Cloud Run
+        id: token
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ needs.deploy-serving.outputs.service_url }}
+          id_token_include_email: true
+
+      - name: Verify hosted serving staging
+        env:
+          SERVE_URL: ${{ needs.deploy-serving.outputs.service_url }}
+          SERVE_BEARER_TOKEN: ${{ steps.token.outputs.id_token }}
+          MODEL_NAME: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python -m ml_lifecycle_platform.serving.smoke_test
+
+  summary:
+    name: Summary
+    if: always()
+    needs:
+      - publish-images
+      - deploy-mlflow
+      - deploy-serving
+      - deploy-platform-jobs
+      - validate-preconditions
+      - maintenance
+      - reproduce
+      - promote-dry-run
+      - rollback-dry-run
+      - pipeline
+      - serving-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write workflow summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Hosted golden path staging"
+            echo
+            echo "- Git SHA: \`${{ needs.publish-images.outputs.git_sha }}\`"
+            echo "- MLflow image: \`${{ needs.publish-images.outputs.mlflow_image }}\`"
+            echo "- Serving image: \`${{ needs.publish-images.outputs.serving_image }}\`"
+            echo "- Platform image: \`${{ needs.publish-images.outputs.platform_image }}\`"
+            echo "- MLflow URL: \`${{ needs.deploy-mlflow.outputs.service_url }}\`"
+            echo "- Serving URL: \`${{ needs.deploy-serving.outputs.service_url }}\`"
+            echo "- Platform jobs: \`${{ needs.deploy-platform-jobs.outputs.job_names }}\`"
+            echo
+            echo "| Stage | Result |"
+            echo "| --- | --- |"
+            echo "| publish-images | \`${{ needs.publish-images.result }}\` |"
+            echo "| deploy-mlflow | \`${{ needs.deploy-mlflow.result }}\` |"
+            echo "| deploy-serving | \`${{ needs.deploy-serving.result }}\` |"
+            echo "| deploy-platform-jobs | \`${{ needs.deploy-platform-jobs.result }}\` |"
+            echo "| validate-preconditions | \`${{ needs.validate-preconditions.result }}\` |"
+            echo "| maintenance | \`${{ needs.maintenance.result }}\` |"
+            echo "| reproduce | \`${{ needs.reproduce.result }}\` |"
+            echo "| promote-dry-run | \`${{ needs.promote-dry-run.result }}\` |"
+            echo "| rollback-dry-run | \`${{ needs.rollback-dry-run.result }}\` |"
+            echo "| pipeline | \`${{ needs.pipeline.result }}\` |"
+            echo "| serving-smoke | \`${{ needs.serving-smoke.result }}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,12 +6,27 @@ on:
       git_sha:
         description: Published Git SHA.
         value: ${{ jobs.build-and-push.outputs.git_sha }}
+      mlflow_image:
+        description: Published Artifact Registry ref for the MLflow image pinned by digest.
+        value: ${{ jobs.build-and-push.outputs.mlflow_image }}
+      mlflow_ref:
+        description: Published Artifact Registry ref for the MLflow image tag.
+        value: ${{ jobs.build-and-push.outputs.mlflow_ref }}
+      mlflow_digest:
+        description: Published digest for the MLflow image.
+        value: ${{ jobs.build-and-push.outputs.mlflow_digest }}
+      platform_image:
+        description: Published Artifact Registry ref for the platform image pinned by digest.
+        value: ${{ jobs.build-and-push.outputs.platform_image }}
       platform_ref:
         description: Published Artifact Registry ref for the platform image.
         value: ${{ jobs.build-and-push.outputs.platform_ref }}
       platform_digest:
         description: Published digest for the platform image.
         value: ${{ jobs.build-and-push.outputs.platform_digest }}
+      serving_image:
+        description: Published Artifact Registry ref for the serving image pinned by digest.
+        value: ${{ jobs.build-and-push.outputs.serving_image }}
       serving_ref:
         description: Published Artifact Registry ref for the serving image.
         value: ${{ jobs.build-and-push.outputs.serving_ref }}
@@ -44,8 +59,13 @@ jobs:
       id-token: write
     outputs:
       git_sha: ${{ steps.context.outputs.git_sha }}
+      mlflow_image: ${{ steps.capture.outputs.mlflow_image }}
+      mlflow_ref: ${{ steps.context.outputs.mlflow_ref }}
+      mlflow_digest: ${{ steps.capture.outputs.mlflow_digest }}
+      platform_image: ${{ steps.capture.outputs.platform_image }}
       platform_ref: ${{ steps.context.outputs.platform_ref }}
       platform_digest: ${{ steps.capture.outputs.platform_digest }}
+      serving_image: ${{ steps.capture.outputs.serving_image }}
       serving_ref: ${{ steps.context.outputs.serving_ref }}
       serving_digest: ${{ steps.capture.outputs.serving_digest }}
 
@@ -63,6 +83,7 @@ jobs:
 
           echo "git_sha=${git_sha}" >> "${GITHUB_OUTPUT}"
           echo "repository=${repository}" >> "${GITHUB_OUTPUT}"
+          echo "mlflow_ref=${repository}/mlflow:${git_sha}" >> "${GITHUB_OUTPUT}"
           echo "platform_ref=${repository}/platform:${git_sha}" >> "${GITHUB_OUTPUT}"
           echo "serving_ref=${repository}/serving:${git_sha}" >> "${GITHUB_OUTPUT}"
 
@@ -108,6 +129,17 @@ jobs:
           version: ">= 363.0.0"
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Build MLflow image
+        env:
+          GIT_SHA: ${{ steps.context.outputs.git_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build \
+            --file deployments/gcp/mlflow/Dockerfile \
+            --tag "mlp-mlflow:${GIT_SHA}" \
+            deployments/gcp/mlflow
+
       - name: Build platform image
         env:
           GIT_SHA: ${{ steps.context.outputs.git_sha }}
@@ -123,6 +155,14 @@ jobs:
         run: |
           set -euo pipefail
           docker build --target serving --tag "mlp-serving:${GIT_SHA}" .
+
+      - name: Smoke test MLflow image
+        env:
+          GIT_SHA: ${{ steps.context.outputs.git_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint mlflow "mlp-mlflow:${GIT_SHA}" --version
 
       - name: Smoke test platform image
         env:
@@ -153,6 +193,16 @@ jobs:
             --password-stdin \
             "https://${REGISTRY_HOST}"
 
+      - name: Push MLflow image
+        env:
+          GIT_SHA: ${{ steps.context.outputs.git_sha }}
+          MLFLOW_REF: ${{ steps.context.outputs.mlflow_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker tag "mlp-mlflow:${GIT_SHA}" "${MLFLOW_REF}"
+          docker push "${MLFLOW_REF}"
+
       - name: Push platform image
         env:
           GIT_SHA: ${{ steps.context.outputs.git_sha }}
@@ -178,12 +228,17 @@ jobs:
         env:
           GIT_SHA: ${{ steps.context.outputs.git_sha }}
           IMAGE_REPOSITORY: ${{ steps.context.outputs.repository }}
+          MLFLOW_REF: ${{ steps.context.outputs.mlflow_ref }}
           PLATFORM_REF: ${{ steps.context.outputs.platform_ref }}
           SERVING_REF: ${{ steps.context.outputs.serving_ref }}
         shell: bash
         run: |
           set -euo pipefail
 
+          mlflow_digest="$(
+            gcloud artifacts docker images describe "${MLFLOW_REF}" \
+              --format='value(image_summary.digest)'
+          )"
           platform_digest="$(
             gcloud artifacts docker images describe "${PLATFORM_REF}" \
               --format='value(image_summary.digest)'
@@ -193,15 +248,20 @@ jobs:
               --format='value(image_summary.digest)'
           )"
 
-          if [[ -z "${platform_digest}" || -z "${serving_digest}" ]]; then
+          if [[ -z "${mlflow_digest}" || -z "${platform_digest}" || -z "${serving_digest}" ]]; then
             echo "Failed to resolve one or more image digests from Artifact Registry."
             exit 1
           fi
 
+          echo "mlflow_digest=${mlflow_digest}" >> "${GITHUB_OUTPUT}"
           echo "platform_digest=${platform_digest}" >> "${GITHUB_OUTPUT}"
           echo "serving_digest=${serving_digest}" >> "${GITHUB_OUTPUT}"
+          echo "mlflow_image=${MLFLOW_REF%@*}@${mlflow_digest}" >> "${GITHUB_OUTPUT}"
+          echo "platform_image=${PLATFORM_REF%@*}@${platform_digest}" >> "${GITHUB_OUTPUT}"
+          echo "serving_image=${SERVING_REF%@*}@${serving_digest}" >> "${GITHUB_OUTPUT}"
 
           export IMAGE_DIGESTS_JSON="${RUNNER_TEMP}/image-digests.json"
+          export MLFLOW_DIGEST="${mlflow_digest}"
           export PLATFORM_DIGEST="${platform_digest}"
           export SERVING_DIGEST="${serving_digest}"
           export IMAGE_GIT_SHA="${GIT_SHA}"
@@ -216,6 +276,11 @@ jobs:
               "repository": os.environ["IMAGE_REPOSITORY"],
               "git_sha": os.environ["IMAGE_GIT_SHA"],
               "images": {
+                  "mlflow": {
+                      "tag": os.environ["IMAGE_GIT_SHA"],
+                      "ref": os.environ["MLFLOW_REF"],
+                      "digest": os.environ["MLFLOW_DIGEST"],
+                  },
                   "platform": {
                       "tag": os.environ["IMAGE_GIT_SHA"],
                       "ref": os.environ["PLATFORM_REF"],
@@ -238,6 +303,8 @@ jobs:
 
       - name: Write workflow summary
         env:
+          MLFLOW_REF: ${{ steps.context.outputs.mlflow_ref }}
+          MLFLOW_DIGEST: ${{ steps.capture.outputs.mlflow_digest }}
           PLATFORM_REF: ${{ steps.context.outputs.platform_ref }}
           PLATFORM_DIGEST: ${{ steps.capture.outputs.platform_digest }}
           SERVING_REF: ${{ steps.context.outputs.serving_ref }}
@@ -250,6 +317,7 @@ jobs:
             echo
             echo "| Image | Ref | Digest |"
             echo "| --- | --- | --- |"
+            echo "| mlflow | \`${MLFLOW_REF}\` | \`${MLFLOW_DIGEST}\` |"
             echo "| platform | \`${PLATFORM_REF}\` | \`${PLATFORM_DIGEST}\` |"
             echo "| serving | \`${SERVING_REF}\` | \`${SERVING_DIGEST}\` |"
             echo

--- a/.github/workflows/run-platform-job-staging.yml
+++ b/.github/workflows/run-platform-job-staging.yml
@@ -1,6 +1,16 @@
 name: Run Platform Job Staging
 
 on:
+  workflow_call:
+    inputs:
+      job_name:
+        description: Deployed Cloud Run job to execute in staging.
+        required: true
+        type: string
+      execution_mode:
+        description: Safe execution mode for the selected job.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       job_name:

--- a/.github/workflows/seed-staging-model.yml
+++ b/.github/workflows/seed-staging-model.yml
@@ -181,18 +181,35 @@ jobs:
             "${PLATFORM_IMAGE}" \
             python -m ml_lifecycle_platform.registry.promote --model-name breast_cancer_clf --format json
 
-      - name: Verify hosted MLflow prod alias exists
+      - name: Run hosted pipeline and register a fresh candidate
         env:
+          PLATFORM_IMAGE: ${{ steps.platform_context.outputs.platform_image }}
+          MLFLOW_URL: ${{ steps.mlflow.outputs.service_url }}
           MLFLOW_TRACKING_TOKEN: ${{ steps.mlflow_token.outputs.id_token }}
-          MLFLOW_TRACKING_URI: ${{ steps.mlflow.outputs.service_url }}
-          MLFLOW_REGISTRY_URI: ${{ steps.mlflow.outputs.service_url }}
         shell: bash
         run: |
           set -euo pipefail
-          uv run python scripts/verify_hosted_model_alias.py \
+          docker run --rm \
+            -e MLP_ENV=staging \
+            -e MLFLOW_TRACKING_URI="${MLFLOW_URL}" \
+            -e MLFLOW_REGISTRY_URI="${MLFLOW_URL}" \
+            -e MLFLOW_TRACKING_TOKEN="${MLFLOW_TRACKING_TOKEN}" \
+            -e MODEL_NAME=breast_cancer_clf \
+            -e MLP_MODEL_SPEC_PATH=configs/models/breast_cancer_demo.yaml \
+            "${PLATFORM_IMAGE}" \
+            python -m ml_lifecycle_platform.pipeline.orchestrate
+
+      - name: Verify hosted release fixture
+        env:
+          MLFLOW_TRACKING_TOKEN: ${{ steps.mlflow_token.outputs.id_token }}
+          MLFLOW_TRACKING_URI: ${{ steps.mlflow.outputs.service_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/verify_hosted_release_fixture.py \
             --tracking-uri "${MLFLOW_TRACKING_URI}" \
             --model-name "breast_cancer_clf" \
-            --alias "prod"
+            --model-spec-path "configs/models/breast_cancer_demo.yaml"
 
       - name: Write workflow summary
         env:
@@ -206,5 +223,5 @@ jobs:
             echo
             echo "- Platform image: \`${PLATFORM_IMAGE}\`"
             echo "- Hosted MLflow: \`${MLFLOW_URL}\`"
-            echo "- Model alias: \`breast_cancer_clf@prod\`"
+            echo "- Fixture: rollback-ready \`breast_cancer_clf@prod\` plus fresh \`breast_cancer_clf@candidate\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/seed-staging-model.yml
+++ b/.github/workflows/seed-staging-model.yml
@@ -1,12 +1,17 @@
 name: Seed Hosted Staging Model
 
 on:
+  workflow_call:
+    inputs:
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the platform image to use for seeding.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
-      git_sha:
-        description: Optional Git SHA for a published platform image. Uses the latest published platform image when empty.
-        required: false
-        default: ""
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the platform image to use for seeding.
+        required: true
         type: string
 
 permissions:
@@ -21,7 +26,6 @@ env:
   GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
   GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
   GCP_REGION: europe-west1
-  ARTIFACT_REGISTRY_REPOSITORY: mlp-images
 
 jobs:
   seed:
@@ -89,44 +93,24 @@ jobs:
           uv sync --frozen --group dev
 
       - id: platform_context
-        name: Resolve published platform image
+        name: Validate platform image input
         env:
-          INPUT_GIT_SHA: ${{ inputs.git_sha }}
+          INPUT_PLATFORM_IMAGE: ${{ inputs.platform_image }}
         shell: bash
         run: |
           set -euo pipefail
 
-          repository="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}"
-          git_sha="${INPUT_GIT_SHA}"
-
-          if [[ -z "${git_sha}" ]]; then
-            git_sha="$(
-              gcloud artifacts docker images list "${repository}/platform" \
-                --include-tags \
-                --sort-by='~updateTime' \
-                --limit=1 \
-                --format='get(tags)'
-            )"
+          platform_image="${INPUT_PLATFORM_IMAGE}"
+          if [[ -z "${platform_image}" ]]; then
+            echo "Provide platform_image as a digest-pinned Artifact Registry ref."
+            exit 1
           fi
-
-          if [[ -z "${git_sha}" ]]; then
-            echo "Could not resolve a published platform image tag."
+          if [[ "${platform_image}" != *@sha256:* ]]; then
+            echo "platform_image must be pinned by digest, for example .../platform@sha256:..."
             exit 1
           fi
 
-          platform_ref="${repository}/platform:${git_sha}"
-          platform_digest="$(
-            gcloud artifacts docker images describe "${platform_ref}" \
-              --format='value(image_summary.digest)'
-          )"
-
-          if [[ -z "${platform_digest}" ]]; then
-            echo "Failed to resolve platform image digest from Artifact Registry."
-            exit 1
-          fi
-
-          echo "git_sha=${git_sha}" >> "${GITHUB_OUTPUT}"
-          echo "platform_image=${platform_ref%@*}@${platform_digest}" >> "${GITHUB_OUTPUT}"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
 
       - id: mlflow
         name: Resolve hosted MLflow service contract
@@ -214,7 +198,6 @@ jobs:
         env:
           PLATFORM_IMAGE: ${{ steps.platform_context.outputs.platform_image }}
           MLFLOW_URL: ${{ steps.mlflow.outputs.service_url }}
-          GIT_SHA: ${{ steps.platform_context.outputs.git_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -222,7 +205,6 @@ jobs:
             echo "## Hosted staging model seeded"
             echo
             echo "- Platform image: \`${PLATFORM_IMAGE}\`"
-            echo "- Git SHA: \`${GIT_SHA}\`"
             echo "- Hosted MLflow: \`${MLFLOW_URL}\`"
             echo "- Model alias: \`breast_cancer_clf@prod\`"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Start here if you want to run or change the local platform.
 - [`runbooks/deploy-mlflow.md`](./runbooks/deploy-mlflow.md): build, deploy, and verify hosted MLflow staging
 - [`runbooks/deploy-serving.md`](./runbooks/deploy-serving.md): deploy the serving API to hosted staging and run authenticated smoke checks
 - [`runbooks/deploy-platform-jobs.md`](./runbooks/deploy-platform-jobs.md): deploy hosted Cloud Run jobs and run them manually
+- [`runbooks/hosted-golden-path.md`](./runbooks/hosted-golden-path.md): run the canonical hosted GCP publish-deploy-validate path
 - [`runbooks/schedule-platform-jobs.md`](./runbooks/schedule-platform-jobs.md): inspect, pause, resume, and verify Cloud Scheduler for hosted jobs
 - [`runbooks/serving-staging-baseline.md`](./runbooks/serving-staging-baseline.md): run the first advisory k6 baseline against hosted serving staging
 - [`runbooks/gcp-ci-auth.md`](./runbooks/gcp-ci-auth.md): verify GitHub Actions OIDC auth into GCP

--- a/docs/architecture/how-it-works.md
+++ b/docs/architecture/how-it-works.md
@@ -158,6 +158,18 @@ Safe hosted proof order:
 4. `rollback` with `dry_run`
 5. `pipeline`
 
+### 5a. Run the canonical hosted golden path
+
+Use:
+
+- [`../runbooks/hosted-golden-path.md`](../runbooks/hosted-golden-path.md)
+
+This is the one-button hosted path that:
+
+- publishes images once
+- deploys MLflow, serving, and platform jobs by digest
+- validates the staged hosted flow end to end
+
 ### 6. Inspect or operate scheduler
 
 Use:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,12 +12,12 @@ The repo has fifteen lanes:
 | `GCP Auth Verify` | push to `master`, manual dispatch | GitHub OIDC to GCP WIF verification plus hosted-foundation prerequisite checks |
 | `Publish Images` | called from `CI` on push to `master`, manual dispatch | builds, smoke-checks, and publishes hosted runtime images to Artifact Registry |
 | `Deploy MLflow Staging` | manual dispatch and reusable workflow call | deploys hosted MLflow from a digest-pinned image and runs authenticated smoke checks |
-| `Seed Hosted Staging Model` | manual dispatch and reusable workflow call | runs the demo pipeline against hosted MLflow staging from a digest-pinned platform image, registers a candidate, and promotes it to `prod` |
+| `Seed Hosted Staging Model` | manual dispatch and reusable workflow call | creates a deterministic hosted release fixture from a digest-pinned platform image: rollback-ready `prod` plus a fresh promotable `candidate` |
 | `Deploy Serving Staging` | manual dispatch and reusable workflow call | deploys hosted serving from a digest-pinned image and runs authenticated smoke checks |
 | `Serving Staging Baseline` | manual dispatch | runs an advisory k6 baseline against the direct hosted serving staging URL and uploads artifacts |
 | `Deploy Platform Jobs Staging` | manual dispatch and reusable workflow call | deploys hosted Cloud Run Jobs from a digest-pinned platform image and preserves the current MLflow/serving images |
 | `Run Platform Job Staging` | manual dispatch and reusable workflow call | executes one deployed Cloud Run Job in staging with an optional args override |
-| `Hosted Golden Path Staging` | manual dispatch | runs the canonical hosted publish-deploy-validate path end to end |
+| `Hosted Golden Path Staging` | manual dispatch | runs the canonical hosted publish-deploy-validate path end to end, including explicit staging fixture preparation |
 | `E2E` | nightly and manual dispatch | dockerized golden path |
 
 ## Local mapping
@@ -235,6 +235,8 @@ Recommended first hosted proofs:
 - `rollback --dry-run`
 
 Only after those are boring should operators move on to the mutating paths such as `pipeline` or an actual rollback.
+
+For a deterministic full hosted check, use `Hosted Golden Path Staging`. That workflow seeds a rollback-ready `prod` plus a distinct promotable `candidate` before it runs the dry-run checks.
 
 ## Deploy workflow troubleshooting
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,6 @@
 # CI
 
-The repo has fourteen lanes:
+The repo has fifteen lanes:
 
 | Lane | Trigger | Purpose |
 | --- | --- | --- |
@@ -11,12 +11,13 @@ The repo has fourteen lanes:
 | `Zizmor` | pull requests, push to `master`, weekly, manual dispatch | GitHub Actions security lint and SARIF upload |
 | `GCP Auth Verify` | push to `master`, manual dispatch | GitHub OIDC to GCP WIF verification plus hosted-foundation prerequisite checks |
 | `Publish Images` | called from `CI` on push to `master`, manual dispatch | builds, smoke-checks, and publishes hosted runtime images to Artifact Registry |
-| `Deploy MLflow Staging` | manual dispatch | builds the hosted MLflow image, deploys Cloud Run staging by digest, and runs authenticated smoke checks |
-| `Seed Hosted Staging Model` | manual dispatch | runs the demo pipeline against hosted MLflow staging, registers a candidate, and promotes it to `prod` |
-| `Deploy Serving Staging` | manual dispatch | resolves a published serving image by SHA, deploys Cloud Run staging by digest, and runs authenticated smoke checks |
+| `Deploy MLflow Staging` | manual dispatch and reusable workflow call | deploys hosted MLflow from a digest-pinned image and runs authenticated smoke checks |
+| `Seed Hosted Staging Model` | manual dispatch and reusable workflow call | runs the demo pipeline against hosted MLflow staging from a digest-pinned platform image, registers a candidate, and promotes it to `prod` |
+| `Deploy Serving Staging` | manual dispatch and reusable workflow call | deploys hosted serving from a digest-pinned image and runs authenticated smoke checks |
 | `Serving Staging Baseline` | manual dispatch | runs an advisory k6 baseline against the direct hosted serving staging URL and uploads artifacts |
-| `Deploy Platform Jobs Staging` | manual dispatch | resolves a published platform image by SHA, deploys Cloud Run Jobs by digest, and preserves the current MLflow/serving images |
-| `Run Platform Job Staging` | manual dispatch | executes one deployed Cloud Run Job in staging with an optional args override |
+| `Deploy Platform Jobs Staging` | manual dispatch and reusable workflow call | deploys hosted Cloud Run Jobs from a digest-pinned platform image and preserves the current MLflow/serving images |
+| `Run Platform Job Staging` | manual dispatch and reusable workflow call | executes one deployed Cloud Run Job in staging with an optional args override |
+| `Hosted Golden Path Staging` | manual dispatch | runs the canonical hosted publish-deploy-validate path end to end |
 | `E2E` | nightly and manual dispatch | dockerized golden path |
 
 ## Local mapping
@@ -85,6 +86,7 @@ Trigger model:
 
 Published image refs:
 
+- `europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/mlflow:<git-sha>`
 - `europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/platform:<git-sha>`
 - `europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/serving:<git-sha>`
 
@@ -93,8 +95,9 @@ Contract:
 - only immutable Git SHA tags are published
 - each image is built once, smoke-tested locally in CI, then that same image is pushed
 - digests are captured after push and recorded in both the workflow summary and `image-digests.json`
+- reusable workflow outputs expose digest-pinned image refs for downstream deploy workflows
 
-Downstream deploy workflows should consume digests, not tags. Treat tags as discovery aids and digests as the deploy contract.
+Downstream deploy workflows should consume digest-pinned image refs, not tags. Treat tags as discovery aids, Artifact Registry digests as the source of truth, and `image-digests.json` as the operator/debug artifact.
 
 Expected artifact shape:
 
@@ -104,6 +107,11 @@ Expected artifact shape:
   "repository": "europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images",
   "git_sha": "<sha>",
   "images": {
+    "mlflow": {
+      "tag": "<sha>",
+      "ref": ".../mlflow:<sha>",
+      "digest": "sha256:..."
+    },
     "platform": {
       "tag": "<sha>",
       "ref": ".../platform:<sha>",
@@ -127,9 +135,8 @@ Hosted MLflow staging deploy lives in:
 Current shape:
 
 - manual `workflow_dispatch`
-- builds the hosted MLflow image from `deployments/gcp/mlflow/`
-- pushes `mlflow:<git-sha>` to Artifact Registry
-- applies Terraform with the resolved image digest
+- consumes a digest-pinned `mlflow_image` from `Publish Images`
+- applies Terraform with that image and preserves the current serving/platform images
 - verifies the deployed service with an authenticated MLflow smoke script
 - mints the Cloud Run verification token with `google-github-actions/auth`
 
@@ -155,10 +162,9 @@ Hosted serving staging deploy lives in:
 Current shape:
 
 - manual `workflow_dispatch`
-- takes a required `git_sha` input
-- resolves the published `serving:<git-sha>` image from Artifact Registry
+- takes a required digest-pinned `serving_image` input
 - preserves the current hosted MLflow image input when applying the shared Terraform root
-- applies Terraform with the resolved serving image digest
+- applies Terraform with the provided serving image
 - verifies the deployed service with authenticated smoke checks
 - mints the Cloud Run verification token with `google-github-actions/auth`
 
@@ -209,7 +215,7 @@ Hosted platform jobs live in:
 Current shape:
 
 - deploy workflow is manual `workflow_dispatch`
-- deploy resolves `platform:<git-sha>` from Artifact Registry by digest
+- deploy takes a required digest-pinned `platform_image` input
 - deploy preserves the current hosted MLflow and serving image inputs when applying the shared Terraform root
 - run executes one named Cloud Run Job in staging
 

--- a/docs/reference/release-contract.md
+++ b/docs/reference/release-contract.md
@@ -53,8 +53,7 @@ Artifact path:
 
 Source of truth:
 
-- `Publish Images` workflow
-- `image-digests.json` artifact
+- Artifact Registry digests produced by `Publish Images`
 
 Purpose:
 
@@ -62,6 +61,7 @@ Purpose:
 
 Current published image names:
 
+- `mlflow`
 - `platform`
 - `serving`
 
@@ -73,7 +73,9 @@ Current publish rule:
 
 - publish immutable Git SHA tags only
 - capture remote digests after push
-- downstream deploys should use digests, not tags
+- downstream deploys should use digest-pinned image refs, not tags
+- reusable workflow outputs are the normal transport path
+- `image-digests.json` is the human/debug artifact, not the primary deploy contract
 
 ## Current contract
 
@@ -140,7 +142,9 @@ It is not the same as:
 
 Today and going forward:
 
-- consume `image-digests.json` for container identity
+- consume Artifact Registry image refs pinned by digest for container identity
+- use reusable workflow outputs as the normal transport path between publish and deploy workflows
+- keep `image-digests.json` as the operator/debug artifact
 - consume MLflow aliases and model versions for model identity
 - do not deploy from mutable tags
 - do not infer model rollout from package release versions

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -113,10 +113,11 @@ Hosted runtime images are published by the `Publish Images` workflow described i
 
 Current published image contracts:
 
+- `mlflow`
 - `platform`
 - `serving`
 
-Deploy workflows should consume image digests from the `image-digests.json` artifact, not mutable tags.
+Deploy workflows should consume Artifact Registry image refs pinned by digest as the normal contract. `image-digests.json` remains the operator/debug artifact.
 
 This is separate from model release state:
 

--- a/docs/runbooks/deploy-mlflow.md
+++ b/docs/runbooks/deploy-mlflow.md
@@ -6,9 +6,8 @@ This runbook covers the hosted MLflow staging deploy path added in `UP-17`.
 
 Current scope:
 
-- build the hosted MLflow image from committed source
-- push the image to Artifact Registry
 - deploy Cloud Run service `mlp-mlflow-staging`
+- consume a prebuilt digest-pinned MLflow image
 - use Cloud SQL as the backend store
 - use GCS through MLflow artifact proxying
 - verify the service with an authenticated smoke test
@@ -78,15 +77,17 @@ Run the GitHub Actions workflow:
 What it does:
 
 1. authenticate to GCP with WIF
-2. build the hosted MLflow image from `deployments/gcp/mlflow/`
-3. push `mlflow:<git-sha>` to Artifact Registry
-4. resolve the pushed digest
-5. apply Terraform with `TF_VAR_mlflow_image=<ref@sha256:...>`
+2. validate the provided `mlflow_image` Artifact Registry ref pinned by digest
+3. apply Terraform with `TF_VAR_mlflow_image=<ref@sha256:...>`
    and preserve:
    - `TF_VAR_serving_image=<current-serving-ref@sha256:...>`
    - `TF_VAR_platform_image=<current-platform-ref@sha256:...>`
-6. mint an identity token for the Cloud Run URL
-7. verify authenticated MLflow metadata and artifact writes
+4. mint an identity token for the Cloud Run URL
+5. verify authenticated MLflow metadata and artifact writes
+
+Operator input:
+
+- `mlflow_image`: digest-pinned Artifact Registry ref from `Publish Images`
 
 Important auth note:
 

--- a/docs/runbooks/deploy-platform-jobs.md
+++ b/docs/runbooks/deploy-platform-jobs.md
@@ -56,19 +56,18 @@ Run the GitHub Actions workflow:
 
 Input:
 
-- optional `git_sha`
-  - when empty, the workflow uses the selected workflow commit SHA
-  - that SHA must already be published by `Publish Images` as `platform:<sha>`
+- required `platform_image`
+  - digest-pinned Artifact Registry ref published by `Publish Images`
 
 What it does:
 
 1. authenticate to GCP with WIF
-2. resolve the published `platform` image by digest
+2. validate the provided digest-pinned `platform_image`
 3. resolve the current hosted MLflow and serving images
 4. apply Terraform with:
    - `TF_VAR_mlflow_image=<current-mlflow-ref@sha256:...>`
    - `TF_VAR_serving_image=<current-serving-ref@sha256:...>`
-   - `TF_VAR_platform_image=<platform-ref@sha256:...>`
+   - `TF_VAR_platform_image=<provided-platform-ref@sha256:...>`
 
 The workflow preserves MLflow and serving because all three runtime paths still share one Terraform root.
 

--- a/docs/runbooks/deploy-platform-jobs.md
+++ b/docs/runbooks/deploy-platform-jobs.md
@@ -94,6 +94,17 @@ Inputs:
 
 Recommended validation order:
 
+If you want a deterministic hosted validation fixture first, run:
+
+- `Seed Hosted Staging Model`
+
+That workflow leaves staging with:
+
+- a rollback-ready `prod`
+- a fresh distinct `candidate`
+
+Then run:
+
 1. `maintenance`
 2. `reproduce`
 3. `promote` with `execution_mode=dry_run`

--- a/docs/runbooks/deploy-serving.md
+++ b/docs/runbooks/deploy-serving.md
@@ -6,8 +6,8 @@ This runbook covers the hosted serving staging deploy path added in `UP-18`.
 
 Current scope:
 
-- resolve a published `serving` image by immutable Git SHA
 - deploy Cloud Run service `mlp-serving-staging` by digest
+- consume a prebuilt digest-pinned serving image
 - point serving at the hosted MLflow staging service
 - require IAM-authenticated access
 - verify the service with authenticated smoke tests
@@ -66,16 +66,16 @@ Run the GitHub Actions workflow:
 
 Required input:
 
-- `git_sha`: the immutable SHA tag published by `Publish Images`
+- `serving_image`: digest-pinned Artifact Registry ref published by `Publish Images`
 
 What it does:
 
 1. authenticate to GCP with WIF
-2. resolve `serving:<git-sha>` from Artifact Registry
+2. validate the provided digest-pinned `serving_image`
 3. resolve the current hosted MLflow image from Terraform output
 4. apply Terraform with:
    - `TF_VAR_mlflow_image=<current-mlflow-ref@sha256:...>`
-   - `TF_VAR_serving_image=<serving-ref@sha256:...>`
+   - `TF_VAR_serving_image=<provided-serving-ref@sha256:...>`
    - `TF_VAR_platform_image=<current-platform-ref@sha256:...>`
 5. mint an identity token for the serving service URL
 6. run authenticated smoke checks for:
@@ -151,7 +151,7 @@ If you need a staged performance reference, run the `Serving Staging Baseline` w
 | serving apply updates MLflow unexpectedly | shared Terraform root missing current MLflow image input | keep resolving `mlflow_service.image` before apply |
 | `/health` works but `/predict` fails | no `prod` alias in staged MLflow | register the model and assign `prod` before rerunning |
 | metadata endpoints work but model loading fails | serving cannot call hosted MLflow | check `MLFLOW_CLOUD_RUN_AUDIENCE` and `mlp-runtime` `run.invoker` on `mlp-mlflow-staging` |
-| deploy workflow cannot resolve serving digest | image was not published for that SHA | rerun `Publish Images` or use the correct `git_sha` |
+| deploy workflow cannot resolve serving image | wrong image ref or image was not published | rerun `Publish Images` and use the digest-pinned `serving_image` output |
 | response schema or prediction payload fails | model spec drift | check `MODEL_NAME` and `MLP_MODEL_SPEC_PATH` against the registered model |
 
 ## Expected success state

--- a/docs/runbooks/hosted-golden-path.md
+++ b/docs/runbooks/hosted-golden-path.md
@@ -1,0 +1,94 @@
+# Hosted Golden Path Staging
+
+Last verified: 2026-03-20
+
+This runbook covers the canonical hosted end-to-end validation path for staging.
+
+Current scope:
+
+- publish hosted runtime images once
+- deploy MLflow, serving, and platform jobs from digest-pinned Artifact Registry refs
+- validate the staged hosted path in one documented order
+
+Out of scope here:
+
+- package release management
+- production rollout
+- Cloud Deploy adoption
+
+## Contract
+
+Runtime release identity:
+
+- Artifact Registry image refs pinned by digest
+- `Publish Images` is the only image producer
+
+Transport path:
+
+- reusable workflow outputs are the normal deploy path
+- `image-digests.json` remains the human/debug artifact
+
+Model-state boundary:
+
+- image deploy chooses the runtime container
+- MLflow alias state chooses the served model
+- do not collapse those two release identities
+
+## Canonical order
+
+Run the GitHub Actions workflow:
+
+- `Hosted Golden Path Staging`
+
+What it does:
+
+1. runs `Publish Images`
+2. deploys hosted MLflow staging
+3. deploys hosted serving staging
+4. deploys hosted platform jobs staging
+5. checks the staged `prod` alias precondition
+6. runs hosted `maintenance`
+7. runs hosted `reproduce`
+8. runs hosted `promote` in `dry_run`
+9. runs hosted `rollback` in `dry_run`
+10. runs hosted `pipeline`
+11. runs hosted serving smoke validation
+
+## Important precondition
+
+The hosted golden path does not silently seed staged MLflow model state.
+
+If hosted MLflow does not currently resolve:
+
+- `breast_cancer_clf@prod`
+
+the golden path fails with an explicit message and points the operator to:
+
+- `Seed Hosted Staging Model`
+
+That is intentional.
+Model-state bootstrapping should stay explicit instead of being hidden inside serving deploy or the hosted golden path.
+
+## Expected success state
+
+After a good hosted golden-path run you should have:
+
+- one source Git SHA
+- one digest-pinned MLflow image
+- one digest-pinned serving image
+- one digest-pinned platform image
+- hosted MLflow reachable
+- hosted serving reachable
+- hosted platform jobs runnable
+- one workflow summary showing the end-to-end pass/fail state
+
+## Failure interpretation
+
+Treat these as different failures:
+
+- deploy failure: runtime did not roll out correctly
+- runtime regression: deployed service or job behavior is broken
+- model-state-precondition failure: staged alias state was not ready
+- expected policy-blocked dry-run: promotion or rollback dry-run returned a safe policy block
+
+Do not treat those as the same incident.

--- a/docs/runbooks/hosted-golden-path.md
+++ b/docs/runbooks/hosted-golden-path.md
@@ -46,7 +46,7 @@ What it does:
 2. deploys hosted MLflow staging
 3. deploys hosted serving staging
 4. deploys hosted platform jobs staging
-5. checks the staged `prod` alias precondition
+5. runs `Seed Hosted Staging Model` to create a deterministic hosted release fixture
 6. runs hosted `maintenance`
 7. runs hosted `reproduce`
 8. runs hosted `promote` in `dry_run`
@@ -54,20 +54,24 @@ What it does:
 10. runs hosted `pipeline`
 11. runs hosted serving smoke validation
 
-## Important precondition
+## Deterministic Fixture
 
-The hosted golden path does not silently seed staged MLflow model state.
+The hosted golden path now prepares staged model state explicitly.
 
-If hosted MLflow does not currently resolve:
+`Seed Hosted Staging Model` is an explicit workflow stage. It is not hidden inside MLflow deploy, serving deploy, or Terraform apply.
 
-- `breast_cancer_clf@prod`
+That stage leaves staging with:
 
-the golden path fails with an explicit message and points the operator to:
+- `breast_cancer_clf@prod` pointing to a promoted version with rollback metadata
+- `breast_cancer_clf@candidate` pointing to a newer distinct version
+- a candidate that already satisfies the configured promotion policy
 
-- `Seed Hosted Staging Model`
+This is the state required for both:
 
-That is intentional.
-Model-state bootstrapping should stay explicit instead of being hidden inside serving deploy or the hosted golden path.
+- `promote --dry-run`
+- `rollback --dry-run`
+
+to be stable golden-path checks instead of depending on whatever staging history was already there.
 
 ## Expected success state
 
@@ -80,6 +84,8 @@ After a good hosted golden-path run you should have:
 - hosted MLflow reachable
 - hosted serving reachable
 - hosted platform jobs runnable
+- `@prod` rollback-ready
+- `@candidate` distinct from `@prod` and promotable
 - one workflow summary showing the end-to-end pass/fail state
 
 ## Failure interpretation
@@ -88,7 +94,7 @@ Treat these as different failures:
 
 - deploy failure: runtime did not roll out correctly
 - runtime regression: deployed service or job behavior is broken
-- model-state-precondition failure: staged alias state was not ready
+- fixture-preparation failure: the hosted release fixture was not created correctly
 - expected policy-blocked dry-run: promotion or rollback dry-run returned a safe policy block
 
 Do not treat those as the same incident.

--- a/scripts/verify_hosted_release_fixture.py
+++ b/scripts/verify_hosted_release_fixture.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify that hosted MLflow exposes a rollback-ready prod and a distinct "
+            "promotable candidate."
+        )
+    )
+    parser.add_argument("--tracking-uri", required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--model-spec-path", required=True)
+    return parser
+
+
+def main() -> int:
+    from ml_lifecycle_platform.ci.hosted_release_fixture_verifier import (
+        HostedReleaseFixtureVerificationConfig,
+        VerificationError,
+        verify_release_fixture,
+    )
+
+    tracking_token = os.getenv("MLFLOW_TRACKING_TOKEN", "").strip()
+    if not tracking_token:
+        print(
+            "MLFLOW_TRACKING_TOKEN must be set for hosted release fixture verification.",
+            file=sys.stderr,
+        )
+        return 2
+
+    args = build_parser().parse_args()
+    config = HostedReleaseFixtureVerificationConfig(
+        tracking_uri=args.tracking_uri,
+        tracking_token=tracking_token,
+        model_name=args.model_name,
+        model_spec_path=args.model_spec_path,
+    )
+    try:
+        fixture = verify_release_fixture(config)
+    except VerificationError as error:
+        print(f"Hosted release fixture verification failed: {error}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(fixture, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ml_lifecycle_platform/ci/hosted_release_fixture_verifier.py
+++ b/src/ml_lifecycle_platform/ci/hosted_release_fixture_verifier.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import mlflow
+from mlflow import MlflowClient
+
+from ml_lifecycle_platform.core.model_specs import load_model_spec
+from ml_lifecycle_platform.policy.release_policy import evaluate_promotion_policy
+from ml_lifecycle_platform.registry.rollback import _resolve_rollback_target
+
+
+class VerificationError(RuntimeError):
+    """Raised when hosted MLflow is missing the expected release fixture."""
+
+
+@dataclass(frozen=True)
+class HostedReleaseFixtureVerificationConfig:
+    tracking_uri: str
+    tracking_token: str
+    model_name: str
+    model_spec_path: str
+
+
+def verify_release_fixture(
+    config: HostedReleaseFixtureVerificationConfig,
+) -> dict[str, str]:
+    if not config.tracking_token.strip():
+        raise VerificationError("hosted MLflow verification requires a tracking token.")
+
+    mlflow.set_tracking_uri(config.tracking_uri)
+    client = MlflowClient()
+    model_spec = load_model_spec(config.model_spec_path)
+
+    decision = evaluate_promotion_policy(
+        client,
+        config.model_name,
+        policy=model_spec.policy,
+    )
+    if not decision.allowed:
+        raise VerificationError(
+            "hosted release fixture is not promotable: "
+            f"{json.dumps(decision.to_dict(), sort_keys=True)}"
+        )
+
+    try:
+        current_prod, rollback_target_version, _, _, resolution_source = (
+            _resolve_rollback_target(client, model_name=config.model_name)
+        )
+    except RuntimeError as error:
+        raise VerificationError(
+            f"hosted release fixture is not rollback-ready: {error}"
+        ) from error
+
+    candidate_version = str(decision.context.get("candidate_version", "")).strip()
+    current_prod_version = str(decision.context.get("current_prod_version", "")).strip()
+    if not candidate_version or not current_prod_version:
+        raise VerificationError(
+            "hosted release fixture returned empty candidate/prod versions."
+        )
+
+    return {
+        "candidate_version": candidate_version,
+        "current_prod_version": current_prod_version,
+        "rollback_target_version": rollback_target_version,
+        "rollback_resolution_source": resolution_source,
+        "current_prod_alias_version": str(current_prod.version),
+    }

--- a/tests/unit/test_hosted_release_fixture_verifier.py
+++ b/tests/unit/test_hosted_release_fixture_verifier.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from ml_lifecycle_platform.ci.hosted_release_fixture_verifier import (
+    HostedReleaseFixtureVerificationConfig,
+    VerificationError,
+    verify_release_fixture,
+)
+from ml_lifecycle_platform.core.policy_engine import PolicyDecision, Violation
+
+pytestmark = pytest.mark.unit
+
+
+def test_verify_release_fixture_returns_versions_when_fixture_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, tuple[object, ...]]] = []
+
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.mlflow.set_tracking_uri",
+        lambda uri: calls.append(("set_tracking_uri", (uri,))),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.MlflowClient",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.load_model_spec",
+        lambda path: SimpleNamespace(policy="policy", spec_path=path),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.evaluate_promotion_policy",
+        lambda client, model_name, policy: PolicyDecision(
+            allowed=True,
+            errors=(),
+            warnings=(),
+            context={
+                "candidate_version": "4",
+                "current_prod_version": "3",
+                "model_name": model_name,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier._resolve_rollback_target",
+        lambda client, model_name: (
+            SimpleNamespace(version="3"),
+            "2",
+            None,
+            None,
+            "manifest",
+        ),
+    )
+
+    fixture = verify_release_fixture(
+        HostedReleaseFixtureVerificationConfig(
+            tracking_uri="https://mlflow.example.run.app",
+            tracking_token="token",
+            model_name="breast_cancer_clf",
+            model_spec_path="configs/models/breast_cancer_demo.yaml",
+        )
+    )
+
+    assert fixture == {
+        "candidate_version": "4",
+        "current_prod_version": "3",
+        "rollback_target_version": "2",
+        "rollback_resolution_source": "manifest",
+        "current_prod_alias_version": "3",
+    }
+    assert ("set_tracking_uri", ("https://mlflow.example.run.app",)) in calls
+
+
+def test_verify_release_fixture_fails_when_promotion_would_be_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.mlflow.set_tracking_uri",
+        lambda uri: None,
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.MlflowClient",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.load_model_spec",
+        lambda path: SimpleNamespace(policy="policy", spec_path=path),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.evaluate_promotion_policy",
+        lambda client, model_name, policy: PolicyDecision(
+            allowed=False,
+            errors=(
+                Violation(
+                    code="NOOP_PROMOTION",
+                    message="Promotion blocked: candidate is already the current prod version.",
+                    details={"candidate_version": "3", "current_prod_version": "3"},
+                ),
+            ),
+            warnings=(),
+            context={"candidate_version": "3", "current_prod_version": "3"},
+        ),
+    )
+
+    with pytest.raises(VerificationError, match="not promotable"):
+        verify_release_fixture(
+            HostedReleaseFixtureVerificationConfig(
+                tracking_uri="https://mlflow.example.run.app",
+                tracking_token="token",
+                model_name="breast_cancer_clf",
+                model_spec_path="configs/models/breast_cancer_demo.yaml",
+            )
+        )
+
+
+def test_verify_release_fixture_fails_when_rollback_target_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.mlflow.set_tracking_uri",
+        lambda uri: None,
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.MlflowClient",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.load_model_spec",
+        lambda path: SimpleNamespace(policy="policy", spec_path=path),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier.evaluate_promotion_policy",
+        lambda client, model_name, policy: PolicyDecision(
+            allowed=True,
+            errors=(),
+            warnings=(),
+            context={"candidate_version": "4", "current_prod_version": "3"},
+        ),
+    )
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.hosted_release_fixture_verifier._resolve_rollback_target",
+        lambda client, model_name: (_ for _ in ()).throw(
+            RuntimeError(
+                "Rollback blocked: current prod does not have a previous prod recorded."
+            )
+        ),
+    )
+
+    with pytest.raises(VerificationError, match="not rollback-ready"):
+        verify_release_fixture(
+            HostedReleaseFixtureVerificationConfig(
+                tracking_uri="https://mlflow.example.run.app",
+                tracking_token="token",
+                model_name="breast_cancer_clf",
+                model_spec_path="configs/models/breast_cancer_demo.yaml",
+            )
+        )

--- a/tests/unit/test_verify_hosted_release_fixture_script.py
+++ b/tests/unit/test_verify_hosted_release_fixture_script.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_hosted_release_fixture.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_hosted_release_fixture_script", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_returns_2_when_tracking_token_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+    monkeypatch.delenv("MLFLOW_TRACKING_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "verify_hosted_release_fixture.py",
+            "--tracking-uri",
+            "https://mlflow.example.run.app",
+            "--model-name",
+            "breast_cancer_clf",
+            "--model-spec-path",
+            "configs/models/breast_cancer_demo.yaml",
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 2
+    assert "MLFLOW_TRACKING_TOKEN must be set" in capsys.readouterr().err
+
+
+def test_main_returns_0_when_release_fixture_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+    monkeypatch.setenv("MLFLOW_TRACKING_TOKEN", "token-123")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "verify_hosted_release_fixture.py",
+            "--tracking-uri",
+            "https://mlflow.example.run.app",
+            "--model-name",
+            "breast_cancer_clf",
+            "--model-spec-path",
+            "configs/models/breast_cancer_demo.yaml",
+        ],
+    )
+
+    from ml_lifecycle_platform.ci import (
+        hosted_release_fixture_verifier as verifier,
+    )
+
+    monkeypatch.setattr(
+        verifier,
+        "verify_release_fixture",
+        lambda config: {
+            "candidate_version": "4",
+            "current_prod_version": "3",
+            "rollback_target_version": "2",
+            "rollback_resolution_source": "manifest",
+            "current_prod_alias_version": "3",
+        },
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 0
+    assert '"candidate_version": "4"' in capsys.readouterr().out


### PR DESCRIPTION
## What

This PR implements the hosted Cloud golden path for staging and closes #130.

It finishes the move to a build-once, deploy-by-digest hosted contract and adds a deterministic end-to-end validation path for GCP staging.

Changes in this PR:

- adds a canonical `Hosted Golden Path Staging` workflow that runs the full hosted path in one order
- makes hosted staging fixture preparation explicit instead of relying on whatever MLflow alias state already exists
- updates `Seed Hosted Staging Model` to create a rollback-ready `prod` and a fresh distinct promotable `candidate`
- adds a hosted release fixture verifier plus focused unit tests
- updates hosted runbooks and CI docs to document the canonical cloud path and its invariants

## Why

Closes #130.

The hosted path previously had two problems:

1. deploy identity and validation were getting stronger, but the end-to-end cloud path still depended on mutable staging MLflow state
2. `promote --dry-run` and `rollback --dry-run` were not stable golden-path checks unless staging already happened to be in the right alias/tag state

That is not a reliable operator contract.

This change makes the hosted path deterministic and closer to the expected SWE standard for MLE/platform infrastructure:

- build once
- deploy immutable artifacts
- prepare known-good staged state explicitly
- validate the hosted path end to end in one documented order

## How

Key implementation decisions:

- keep runtime release identity and model-state identity separate
  - runtime rollout is still driven by digest-pinned Artifact Registry refs
  - model-state preparation is now an explicit workflow stage

- make staged MLflow fixture preparation deterministic
  - run hosted pipeline to register a candidate
  - promote that candidate to `prod`
  - run hosted pipeline again to create a fresh candidate
  - verify that staging now has:
    - rollback-ready `prod`
    - distinct promotable `candidate`

- add an explicit verifier instead of a shallow alias-exists check
  - the new verifier checks that promotion policy would allow `promote --dry-run`
  - it also checks that rollback metadata exists for `rollback --dry-run`

- wire the hosted workflow in canonical order
  1. publish images
  2. deploy MLflow
  3. deploy serving
  4. deploy platform jobs
  5. seed deterministic staging fixture
  6. maintenance
  7. reproduce
  8. promote dry run
  9. rollback dry run
  10. pipeline
  11. serving smoke

Trade-off:
- the seed workflow now does more work up front, but that is the right trade for a golden path because it removes flaky dependence on prior staging history.

## Testing

- [x] Unit
- [x] Integration / E2E
- [x] Manual (describe)

Manual:
- ran local `make e2e-clean`
- ran targeted unit tests for the hosted fixture verifier and CLI script
- ran `pre-commit` on the touched files
- ran docs link checks
- verified the hosted workflow structure and documented execution order

Hosted validation to run on this branch:
- `Hosted Golden Path Staging`

## Risk

Main risk is staged model-state churn.

This PR intentionally changes how hosted staging model aliases are prepared before validation. If the seed workflow is wrong, the likely failure mode is:

- `promote --dry-run` becomes policy-blocked
- `rollback --dry-run` cannot resolve a rollback target
- hosted golden-path staging fails in the seed or dry-run phases

This should not affect local OSS flows and should not change production behavior.

The runtime deploy contract is unchanged in principle:
- hosted deploys still consume digest-pinned images
- this PR mainly strengthens the hosted staging validation path and its preconditions

## Rollback

Rollback options:

1. revert this PR commit and re-run the previous hosted staging workflows independently
2. if only the hosted fixture logic is problematic, skip `Hosted Golden Path Staging` and use the existing individual staging workflows:
   - `Publish Images`
   - `Deploy MLflow Staging`
   - `Deploy Serving Staging`
   - `Deploy Platform Jobs Staging`
   - `Run Platform Job Staging`
3. if staging model state is left in a bad validation shape, re-run `Seed Hosted Staging Model` from a known-good platform image or restore aliases manually in hosted MLflow
