### PR TITLE
fix: shorten workflow names for README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI / Presubmit and Postsubmit
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: CI / Local E2E
+name: Local E2E
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/hosted-golden-path-staging.yml
+++ b/.github/workflows/hosted-golden-path-staging.yml
@@ -1,4 +1,4 @@
-name: CD / Release Validation / Staging
+name: Staging Verification
 
 run-name: staging release validation / ${{ github.event_name }} / ${{ github.ref_name }}
 


### PR DESCRIPTION
## Summary
Shorten the top-level workflow names so the README badges so they show as `CI`, `Local E2E`, and `Staging Verification`.

## Why
The previous names were too long for the README and made the badge row harder to scan.

## Testing
- [x] Manual
