### PR TITLE
fix: read compose AWS creds from MLP_COMPOSE_* env vars

### DIFF
--- a/src/ml_lifecycle_platform/runtime/profile.py
+++ b/src/ml_lifecycle_platform/runtime/profile.py
@@ -133,8 +133,8 @@ def _apply_env_overrides(payload: dict[str, Any]) -> dict[str, Any]:
         "compose_tracking_uri": os.getenv("MLP_COMPOSE_TRACKING_URI"),
         "compose_registry_uri": os.getenv("MLP_COMPOSE_REGISTRY_URI"),
         "compose_s3_endpoint_url": os.getenv("MLP_COMPOSE_S3_ENDPOINT_URL"),
-        "compose_aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID"),
-        "compose_aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
+        "compose_aws_access_key_id": os.getenv("MLP_COMPOSE_AWS_ACCESS_KEY_ID"),
+        "compose_aws_secret_access_key": os.getenv("MLP_COMPOSE_AWS_SECRET_ACCESS_KEY"),
         "compose_serve_url": os.getenv("MLP_COMPOSE_SERVE_URL")
         or os.getenv("SERVE_URL"),
         "mlflow_host": os.getenv("MLFLOW_HOST"),

--- a/tests/unit/test_runtime_profile.py
+++ b/tests/unit/test_runtime_profile.py
@@ -87,6 +87,25 @@ def test_load_runtime_profile_env_overrides_take_precedence(
     )
 
 
+def test_compose_aws_credentials_use_mlp_compose_prefix_not_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_path = tmp_path / "local.yaml"
+    _write_profile(profile_path)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "host-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "host-secret")
+    monkeypatch.setenv("MLP_COMPOSE_AWS_ACCESS_KEY_ID", "compose-key")
+    monkeypatch.setenv("MLP_COMPOSE_AWS_SECRET_ACCESS_KEY", "compose-secret")
+
+    profile = load_runtime_profile(profile_path=profile_path)
+
+    assert profile.aws_access_key_id == "host-key"
+    assert profile.aws_secret_access_key == "host-secret"
+    assert profile.compose_aws_access_key_id == "compose-key"
+    assert profile.compose_aws_secret_access_key == "compose-secret"
+
+
 def test_load_runtime_profile_rejects_missing_required_field(tmp_path: Path) -> None:
     profile_path = tmp_path / "invalid.yaml"
     profile_path.write_text(


### PR DESCRIPTION
## Summary

- `runtime/profile.py` was reading host `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for the `compose_aws_*` override keys, breaking the `MLP_COMPOSE_*` prefix convention used by every neighbouring `compose_*` field.
- Switched the override reads to `MLP_COMPOSE_AWS_ACCESS_KEY_ID` / `MLP_COMPOSE_AWS_SECRET_ACCESS_KEY`. Host credential env vars still feed the `aws_access_key_id` / `aws_secret_access_key` fields.
- Added a regression test that sets host and compose-scoped env vars to distinct values and asserts both flow through to the right fields.

### Why this matters

When an operator had `AWS_ACCESS_KEY_ID` set for an unrelated `aws` CLI session, the docker-compose stack silently picked those up instead of the MinIO-scoped credentials — producing opaque S3 403s or artifacts landing in the wrong bucket.

Closes #142

## Test plan

- [x] `make check` green locally (129 tests, ruff + mypy clean)
- [x] New regression test `test_compose_aws_credentials_use_mlp_compose_prefix_not_host` passes
- [ ] CI green

### Rollback

Revert the commit. No schema or config-file changes — only env-var names the override map consults.