### PR TITLE
refactor: narrow exception handling to specific types (P07b)

### DIFF
--- a/src/ml_lifecycle_platform/common/mlflow_cloud_run_auth.py
+++ b/src/ml_lifecycle_platform/common/mlflow_cloud_run_auth.py
@@ -80,7 +80,7 @@ def _decode_token_expiry(token: str) -> float | None:
     try:
         decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
         claims = json.loads(decoded.decode("utf-8"))
-    except Exception:
+    except ValueError:
         return None
 
     exp = claims.get("exp")

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -32,28 +32,15 @@ def _run_step(module: str) -> None:
 
 
 def _latest_train_run_id(experiment_id: str) -> str:
-    runs = mlflow.search_runs(
+    runs_df = mlflow.search_runs(
         experiment_ids=[experiment_id],
         filter_string=f"tags.{TAG_STEP} = '{STEP_TRAIN}'",
         order_by=["attributes.start_time DESC"],
         max_results=1,
     )
-
-    if hasattr(runs, "empty") and hasattr(runs, "iloc"):
-        if runs.empty:  # type: ignore[attr-defined]
-            raise RuntimeError("No train run found after training step.")
-        return str(runs.iloc[0]["run_id"])  # type: ignore[index]
-
-    if isinstance(runs, list):
-        if not runs:
-            raise RuntimeError("No train run found after training step.")
-        run0 = runs[0]
-        run_id = getattr(getattr(run0, "info", None), "run_id", None)
-        if not run_id:
-            raise RuntimeError("Train run object missing run_id.")
-        return str(run_id)
-
-    raise TypeError(f"Unexpected mlflow.search_runs return type: {type(runs)}")
+    if runs_df.empty:  # type: ignore[union-attr]
+        raise RuntimeError("No train run found after training step.")
+    return str(runs_df.iloc[0]["run_id"])  # type: ignore[union-attr,index]
 
 
 def main() -> None:

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -6,6 +6,7 @@ import logging
 import sys
 from typing import Any
 
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.mlflow_utils import client as mlflow_client
@@ -76,7 +77,7 @@ def _print_decision(decision: PolicyDecision, fmt: str) -> None:
 def _try_get_prod_version(client: MlflowClient, model_name: str) -> str | None:
     try:
         prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
-    except Exception:
+    except MlflowException:
         return None
     return str(prod.version)
 
@@ -88,7 +89,8 @@ def _model_version_source_run_id(model_version: Any) -> str:
 def _source_run_metrics(client: MlflowClient, run_id: str) -> dict[str, float]:
     try:
         run = client.get_run(run_id)
-    except Exception:
+    except MlflowException as exc:
+        logger.debug("Could not fetch run metrics for %s: %s", run_id, exc)
         return {}
     metrics = getattr(getattr(run, "data", None), "metrics", {}) or {}
     return {str(key): float(value) for key, value in metrics.items()}
@@ -117,7 +119,12 @@ def _build_promotion_bundle(
         try:
             previous_prod = client.get_model_version(model_name, previous_prod_version)
             target_source_run_id = _model_version_source_run_id(previous_prod) or None
-        except Exception:
+        except MlflowException as exc:
+            logger.debug(
+                "Could not resolve previous prod version %s: %s",
+                previous_prod_version,
+                exc,
+            )
             target_source_run_id = None
 
     generated_at = utc_now_iso()
@@ -229,7 +236,7 @@ def apply_promotion(
                 key=TAG_RELEASE_STATUS,
                 value=RELEASE_STATUS_PREVIOUS_PROD,
             )
-        except Exception:
+        except MlflowException:
             logger.info(
                 "Could not mark old prod version %s as %s",
                 prev_prod_version,

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.constants import (
@@ -55,6 +56,12 @@ from ml_lifecycle_platform.registry.release_evidence import emit_release_evidenc
 logger = logging.getLogger(__name__)
 
 
+def _classify_download_error(exc: Exception, *, fallback_code: str) -> str:
+    if "Unable to locate credentials" in str(exc):
+        return "artifact_credentials_missing"
+    return fallback_code
+
+
 @dataclass
 class ReproduceFailure(Exception):
     code: str
@@ -96,17 +103,11 @@ def _read_contract(client: MlflowClient, run_id: str, work_dir: Path) -> ReproCo
                 dst_path=str(work_dir),
             )
         )
-    except Exception as exc:
-        error_text = str(exc)
-        code = (
-            "artifact_credentials_missing"
-            if "Unable to locate credentials" in error_text
-            else "missing_repro_contract"
-        )
+    except (MlflowException, OSError) as exc:
         raise ReproduceFailure(
-            code=code,
+            code=_classify_download_error(exc, fallback_code="missing_repro_contract"),
             message="Could not download repro contract from source training run.",
-            details={"run_id": run_id, "error": error_text},
+            details={"run_id": run_id, "error": str(exc)},
         ) from exc
 
     try:
@@ -133,20 +134,14 @@ def _download_required_artifact(
                 dst_path=str(work_dir),
             )
         )
-    except Exception as exc:
-        error_text = str(exc)
-        code = (
-            "artifact_credentials_missing"
-            if "Unable to locate credentials" in error_text
-            else "artifact_missing"
-        )
+    except (MlflowException, OSError) as exc:
         raise ReproduceFailure(
-            code=code,
+            code=_classify_download_error(exc, fallback_code="artifact_missing"),
             message="Required training-run artifact is missing.",
             details={
                 "run_id": run_id,
                 "artifact_path": artifact_path,
-                "error": error_text,
+                "error": str(exc),
             },
         ) from exc
 
@@ -198,7 +193,7 @@ def _print_report(report: dict[str, Any], fmt: str) -> None:
 def _resolve_current_prod_version(client: MlflowClient, model_name: str) -> str | None:
     try:
         prod = client.get_model_version_by_alias(model_name, "prod")
-    except Exception:
+    except MlflowException:
         return None
     return str(prod.version)
 
@@ -218,7 +213,7 @@ def _emit_reproduce_evidence(
             model_version=model_version,
             alias=alias,
         )
-    except Exception:
+    except MlflowException:
         logger.warning(
             "Could not resolve model version for reproduce evidence emission."
         )

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.constants import (
@@ -60,7 +61,8 @@ def _source_run_id(model_version: Any) -> str:
 def _run_metrics(client: MlflowClient, run_id: str) -> dict[str, float]:
     try:
         run = client.get_run(run_id)
-    except Exception:
+    except MlflowException as exc:
+        logger.debug("Could not fetch run metrics for %s: %s", run_id, exc)
         return {}
     metrics = getattr(getattr(run, "data", None), "metrics", {}) or {}
     return {str(key): float(value) for key, value in metrics.items()}

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -18,8 +18,10 @@ from starlette.responses import Response
 
 try:
     import mlflow  # type: ignore
+    from mlflow.exceptions import MlflowException
 except Exception:  # pragma: no cover
     mlflow = None  # type: ignore[assignment]
+    MlflowException = Exception  # type: ignore[assignment, misc]
 
 from ml_lifecycle_platform.common.mlflow_utils import client as get_mlflow_client
 from ml_lifecycle_platform.core.feature_contracts import (
@@ -225,7 +227,7 @@ def _registry_resolves_prod_alias(settings: Settings) -> tuple[bool, str | None]
         client = get_mlflow_client()
         _ = client.get_model_version_by_alias(settings.model_name, settings.prod_alias)
         return True, None
-    except Exception as e:
+    except MlflowException as e:
         return False, f"registry check failed: {e}"
 
 
@@ -236,7 +238,7 @@ def _get_version(settings: Settings, alias: str) -> str | None:
         client = get_mlflow_client()
         mv = client.get_model_version_by_alias(settings.model_name, alias)
         return str(mv.version)
-    except Exception:
+    except MlflowException:
         return None
 
 


### PR DESCRIPTION
## Summary

- Replace `except Exception` with `except MlflowException` in `promote.py` (4 sites), `rollback.py`, `reproduce.py` (2 sites), and `serving/app.py` (2 sites)
- Add `_classify_download_error(exc, fallback_code)` helper in `reproduce.py` to replace inline string matching for AWS credential errors
- Narrow `_decode_token_expiry` in `mlflow_cloud_run_auth.py` to `except ValueError` (covers `binascii.Error`, `json.JSONDecodeError`, `UnicodeDecodeError`)
- Simplify `_latest_train_run_id` in `orchestrate.py`: drop DataFrame/list duck-typing, use DataFrame path directly (MLflow 2.x always returns DataFrame)

## Test plan

- [x] `make check` — ruff format, mypy, 129 unit tests all passed
- [x] `make e2e-clean` — full docker-compose pipeline + serving smoke test, `[smoke] ALL OK`

Closes #151