### PR TITLE
refactor: remove dead forbidden-paths script and replace egrep

### DIFF
--- a/scripts/check_forbidden_tracked.sh
+++ b/scripts/check_forbidden_tracked.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-forbidden_regex='(^mlruns/|^mlartifacts/|^\.venv/|^venv/|^\.pytest_cache/|^\.mypy_cache/|^\.ruff_cache/|^__pycache__/|\.DS_Store$|^data/|^artifacts/)'
-
-if git ls-files | egrep -n "${forbidden_regex}"; then
-  echo "Forbidden files are tracked by git. Remove from the index and add to .gitignore."
-  exit 1
-fi

--- a/scripts/precommit_block_forbidden_tracked_paths.sh
+++ b/scripts/precommit_block_forbidden_tracked_paths.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 forbidden_regex='(^mlruns/|^mlartifacts/|^\.venv/|^venv/|^\.pytest_cache/|^\.mypy_cache/|^\.ruff_cache/|^__pycache__/|\.DS_Store$|^data/|^artifacts/)'
 
-if git ls-files | egrep -n "${forbidden_regex}"; then
+if git ls-files | grep -En "${forbidden_regex}"; then
   echo ""
   echo "ERROR: Forbidden files are tracked by git."
   echo "Remove them from the index and add them to .gitignore."


### PR DESCRIPTION
## Summary

- Delete `scripts/check_forbidden_tracked.sh` — unreferenced duplicate of `scripts/precommit_block_forbidden_tracked_paths.sh` (confirmed via grep: zero references in Makefile, CI, pre-commit config, or docs).
- Replace `egrep` with `grep -En` in the kept script. `egrep` is deprecated since GNU grep 2.5.3 and warns on newer systems.

No behavior change. The kept script is still wired into `.pre-commit-config.yaml` and referenced in `CONTRIBUTING.md`.

Closes #144

## Test plan

- [x] `make precommit` passes locally (exercises the kept script)
- [x] `git ls-files | grep check_forbidden_tracked` returns nothing after the change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)