### PR TITLE
fix: retry MLflow staging health probe and drop Cloud Run cold-start flakes

### DIFF
--- a/src/ml_lifecycle_platform/ci/mlflow_staging_verifier.py
+++ b/src/ml_lifecycle_platform/ci/mlflow_staging_verifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import Path
 import tempfile
@@ -7,6 +8,7 @@ import tempfile
 import mlflow
 from mlflow import MlflowClient
 import requests
+from requests.exceptions import RequestException
 
 
 class VerificationError(RuntimeError):
@@ -23,16 +25,47 @@ class MlflowStagingVerificationConfig:
     artifact_body: str = "mlflow staging smoke\n"
 
 
+# Cloud Run scale-to-zero: absorb MLflow cold starts, fail fast on auth errors.
+_RETRY_DELAYS_SECONDS = (0, 5, 15, 45)
+_REQUEST_TIMEOUT_SECONDS = 30
+
+
 def verify_http_reachable(config: MlflowStagingVerificationConfig) -> None:
-    response = requests.get(
-        config.tracking_uri.rstrip("/") + "/",
-        headers={"Authorization": f"Bearer {config.tracking_token}"},
-        timeout=15,
-    )
-    if response.status_code != 200:
+    url = config.tracking_uri.rstrip("/") + "/health"
+    headers = {"Authorization": f"Bearer {config.tracking_token}"}
+
+    last_error: Exception | None = None
+    last_status: int | None = None
+
+    for delay in _RETRY_DELAYS_SECONDS:
+        if delay:
+            time.sleep(delay)
+        try:
+            response = requests.get(
+                url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS
+            )
+        except RequestException as error:
+            last_error = error
+            continue
+        if response.status_code == 200:
+            return
+        if response.status_code in (401, 403):
+            raise VerificationError(
+                f"MLflow staging at {url} returned {response.status_code}; "
+                "check tracking token."
+            )
+        last_status = response.status_code
+        last_error = None
+
+    if last_error is not None:
         raise VerificationError(
-            f"expected authenticated GET / to return 200, got {response.status_code}."
-        )
+            f"MLflow staging at {url} unreachable after "
+            f"{len(_RETRY_DELAYS_SECONDS)} attempts: {last_error}"
+        ) from last_error
+    raise VerificationError(
+        f"MLflow staging at {url} returned {last_status} after "
+        f"{len(_RETRY_DELAYS_SECONDS)} attempts."
+    )
 
 
 def verify_mlflow_roundtrip(config: MlflowStagingVerificationConfig) -> str:

--- a/tests/unit/test_mlflow_staging_verifier.py
+++ b/tests/unit/test_mlflow_staging_verifier.py
@@ -3,14 +3,24 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from requests.exceptions import ReadTimeout
 
 from ml_lifecycle_platform.ci.mlflow_staging_verifier import (
     MlflowStagingVerificationConfig,
     VerificationError,
+    verify_http_reachable,
     verify_staging,
 )
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.mlflow_staging_verifier.time.sleep",
+        lambda _seconds: None,
+    )
 
 
 def test_verify_staging_checks_http_and_mlflow_roundtrip(
@@ -82,15 +92,22 @@ def test_verify_staging_checks_http_and_mlflow_roundtrip(
     assert any(name == "log_artifact" for name, _ in calls)
 
 
-def test_verify_staging_fails_on_http_error(
+def test_verify_http_reachable_fails_fast_on_auth_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _Response:
         status_code = 403
 
+    calls: list[str] = []
+
+    def _fake_get(url: str, *args: object, **kwargs: object) -> _Response:
+        del args, kwargs
+        calls.append(url)
+        return _Response()
+
     monkeypatch.setattr(
         "ml_lifecycle_platform.ci.mlflow_staging_verifier.requests.get",
-        lambda *args, **kwargs: _Response(),
+        _fake_get,
     )
 
     config = MlflowStagingVerificationConfig(
@@ -99,8 +116,67 @@ def test_verify_staging_fails_on_http_error(
         experiment_name="smoke-exp",
     )
 
-    with pytest.raises(VerificationError, match="return 200"):
-        verify_staging(config)
+    with pytest.raises(VerificationError, match="check tracking token"):
+        verify_http_reachable(config)
+
+    assert calls == ["https://mlflow.example.run.app/health"]
+
+
+def test_verify_http_reachable_retries_on_timeout_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Ok:
+        status_code = 200
+
+    responses: list[_Ok | ReadTimeout] = [
+        ReadTimeout("cold start"),
+        ReadTimeout("cold start"),
+        _Ok(),
+    ]
+
+    def _fake_get(*args: object, **kwargs: object) -> _Ok:
+        del args, kwargs
+        item = responses.pop(0)
+        if isinstance(item, ReadTimeout):
+            raise item
+        return item
+
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.mlflow_staging_verifier.requests.get",
+        _fake_get,
+    )
+
+    config = MlflowStagingVerificationConfig(
+        tracking_uri="https://mlflow.example.run.app",
+        tracking_token="token",
+        experiment_name="smoke-exp",
+    )
+
+    verify_http_reachable(config)
+
+    assert responses == []
+
+
+def test_verify_http_reachable_raises_after_retries_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _always_timeout(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise ReadTimeout("cold start")
+
+    monkeypatch.setattr(
+        "ml_lifecycle_platform.ci.mlflow_staging_verifier.requests.get",
+        _always_timeout,
+    )
+
+    config = MlflowStagingVerificationConfig(
+        tracking_uri="https://mlflow.example.run.app",
+        tracking_token="token",
+        experiment_name="smoke-exp",
+    )
+
+    with pytest.raises(VerificationError, match="unreachable after"):
+        verify_http_reachable(config)
 
 
 def test_verify_staging_fails_when_artifact_roundtrip_is_missing(


### PR DESCRIPTION
## Summary

Scheduled `Staging Verification` was failing on Cloud Run cold starts ([example run](https://github.com/jellewillekes/ml-lifecycle-platform/actions/runs/24547964432)). Single-shot `GET /` with 15s read timeout cascaded to ~9 skipped downstream jobs.

- Probe `/health` instead of `/`. Auth header still sent; response is smaller and exercises the real service path, not the UI bundle.
- Retry 4x with 0/5/15/45s backoff, 30s per-request timeout. Cap ~95s wall-clock so a dead MLflow still fails the job quickly.
- Fail fast on 401/403 — auth errors are not cold-start noise.
- Added 3 focused unit tests (retry-then-succeed, retries-exhausted, auth-fail-fast). Updated the existing auth-error test to match the new error surface.

No change to `verify_mlflow_roundtrip`; once reachability succeeds the container is warm.

Closes #146

## Test plan

- [x] `make check` (format + lint + mypy + unit) — green locally
- [x] 5 tests in `tests/unit/test_mlflow_staging_verifier.py` — all pass
- [ ] Next scheduled Staging Verification run observes the retry behavior (verify in CI logs after merge)