### PR TITLE
refactor: decompose serving package (P08)

### DIFF
--- a/src/ml_lifecycle_platform/core/batch_contracts.py
+++ b/src/ml_lifecycle_platform/core/batch_contracts.py
@@ -7,7 +7,7 @@ import pandera.pandas as pa
 from pandera import Check
 from pandera.errors import SchemaError, SchemaErrors
 
-from ml_lifecycle_platform.core.model_specs import FeatureFieldSpec, ModelSpec
+from ml_lifecycle_platform.core.model_spec_types import FeatureFieldSpec, ModelSpec
 
 
 class BatchContractValidationError(ValueError):

--- a/src/ml_lifecycle_platform/core/feature_contracts.py
+++ b/src/ml_lifecycle_platform/core/feature_contracts.py
@@ -4,7 +4,10 @@ import math
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
-from ml_lifecycle_platform.core.model_specs import FeatureContractSpec, FeatureFieldSpec
+from ml_lifecycle_platform.core.model_spec_types import (
+    FeatureContractSpec,
+    FeatureFieldSpec,
+)
 
 
 @dataclass(frozen=True)

--- a/src/ml_lifecycle_platform/core/model_spec_types.py
+++ b/src/ml_lifecycle_platform/core/model_spec_types.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ml_lifecycle_platform.common.constants import (
+    ALIAS_CANDIDATE,
+    TAG_CONFIG_HASH,
+    TAG_DATASET_FINGERPRINT,
+    TAG_GIT_SHA,
+    TAG_TRAINING_RUN_ID,
+)
+
+SUPPORTED_TASK = "binary_classifier"
+SUPPORTED_SOURCE_KINDS = {"sklearn_demo", "csv"}
+SUPPORTED_TRAINER_KIND = "logistic_regression"
+SUPPORTED_PREPROCESSOR_KIND = "standard_scaler"
+SUPPORTED_METRICS = {"accuracy", "f1", "roc_auc"}
+SUPPORTED_FEATURE_TYPES = {"float", "int", "bool", "string"}
+DEFAULT_POLICY_REQUIRED_METADATA_TAGS = (
+    TAG_DATASET_FINGERPRINT,
+    TAG_GIT_SHA,
+    TAG_CONFIG_HASH,
+    TAG_TRAINING_RUN_ID,
+)
+
+
+@dataclass(frozen=True)
+class SklearnDemoSourceSpec:
+    kind: str
+    dataset_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "dataset_name": self.dataset_name}
+
+    def data_source_uri(self) -> str:
+        return f"sklearn://{self.dataset_name}"
+
+
+@dataclass(frozen=True)
+class CsvSourceSpec:
+    kind: str
+    path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "path": self.path}
+
+    def resolved_path(self, *, spec_path: Path) -> Path:
+        csv_path = Path(self.path)
+        if csv_path.is_absolute():
+            return csv_path
+        return (spec_path.parent / csv_path).resolve()
+
+    def data_source_uri(self, *, spec_path: Path) -> str:
+        return self.resolved_path(spec_path=spec_path).as_uri()
+
+
+@dataclass(frozen=True)
+class SplitSpec:
+    test_size: float
+    random_state: int
+    stratify: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "test_size": self.test_size,
+            "random_state": self.random_state,
+            "stratify": self.stratify,
+        }
+
+
+@dataclass(frozen=True)
+class PreprocessorSpec:
+    kind: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind}
+
+
+@dataclass(frozen=True)
+class LogisticRegressionTrainerSpec:
+    kind: str
+    max_iter: int
+    solver: str
+    class_weight: str
+    random_state: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "max_iter": self.max_iter,
+            "solver": self.solver,
+            "class_weight": self.class_weight,
+            "random_state": self.random_state,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationGateSpec:
+    metric: str
+    threshold: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"metric": self.metric, "threshold": self.threshold}
+
+
+@dataclass(frozen=True)
+class EvaluationSpec:
+    metrics: tuple[str, ...]
+    gate: EvaluationGateSpec
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"metrics": list(self.metrics), "gate": self.gate.to_dict()}
+
+
+@dataclass(frozen=True)
+class MetricThresholdSpec:
+    metric: str
+    threshold: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"metric": self.metric, "threshold": self.threshold}
+
+
+@dataclass(frozen=True)
+class FeatureFieldSpec:
+    name: str
+    dtype: str
+    required: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "dtype": self.dtype,
+            "required": self.required,
+        }
+
+
+@dataclass(frozen=True)
+class FeatureContractSpec:
+    version: str
+    allow_unknown_fields: bool
+    features: tuple[FeatureFieldSpec, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "allow_unknown_fields": self.allow_unknown_fields,
+            "features": [feature.to_dict() for feature in self.features],
+        }
+
+
+def default_feature_contract_spec() -> FeatureContractSpec:
+    return FeatureContractSpec(
+        version="feature_contract/default",
+        allow_unknown_fields=True,
+        features=(),
+    )
+
+
+@dataclass(frozen=True)
+class PolicySpec:
+    required_metadata_tags: tuple[str, ...]
+    required_release_status: str
+    block_noop_promotion: bool
+    require_reproducibility_evidence: bool
+    minimum_metric_thresholds: tuple[MetricThresholdSpec, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required_metadata_tags": list(self.required_metadata_tags),
+            "required_release_status": self.required_release_status,
+            "block_noop_promotion": self.block_noop_promotion,
+            "require_reproducibility_evidence": self.require_reproducibility_evidence,
+            "minimum_metric_thresholds": [
+                threshold.to_dict() for threshold in self.minimum_metric_thresholds
+            ],
+        }
+
+
+def default_policy_spec() -> PolicySpec:
+    return PolicySpec(
+        required_metadata_tags=DEFAULT_POLICY_REQUIRED_METADATA_TAGS,
+        required_release_status=ALIAS_CANDIDATE,
+        block_noop_promotion=True,
+        require_reproducibility_evidence=False,
+        minimum_metric_thresholds=(),
+    )
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    schema_version: str
+    model_name: str
+    task: str
+    label_column: str
+    source: SklearnDemoSourceSpec | CsvSourceSpec
+    split: SplitSpec
+    preprocessor: PreprocessorSpec
+    trainer: LogisticRegressionTrainerSpec
+    evaluation: EvaluationSpec
+    feature_contract: FeatureContractSpec
+    policy: PolicySpec
+    spec_path: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_name": self.model_name,
+            "task": self.task,
+            "label_column": self.label_column,
+            "source": self.source.to_dict(),
+            "split": self.split.to_dict(),
+            "preprocessor": self.preprocessor.to_dict(),
+            "trainer": self.trainer.to_dict(),
+            "evaluation": self.evaluation.to_dict(),
+            "feature_contract": self.feature_contract.to_dict(),
+            "policy": self.policy.to_dict(),
+        }
+
+    def data_source_uri(self) -> str:
+        if isinstance(self.source, CsvSourceSpec):
+            return self.source.data_source_uri(spec_path=self.spec_path)
+        return self.source.data_source_uri()

--- a/src/ml_lifecycle_platform/core/model_specs.py
+++ b/src/ml_lifecycle_platform/core/model_specs.py
@@ -1,33 +1,35 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
 import yaml
 
-from ml_lifecycle_platform.common.constants import (
-    ALIAS_CANDIDATE,
-    MODEL_SPEC_SCHEMA_VERSION,
-    TAG_CONFIG_HASH,
-    TAG_DATASET_FINGERPRINT,
-    TAG_GIT_SHA,
-    TAG_TRAINING_RUN_ID,
+from ml_lifecycle_platform.common.constants import MODEL_SPEC_SCHEMA_VERSION
+from ml_lifecycle_platform.core.model_spec_types import (
+    CsvSourceSpec,
+    EvaluationGateSpec,
+    EvaluationSpec,
+    FeatureContractSpec,
+    FeatureFieldSpec,
+    LogisticRegressionTrainerSpec,
+    MetricThresholdSpec,
+    ModelSpec,
+    PolicySpec,
+    PreprocessorSpec,
+    SklearnDemoSourceSpec,
+    SplitSpec,
+    SUPPORTED_FEATURE_TYPES,
+    SUPPORTED_METRICS,
+    SUPPORTED_PREPROCESSOR_KIND,
+    SUPPORTED_SOURCE_KINDS,
+    SUPPORTED_TASK,
+    SUPPORTED_TRAINER_KIND,
+    default_feature_contract_spec,
+    default_policy_spec,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-SUPPORTED_TASK = "binary_classifier"
-SUPPORTED_SOURCE_KINDS = {"sklearn_demo", "csv"}
-SUPPORTED_TRAINER_KIND = "logistic_regression"
-SUPPORTED_PREPROCESSOR_KIND = "standard_scaler"
-SUPPORTED_METRICS = {"accuracy", "f1", "roc_auc"}
-SUPPORTED_FEATURE_TYPES = {"float", "int", "bool", "string"}
-DEFAULT_POLICY_REQUIRED_METADATA_TAGS = (
-    TAG_DATASET_FINGERPRINT,
-    TAG_GIT_SHA,
-    TAG_CONFIG_HASH,
-    TAG_TRAINING_RUN_ID,
-)
 
 
 def _require_mapping(payload: Any, *, context: str) -> dict[str, Any]:
@@ -70,205 +72,6 @@ def _require_bool(payload: Mapping[str, Any], key: str, *, context: str) -> bool
     if not isinstance(value, bool):
         raise ValueError(f"{context}.{key} must be a boolean.")
     return value
-
-
-@dataclass(frozen=True)
-class SklearnDemoSourceSpec:
-    kind: str
-    dataset_name: str
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"kind": self.kind, "dataset_name": self.dataset_name}
-
-    def data_source_uri(self) -> str:
-        return f"sklearn://{self.dataset_name}"
-
-
-@dataclass(frozen=True)
-class CsvSourceSpec:
-    kind: str
-    path: str
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"kind": self.kind, "path": self.path}
-
-    def resolved_path(self, *, spec_path: Path) -> Path:
-        csv_path = Path(self.path)
-        if csv_path.is_absolute():
-            return csv_path
-        return (spec_path.parent / csv_path).resolve()
-
-    def data_source_uri(self, *, spec_path: Path) -> str:
-        return self.resolved_path(spec_path=spec_path).as_uri()
-
-
-@dataclass(frozen=True)
-class SplitSpec:
-    test_size: float
-    random_state: int
-    stratify: bool
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "test_size": self.test_size,
-            "random_state": self.random_state,
-            "stratify": self.stratify,
-        }
-
-
-@dataclass(frozen=True)
-class PreprocessorSpec:
-    kind: str
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"kind": self.kind}
-
-
-@dataclass(frozen=True)
-class LogisticRegressionTrainerSpec:
-    kind: str
-    max_iter: int
-    solver: str
-    class_weight: str
-    random_state: int
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "kind": self.kind,
-            "max_iter": self.max_iter,
-            "solver": self.solver,
-            "class_weight": self.class_weight,
-            "random_state": self.random_state,
-        }
-
-
-@dataclass(frozen=True)
-class EvaluationGateSpec:
-    metric: str
-    threshold: float
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"metric": self.metric, "threshold": self.threshold}
-
-
-@dataclass(frozen=True)
-class EvaluationSpec:
-    metrics: tuple[str, ...]
-    gate: EvaluationGateSpec
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"metrics": list(self.metrics), "gate": self.gate.to_dict()}
-
-
-@dataclass(frozen=True)
-class MetricThresholdSpec:
-    metric: str
-    threshold: float
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"metric": self.metric, "threshold": self.threshold}
-
-
-@dataclass(frozen=True)
-class FeatureFieldSpec:
-    name: str
-    dtype: str
-    required: bool = True
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "dtype": self.dtype,
-            "required": self.required,
-        }
-
-
-@dataclass(frozen=True)
-class FeatureContractSpec:
-    version: str
-    allow_unknown_fields: bool
-    features: tuple[FeatureFieldSpec, ...]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "version": self.version,
-            "allow_unknown_fields": self.allow_unknown_fields,
-            "features": [feature.to_dict() for feature in self.features],
-        }
-
-
-def default_feature_contract_spec() -> FeatureContractSpec:
-    return FeatureContractSpec(
-        version="feature_contract/default",
-        allow_unknown_fields=True,
-        features=(),
-    )
-
-
-@dataclass(frozen=True)
-class PolicySpec:
-    required_metadata_tags: tuple[str, ...]
-    required_release_status: str
-    block_noop_promotion: bool
-    require_reproducibility_evidence: bool
-    minimum_metric_thresholds: tuple[MetricThresholdSpec, ...]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "required_metadata_tags": list(self.required_metadata_tags),
-            "required_release_status": self.required_release_status,
-            "block_noop_promotion": self.block_noop_promotion,
-            "require_reproducibility_evidence": self.require_reproducibility_evidence,
-            "minimum_metric_thresholds": [
-                threshold.to_dict() for threshold in self.minimum_metric_thresholds
-            ],
-        }
-
-
-def default_policy_spec() -> PolicySpec:
-    return PolicySpec(
-        required_metadata_tags=DEFAULT_POLICY_REQUIRED_METADATA_TAGS,
-        required_release_status=ALIAS_CANDIDATE,
-        block_noop_promotion=True,
-        require_reproducibility_evidence=False,
-        minimum_metric_thresholds=(),
-    )
-
-
-@dataclass(frozen=True)
-class ModelSpec:
-    schema_version: str
-    model_name: str
-    task: str
-    label_column: str
-    source: SklearnDemoSourceSpec | CsvSourceSpec
-    split: SplitSpec
-    preprocessor: PreprocessorSpec
-    trainer: LogisticRegressionTrainerSpec
-    evaluation: EvaluationSpec
-    feature_contract: FeatureContractSpec
-    policy: PolicySpec
-    spec_path: Path
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "schema_version": self.schema_version,
-            "model_name": self.model_name,
-            "task": self.task,
-            "label_column": self.label_column,
-            "source": self.source.to_dict(),
-            "split": self.split.to_dict(),
-            "preprocessor": self.preprocessor.to_dict(),
-            "trainer": self.trainer.to_dict(),
-            "evaluation": self.evaluation.to_dict(),
-            "feature_contract": self.feature_contract.to_dict(),
-            "policy": self.policy.to_dict(),
-        }
-
-    def data_source_uri(self) -> str:
-        if isinstance(self.source, CsvSourceSpec):
-            return self.source.data_source_uri(spec_path=self.spec_path)
-        return self.source.data_source_uri()
 
 
 def _parse_source(

--- a/src/ml_lifecycle_platform/core/policy_engine.py
+++ b/src/ml_lifecycle_platform/core/policy_engine.py
@@ -21,7 +21,7 @@ from ml_lifecycle_platform.common.constants import (
     TAG_SOURCE_RUN_ID,
     TAG_TRAINING_RUN_ID,
 )
-from ml_lifecycle_platform.core.model_specs import PolicySpec, default_policy_spec
+from ml_lifecycle_platform.core.model_spec_types import PolicySpec, default_policy_spec
 
 REPRODUCIBILITY_EVIDENCE_TAGS: tuple[str, ...] = (
     TAG_SOURCE_RUN_ID,

--- a/src/ml_lifecycle_platform/pipeline/evaluate.py
+++ b/src/ml_lifecycle_platform/pipeline/evaluate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
@@ -25,9 +23,6 @@ from ml_lifecycle_platform.core.batch_contracts import validate_labeled_dataset
 from ml_lifecycle_platform.core.model_specs import load_model_spec
 from ml_lifecycle_platform.pipeline.train import compute_binary_metrics
 
-DATA_DIR = Path("/app/data")
-ART_DIR = Path("/app/artifacts")
-
 
 def main() -> None:
     ctx = get_runtime_context()
@@ -35,7 +30,7 @@ def main() -> None:
     mlflow.set_experiment(ctx.experiment_name)
     spec = load_model_spec(ctx.model_spec_path)
 
-    test_df = pd.read_csv(DATA_DIR / TEST_CSV)
+    test_df = pd.read_csv(ctx.data_dir / TEST_CSV)
     test_df = validate_labeled_dataset(
         test_df,
         spec=spec,
@@ -45,7 +40,9 @@ def main() -> None:
     X_test = test_df.drop(columns=[spec.label_column])
     y_test = test_df[spec.label_column].astype(int)
 
-    train_run_id = (ART_DIR / ART_TRAIN_RUN_ID).read_text(encoding="utf-8").strip()
+    train_run_id = (
+        (ctx.artifacts_dir / ART_TRAIN_RUN_ID).read_text(encoding="utf-8").strip()
+    )
 
     model_uri = f"runs:/{train_run_id}/{MLFLOW_ARTIFACT_PATH_MODEL}"
     model = mlflow.pyfunc.load_model(model_uri)
@@ -61,11 +58,11 @@ def main() -> None:
         prefix="eval",
     )
 
-    ART_DIR.mkdir(parents=True, exist_ok=True)
-    report_path = ART_DIR / ART_EVALUATION_JSON
+    ctx.artifacts_dir.mkdir(parents=True, exist_ok=True)
+    report_path = ctx.artifacts_dir / ART_EVALUATION_JSON
     write_json(report_path, metrics)
 
-    fig_path = ART_DIR / ART_ROC_CURVE_PNG
+    fig_path = ctx.artifacts_dir / ART_ROC_CURVE_PNG
     plt.figure()
     RocCurveDisplay.from_predictions(y_test, proba)
     plt.savefig(fig_path, bbox_inches="tight")
@@ -81,7 +78,7 @@ def main() -> None:
 
         gate_metric_key = f"eval_{spec.evaluation.gate.metric}"
         gate_ok = metrics[gate_metric_key] >= spec.evaluation.gate.threshold
-        gate_path = ART_DIR / ART_GATE_OK
+        gate_path = ctx.artifacts_dir / ART_GATE_OK
         gate_path.write_text("true" if gate_ok else "false", encoding="utf-8")
         mlflow.log_artifact(str(gate_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
 

--- a/src/ml_lifecycle_platform/pipeline/featurize.py
+++ b/src/ml_lifecycle_platform/pipeline/featurize.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import joblib
 import mlflow
 import pandas as pd
@@ -22,9 +20,6 @@ from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
 from ml_lifecycle_platform.core.batch_contracts import validate_labeled_dataset
 from ml_lifecycle_platform.core.model_specs import load_model_spec
 
-DATA_DIR = Path("/app/data")
-ART_DIR = Path("/app/artifacts")
-
 
 def main() -> None:
     ctx = get_runtime_context()
@@ -32,10 +27,10 @@ def main() -> None:
     mlflow.set_experiment(ctx.experiment_name)
     spec = load_model_spec(ctx.model_spec_path)
 
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    ART_DIR.mkdir(parents=True, exist_ok=True)
+    ctx.data_dir.mkdir(parents=True, exist_ok=True)
+    ctx.artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    raw_path = DATA_DIR / RAW_CSV
+    raw_path = ctx.data_dir / RAW_CSV
     if not raw_path.exists():
         raise RuntimeError(f"Missing raw dataset: {raw_path}. Run ingest first.")
 
@@ -78,13 +73,13 @@ def main() -> None:
         dataset_name="test",
     )
 
-    train_path = DATA_DIR / TRAIN_CSV
-    test_path = DATA_DIR / TEST_CSV
+    train_path = ctx.data_dir / TRAIN_CSV
+    test_path = ctx.data_dir / TEST_CSV
     train_df.to_csv(train_path, index=False)
     test_df.to_csv(test_path, index=False)
 
     preprocessor = StandardScaler(with_mean=True, with_std=True)
-    preprocessor_path = ART_DIR / ART_PREPROCESSOR
+    preprocessor_path = ctx.artifacts_dir / ART_PREPROCESSOR
     joblib.dump(preprocessor, preprocessor_path)
 
     with mlflow.start_run(run_name="featurize") as run:

--- a/src/ml_lifecycle_platform/pipeline/ingest.py
+++ b/src/ml_lifecycle_platform/pipeline/ingest.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import mlflow
 import pandas as pd
 from sklearn.datasets import load_breast_cancer
@@ -15,13 +13,8 @@ from ml_lifecycle_platform.common.constants import (
 from ml_lifecycle_platform.common.mlflow_utils import ensure_experiment
 from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
 from ml_lifecycle_platform.core.batch_contracts import validate_labeled_dataset
-from ml_lifecycle_platform.core.model_specs import (
-    CsvSourceSpec,
-    ModelSpec,
-    load_model_spec,
-)
-
-DATA_DIR = Path("/app/data")
+from ml_lifecycle_platform.core.model_spec_types import CsvSourceSpec, ModelSpec
+from ml_lifecycle_platform.core.model_specs import load_model_spec
 
 
 def _load_source_dataframe(spec: ModelSpec) -> pd.DataFrame:
@@ -46,7 +39,7 @@ def main() -> None:
     mlflow.set_experiment(ctx.experiment_name)
     spec = load_model_spec(ctx.model_spec_path)
 
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    ctx.data_dir.mkdir(parents=True, exist_ok=True)
 
     with mlflow.start_run(run_name="ingest") as run:
         mlflow.set_tag(TAG_STEP, STEP_INGEST)
@@ -54,7 +47,7 @@ def main() -> None:
 
         df = _load_source_dataframe(spec)
 
-        raw_path = DATA_DIR / RAW_CSV
+        raw_path = ctx.data_dir / RAW_CSV
         df.to_csv(raw_path, index=False)
 
         mlflow.log_params(

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import mlflow
+import pandas as pd
 
 from ml_lifecycle_platform.common.constants import (
     ART_TRAIN_RUN_ID,
@@ -31,16 +32,23 @@ def _run_step(module: str) -> None:
         raise RuntimeError(f"Step {module} failed with exit code {return_code}.")
 
 
-def _latest_train_run_id(experiment_id: str) -> str:
-    runs_df = mlflow.search_runs(
+def _search_train_runs(experiment_id: str) -> pd.DataFrame:
+    result = mlflow.search_runs(
         experiment_ids=[experiment_id],
         filter_string=f"tags.{TAG_STEP} = '{STEP_TRAIN}'",
         order_by=["attributes.start_time DESC"],
         max_results=1,
     )
-    if runs_df.empty:  # type: ignore[union-attr]
+    if not isinstance(result, pd.DataFrame):
+        raise TypeError(f"mlflow.search_runs returned unexpected type: {type(result)}")
+    return result
+
+
+def _latest_train_run_id(experiment_id: str) -> str:
+    runs = _search_train_runs(experiment_id)
+    if runs.empty:
         raise RuntimeError("No train run found after training step.")
-    return str(runs_df.iloc[0]["run_id"])  # type: ignore[union-attr,index]
+    return str(runs.iloc[0]["run_id"])
 
 
 def main() -> None:

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -50,7 +50,8 @@ from ml_lifecycle_platform.contracts.dataset_fingerprint import (
     write_fingerprint_json,
 )
 from ml_lifecycle_platform.contracts.repro_contract import ReproContract
-from ml_lifecycle_platform.core.model_specs import ModelSpec, load_model_spec
+from ml_lifecycle_platform.core.model_spec_types import ModelSpec
+from ml_lifecycle_platform.core.model_specs import load_model_spec
 from ml_lifecycle_platform.runtime.bootstrap import (
     configure_mlflow,
     get_runtime_context,
@@ -58,8 +59,6 @@ from ml_lifecycle_platform.runtime.bootstrap import (
 
 logger = logging.getLogger(__name__)
 
-DATA_DIR: Final[Path] = Path("/app/data")
-ART_DIR: Final[Path] = Path("/app/artifacts")
 PROBE_INPUT_LIMIT: Final[int] = 10
 REPRO_INPUTS_ARTIFACT_PATH: Final[str] = f"{MLFLOW_ARTIFACT_PATH_REPRO}/inputs"
 REPRO_OUTPUTS_ARTIFACT_PATH: Final[str] = f"{MLFLOW_ARTIFACT_PATH_REPRO}/outputs"
@@ -122,9 +121,10 @@ def load_training_inputs(
     data_dir: Path | None = None,
     artifacts_dir: Path | None = None,
 ) -> TrainingInputs:
-    data_dir = DATA_DIR if data_dir is None else data_dir
-    artifacts_dir = ART_DIR if artifacts_dir is None else artifacts_dir
-    spec = load_model_spec(get_runtime_context().model_spec_path)
+    ctx = get_runtime_context()
+    data_dir = ctx.data_dir if data_dir is None else data_dir
+    artifacts_dir = ctx.artifacts_dir if artifacts_dir is None else artifacts_dir
+    spec = load_model_spec(ctx.model_spec_path)
     train_df = pd.read_csv(data_dir / TRAIN_CSV)
     test_df = pd.read_csv(data_dir / TEST_CSV)
     train_df = validate_labeled_dataset(
@@ -273,29 +273,32 @@ def main() -> None:
         )
         mlflow.set_tag(TAG_REPRO_SCHEMA_VERSION, repro_contract.schema_version)
 
-        fp_path = ART_DIR / ART_DATASET_FINGERPRINT_JSON
+        art_dir = ctx.artifacts_dir
+        art_dir.mkdir(parents=True, exist_ok=True)
+
+        fp_path = art_dir / ART_DATASET_FINGERPRINT_JSON
         write_fingerprint_json(fp, fp_path)
         mlflow.log_artifact(str(fp_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
 
-        summary_path = ART_DIR / ART_TRAIN_SUMMARY_JSON
+        summary_path = art_dir / ART_TRAIN_SUMMARY_JSON
         _write_json(summary_path, result.metrics)
         mlflow.log_artifact(
             str(summary_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS
         )
 
-        contract_path = ART_DIR / ART_REPRO_CONTRACT_JSON
+        contract_path = art_dir / ART_REPRO_CONTRACT_JSON
         contract_path.write_text(repro_contract.to_json(), encoding="utf-8")
         mlflow.log_artifact(
             str(contract_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPRO
         )
 
-        probe_inputs_path = ART_DIR / ART_REPRO_PROBE_INPUTS_CSV
+        probe_inputs_path = art_dir / ART_REPRO_PROBE_INPUTS_CSV
         result.probe_inputs.to_csv(probe_inputs_path, index=False)
         mlflow.log_artifact(
             str(probe_inputs_path), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
         )
 
-        expected_predictions_path = ART_DIR / ART_REPRO_EXPECTED_PREDICTIONS_JSON
+        expected_predictions_path = art_dir / ART_REPRO_EXPECTED_PREDICTIONS_JSON
         _write_json(
             expected_predictions_path,
             {"probabilities": result.expected_probabilities},
@@ -307,13 +310,13 @@ def main() -> None:
         uv_lock_path = get_uv_lock_path()
         mlflow.log_artifact(str(uv_lock_path), artifact_path=REPRO_ENV_ARTIFACT_PATH)
         mlflow.log_artifact(
-            str(DATA_DIR / TRAIN_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+            str(ctx.data_dir / TRAIN_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
         )
         mlflow.log_artifact(
-            str(DATA_DIR / TEST_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+            str(ctx.data_dir / TEST_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
         )
         mlflow.log_artifact(
-            str(ART_DIR / ART_PREPROCESSOR), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+            str(art_dir / ART_PREPROCESSOR), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
         )
 
         mlflow.log_params(dict(params))

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -24,11 +24,8 @@ from ml_lifecycle_platform.common.constants import (
     TAG_RELEASE_STATUS,
     TAG_SOURCE_RUN_ID,
 )
-from ml_lifecycle_platform.core.model_specs import (
-    PolicySpec,
-    default_policy_spec,
-    load_model_spec,
-)
+from ml_lifecycle_platform.core.model_spec_types import PolicySpec, default_policy_spec
+from ml_lifecycle_platform.core.model_specs import load_model_spec
 from ml_lifecycle_platform.contracts.release_reports import (
     OperationResult,
     PolicyOutcome,

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import time
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
@@ -10,7 +9,6 @@ from contextlib import asynccontextmanager
 from functools import lru_cache
 from typing import Any, Literal, cast
 
-import pandas as pd
 from fastapi import FastAPI, HTTPException, Query, Request
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from pydantic import BaseModel, ConfigDict, Field
@@ -24,12 +22,9 @@ except Exception:  # pragma: no cover
     MlflowException = Exception  # type: ignore[assignment, misc]
 
 from ml_lifecycle_platform.common.mlflow_utils import client as get_mlflow_client
-from ml_lifecycle_platform.core.feature_contracts import (
-    FeatureContractValidationError,
-    validate_rows_against_contract,
-)
-from ml_lifecycle_platform.core.model_specs import FeatureContractSpec, load_model_spec
-from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
+from ml_lifecycle_platform.core.feature_contracts import FeatureContractValidationError
+from ml_lifecycle_platform.core.model_spec_types import FeatureContractSpec
+from ml_lifecycle_platform.core.model_specs import load_model_spec
 
 from .constants import (
     ALIAS_CANDIDATE,
@@ -38,7 +33,9 @@ from .constants import (
     HEADER_MODEL_VERSION,
     HEADER_REQUEST_ID,
 )
-from .metrics import PREDICT_LATENCY_SECONDS, REQUESTS_TOTAL, SHADOW_DIFF_MAE
+from .metrics import PREDICT_LATENCY_SECONDS, REQUESTS_TOTAL
+from .model_store import get_model_store
+from .prediction import run_prediction
 from .router import (
     BucketContext,
     Mode,
@@ -49,14 +46,6 @@ from .router import (
 from .settings import Settings, get_settings
 
 logger = logging.getLogger("serving")
-
-
-# Module-level cache. Tests monkeypatch it.
-model_prod: Any | None = None
-model_candidate: Any | None = None
-prod_version: str | None = None
-candidate_version: str | None = None
-_last_refresh_ts: float = 0.0
 
 
 def _configure_logging(settings: Settings) -> None:
@@ -187,19 +176,6 @@ class SchemaMetadataResponse(BaseModel):
     features: list[SchemaFieldResponse]
 
 
-class _UnitTestModel:
-    """Deterministic stub for unit tests."""
-
-    def predict(self, df: pd.DataFrame) -> list[float]:
-        # Return deterministic probabilities in [0, 1].
-        n = len(df)
-        return [1.0] * n
-
-
-def _models_uri(settings: Settings, alias: str) -> str:
-    return f"models:/{settings.model_name}@{alias}"
-
-
 @lru_cache(maxsize=8)
 def _load_feature_contract(
     model_name: str, model_spec_path: str
@@ -231,92 +207,11 @@ def _registry_resolves_prod_alias(settings: Settings) -> tuple[bool, str | None]
         return False, f"registry check failed: {e}"
 
 
-def _get_version(settings: Settings, alias: str) -> str | None:
-    if settings.unit_testing or mlflow is None:
-        return None
-    try:
-        client = get_mlflow_client()
-        mv = client.get_model_version_by_alias(settings.model_name, alias)
-        return str(mv.version)
-    except MlflowException:
-        return None
-
-
-def _load_model(settings: Settings, alias: str) -> Any:
-    # Unit tests always use a deterministic stub.
-    if settings.unit_testing:
-        return _UnitTestModel()
-
-    if mlflow is None:
-        raise RuntimeError("mlflow not available in serving image")
-
-    # Guard against broken or stub MLflow installs.
-    pyfunc = getattr(mlflow, "pyfunc", None)
-    if pyfunc is None:
-        raise RuntimeError("mlflow.pyfunc is missing (mlflow install is broken)")
-
-    configure_mlflow()
-    return pyfunc.load_model(_models_uri(settings, alias))
-
-
-def _refresh_models_if_needed(
-    settings: Settings,
-    *,
-    force: bool = False,
-    load_candidate: bool = False,
-) -> None:
-    """Refresh cached models and versions."""
-    global \
-        model_prod, \
-        model_candidate, \
-        prod_version, \
-        candidate_version, \
-        _last_refresh_ts
-
-    now = time.time()
-    cache_is_warm = (now - _last_refresh_ts) < settings.model_cache_ttl_sec
-    needs_prod_refresh = model_prod is None or prod_version is None
-    needs_candidate_refresh = load_candidate and (
-        model_candidate is None or candidate_version is None
-    )
-
-    if (
-        not force
-        and cache_is_warm
-        and not (needs_prod_refresh or needs_candidate_refresh)
-    ):
-        return
-
-    if needs_prod_refresh and model_prod is None:
-        model_prod = _load_model(settings, settings.prod_alias)
-
-    if needs_candidate_refresh and model_candidate is None:
-        model_candidate = _load_model(settings, settings.candidate_alias)
-
-    if needs_prod_refresh:
-        prod_version = prod_version or _get_version(settings, settings.prod_alias)
-    if needs_candidate_refresh:
-        candidate_version = candidate_version or _get_version(
-            settings, settings.candidate_alias
-        )
-
-    _last_refresh_ts = now
-
-
-def _get_model(
-    settings: Settings, alias: Literal["prod", "candidate"], required: bool
-) -> Any | None:
-    _refresh_models_if_needed(settings, load_candidate=(alias == ALIAS_CANDIDATE))
-    model = model_prod if alias == ALIAS_PROD else model_candidate
-    if required and model is None:
-        raise RuntimeError(f"model for alias={alias} is not available")
-    return model
-
-
 def _prod_model_loadable(settings: Settings) -> tuple[bool, str | None]:
     """Return whether the prod model is loadable."""
+    store = get_model_store()
     try:
-        _ = _get_model(settings, ALIAS_PROD, required=True)
+        _ = store.get_model(settings, ALIAS_PROD, required=True)
         return True, None
     except Exception as e:
         return False, f"prod model not loadable: {e}"
@@ -355,13 +250,13 @@ def health() -> dict[str, Any]:
     settings = get_settings()
     _configure_logging(settings)
 
+    store = get_model_store()
     reg_ok, reg_detail = _registry_resolves_prod_alias(settings)
     model_ok = False
     model_detail: str | None = None
     if reg_ok:
         model_ok, model_detail = _prod_model_loadable(settings)
 
-    model_loaded = bool(model_prod is not None and model_ok)
     ready = bool(reg_ok and model_ok)
 
     return {
@@ -370,13 +265,13 @@ def health() -> dict[str, Any]:
         "model_name": settings.model_name,
         "prod_alias": settings.prod_alias,
         "candidate_alias": settings.candidate_alias,
-        "prod_version": prod_version,
-        "candidate_version": candidate_version,
+        "prod_version": store.get_version(ALIAS_PROD),
+        "candidate_version": store.get_version(ALIAS_CANDIDATE),
         "registry_ok": reg_ok,
         "registry_detail": reg_detail,
         "prod_model_ok": model_ok,
         "prod_model_detail": model_detail,
-        "prod_model_loaded": model_loaded,
+        "prod_model_loaded": store.is_prod_loaded(),
         "cache_ttl_sec": settings.model_cache_ttl_sec,
     }
 
@@ -391,6 +286,7 @@ def metrics() -> Response:
 def metadata_model() -> ModelMetadataResponse:
     settings = get_settings()
     _configure_logging(settings)
+    store = get_model_store()
     try:
         contract = _feature_contract(settings)
     except RuntimeError as e:
@@ -400,8 +296,8 @@ def metadata_model() -> ModelMetadataResponse:
         model_name=settings.model_name,
         prod_alias=settings.prod_alias,
         candidate_alias=settings.candidate_alias,
-        prod_version=_get_version(settings, settings.prod_alias),
-        candidate_version=_get_version(settings, settings.candidate_alias),
+        prod_version=store.get_version(ALIAS_PROD),
+        candidate_version=store.get_version(ALIAS_CANDIDATE),
         contract_version=contract.version,
         allow_unknown_fields=contract.allow_unknown_fields,
     )
@@ -447,10 +343,10 @@ async def predict(
 
     bucket: int | None = None
     bucket_seed_source: SeedSource | None = None
-    shadow_mae: float | None = None
 
     try:
         contract = _feature_contract(settings)
+        store = get_model_store()
 
         # Bucket only matters in canary mode.
         if mode == "canary":
@@ -485,47 +381,26 @@ async def predict(
             ALIAS_CANDIDATE if primary_alias == ALIAS_PROD else ALIAS_PROD,
         )
 
-        # Load candidate only when needed.
-        _refresh_models_if_needed(
+        store.refresh_if_needed(
             settings,
             load_candidate=(primary_alias == ALIAS_CANDIDATE or decision.run_shadow),
         )
 
-        # Primary model must exist.
-        model_primary = _get_model(settings, primary_alias, required=True)
-        if model_primary is None:
-            status_code = 503
-            raise HTTPException(
-                status_code=503, detail=f"model not available: {primary_alias}"
-            )
-
-        validated_rows = validate_rows_against_contract(payload.rows, contract)
-        df = pd.DataFrame(validated_rows)
-        y_primary = model_primary.predict(df)  # type: ignore[union-attr]
-        y_primary_list = [float(x) for x in list(y_primary)]
-
-        # Shadow prediction is best-effort.
-        if decision.run_shadow:
-            model_shadow = _get_model(settings, shadow_alias, required=False)
-            if model_shadow is not None:
-                try:
-                    y_shadow = model_shadow.predict(df)  # type: ignore[union-attr]
-                    y_shadow_list = [float(x) for x in list(y_shadow)]
-                    diffs = [abs(a - b) for a, b in zip(y_primary_list, y_shadow_list)]
-                    shadow_mae = sum(diffs) / max(len(diffs), 1)
-                except Exception as e:
-                    logger.warning("shadow prediction failed: %s", e)
+        result = run_prediction(
+            store,
+            settings,
+            primary_alias=primary_alias,
+            shadow_alias=shadow_alias,
+            run_shadow=decision.run_shadow,
+            contract=contract,
+            rows=payload.rows,
+            mode=mode,
+        )
 
         latency_s = time.perf_counter() - t0
 
-        if shadow_mae is not None and math.isfinite(shadow_mae):
-            SHADOW_DIFF_MAE.labels(mode=str(mode)).observe(shadow_mae)
-
-        selected_model_version = (
-            prod_version if primary_alias == ALIAS_PROD else candidate_version
-        )
-        if selected_model_version:
-            response.headers[HEADER_MODEL_VERSION] = selected_model_version
+        if result.chosen_version:
+            response.headers[HEADER_MODEL_VERSION] = result.chosen_version
         response.headers[HEADER_FEATURE_CONTRACT_VERSION] = contract.version
 
         log: dict[str, Any] = {
@@ -540,22 +415,22 @@ async def predict(
             if bucket_seed_source
             else None,
             "canary_pct": settings.canary_pct if mode == "canary" else None,
-            "shadow_mae": shadow_mae,
-            "prod_version": prod_version,
-            "candidate_version": candidate_version,
+            "shadow_mae": result.shadow_mae,
+            "prod_version": store.get_version(ALIAS_PROD),
+            "candidate_version": store.get_version(ALIAS_CANDIDATE),
         }
         logger.info(json.dumps(log, separators=(",", ":")))
 
         return PredictResponse(
             mode=mode,
             n=len(payload.rows),
-            proba=y_primary_list,
+            proba=result.y_primary,
             chosen=primary_alias,
             bucket=bucket,
             canary_pct=settings.canary_pct if mode == "canary" else None,
             bucket_seed_source=str(bucket_seed_source) if bucket_seed_source else None,
             metadata=PredictionMetadata(
-                model_version=selected_model_version,
+                model_version=result.chosen_version,
                 contract_version=contract.version,
             ),
         )

--- a/src/ml_lifecycle_platform/serving/model_store.py
+++ b/src/ml_lifecycle_platform/serving/model_store.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Literal
+
+import pandas as pd
+
+try:
+    import mlflow
+    from mlflow.exceptions import MlflowException
+except Exception:  # pragma: no cover
+    mlflow = None  # type: ignore[assignment]
+    MlflowException = Exception  # type: ignore[assignment, misc]
+
+from ml_lifecycle_platform.common.mlflow_utils import client as get_mlflow_client
+from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
+
+from .constants import ALIAS_CANDIDATE, ALIAS_PROD
+from .settings import Settings
+
+
+class _UnitTestModel:
+    """Deterministic stub used when UNIT_TESTING=1."""
+
+    def predict(self, df: pd.DataFrame) -> list[float]:
+        return [1.0] * len(df)
+
+
+def _load_model_from_registry(settings: Settings, alias: str) -> Any:
+    if settings.unit_testing:
+        return _UnitTestModel()
+
+    if mlflow is None:
+        raise RuntimeError("mlflow not available in serving image")
+
+    pyfunc = getattr(mlflow, "pyfunc", None)
+    if pyfunc is None:
+        raise RuntimeError("mlflow.pyfunc is missing (mlflow install is broken)")
+
+    configure_mlflow()
+    return pyfunc.load_model(f"models:/{settings.model_name}@{alias}")
+
+
+def _resolve_version(settings: Settings, alias: str) -> str | None:
+    if settings.unit_testing or mlflow is None:
+        return None
+    try:
+        client = get_mlflow_client()
+        mv = client.get_model_version_by_alias(settings.model_name, alias)
+        return str(mv.version)
+    except MlflowException:
+        return None
+
+
+class ModelStore:
+    """Thread-safe cache for prod and candidate models."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.model_prod: Any | None = None
+        self.model_candidate: Any | None = None
+        self.prod_version: str | None = None
+        self.candidate_version: str | None = None
+        self._last_refresh_ts: float = 0.0
+
+    def reset(self) -> None:
+        with self._lock:
+            self.model_prod = None
+            self.model_candidate = None
+            self.prod_version = None
+            self.candidate_version = None
+            self._last_refresh_ts = 0.0
+
+    def refresh_if_needed(
+        self,
+        settings: Settings,
+        *,
+        force: bool = False,
+        load_candidate: bool = False,
+    ) -> None:
+        with self._lock:
+            now = time.time()
+            cache_is_warm = (now - self._last_refresh_ts) < settings.model_cache_ttl_sec
+            needs_prod_refresh = self.model_prod is None or self.prod_version is None
+            needs_candidate_refresh = load_candidate and (
+                self.model_candidate is None or self.candidate_version is None
+            )
+
+            if (
+                not force
+                and cache_is_warm
+                and not (needs_prod_refresh or needs_candidate_refresh)
+            ):
+                return
+
+            if needs_prod_refresh and self.model_prod is None:
+                self.model_prod = _load_model_from_registry(
+                    settings, settings.prod_alias
+                )
+
+            if needs_candidate_refresh and self.model_candidate is None:
+                self.model_candidate = _load_model_from_registry(
+                    settings, settings.candidate_alias
+                )
+
+            if needs_prod_refresh:
+                self.prod_version = self.prod_version or _resolve_version(
+                    settings, settings.prod_alias
+                )
+            if needs_candidate_refresh:
+                self.candidate_version = self.candidate_version or _resolve_version(
+                    settings, settings.candidate_alias
+                )
+
+            self._last_refresh_ts = now
+
+    def get_model(
+        self,
+        settings: Settings,
+        alias: Literal["prod", "candidate"],
+        required: bool,
+    ) -> Any | None:
+        self.refresh_if_needed(settings, load_candidate=(alias == ALIAS_CANDIDATE))
+        with self._lock:
+            model = self.model_prod if alias == ALIAS_PROD else self.model_candidate
+        if required and model is None:
+            raise RuntimeError(f"model for alias={alias} is not available")
+        return model
+
+    def get_version(self, alias: Literal["prod", "candidate"]) -> str | None:
+        with self._lock:
+            return self.prod_version if alias == ALIAS_PROD else self.candidate_version
+
+    def is_prod_loaded(self) -> bool:
+        return self.model_prod is not None
+
+
+_store = ModelStore()
+
+
+def get_model_store() -> ModelStore:
+    return _store

--- a/src/ml_lifecycle_platform/serving/prediction.py
+++ b/src/ml_lifecycle_platform/serving/prediction.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pandas as pd
+
+from ml_lifecycle_platform.core.feature_contracts import (
+    validate_rows_against_contract,
+)
+from ml_lifecycle_platform.core.model_spec_types import FeatureContractSpec
+
+from .metrics import SHADOW_DIFF_MAE
+from .model_store import ModelStore
+from .router import Mode
+from .settings import Settings
+
+logger = logging.getLogger("serving")
+
+
+@dataclass
+class PredictionResult:
+    y_primary: list[float]
+    shadow_mae: float | None
+    chosen_version: str | None
+
+
+def run_prediction(
+    store: ModelStore,
+    settings: Settings,
+    *,
+    primary_alias: Literal["prod", "candidate"],
+    shadow_alias: Literal["prod", "candidate"],
+    run_shadow: bool,
+    contract: FeatureContractSpec,
+    rows: list[dict[str, Any]],
+    mode: Mode,
+) -> PredictionResult:
+    validated_rows = validate_rows_against_contract(rows, contract)
+    df = pd.DataFrame(validated_rows)
+
+    model_primary = store.get_model(settings, primary_alias, required=True)
+    if model_primary is None:
+        raise RuntimeError(f"model not available: {primary_alias}")
+
+    y_primary = [float(x) for x in model_primary.predict(df)]
+
+    shadow_mae: float | None = None
+    if run_shadow:
+        model_shadow = store.get_model(settings, shadow_alias, required=False)
+        if model_shadow is not None:
+            try:
+                y_shadow = [float(x) for x in model_shadow.predict(df)]
+                diffs = [abs(a - b) for a, b in zip(y_primary, y_shadow)]
+                shadow_mae = sum(diffs) / max(len(diffs), 1)
+            except Exception as e:
+                logger.warning("shadow prediction failed: %s", e)
+
+    if shadow_mae is not None and math.isfinite(shadow_mae):
+        SHADOW_DIFF_MAE.labels(mode=str(mode)).observe(shadow_mae)
+
+    return PredictionResult(
+        y_primary=y_primary,
+        shadow_mae=shadow_mae,
+        chosen_version=store.get_version(primary_alias),
+    )

--- a/tests/integration/test_reproduce.py
+++ b/tests/integration/test_reproduce.py
@@ -42,17 +42,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _latest_train_run_id(experiment_id: str) -> str:
+    import pandas as pd
+
     runs = mlflow.search_runs(
         experiment_ids=[experiment_id],
         filter_string=f"tags.{TAG_STEP} = '{STEP_TRAIN}'",
         order_by=["attributes.start_time DESC"],
         max_results=1,
     )
-    if hasattr(runs, "empty") and hasattr(runs, "iloc"):
-        assert not runs.empty
-        return str(runs.iloc[0]["run_id"])
-    assert isinstance(runs, list)
-    return str(runs[0].info.run_id)
+    assert isinstance(runs, pd.DataFrame) and not runs.empty
+    return str(runs.iloc[0]["run_id"])
 
 
 def _configure_local_pipeline_paths(
@@ -62,13 +61,8 @@ def _configure_local_pipeline_paths(
     data_dir = tmp_path / "data"
     art_dir = tmp_path / "artifacts"
 
-    monkeypatch.setattr(ingest_mod, "DATA_DIR", data_dir)
-    monkeypatch.setattr(featurize_mod, "DATA_DIR", data_dir)
-    monkeypatch.setattr(featurize_mod, "ART_DIR", art_dir)
-    monkeypatch.setattr(train_mod, "DATA_DIR", data_dir)
-    monkeypatch.setattr(train_mod, "ART_DIR", art_dir)
-    monkeypatch.setattr(evaluate_mod, "DATA_DIR", data_dir)
-    monkeypatch.setattr(evaluate_mod, "ART_DIR", art_dir)
+    monkeypatch.setenv("MLP_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MLP_ARTIFACTS_DIR", str(art_dir))
     monkeypatch.setattr(register_mod, "ART_DIR", art_dir)
 
     return data_dir, art_dir

--- a/tests/unit/serving/tests/conftest.py
+++ b/tests/unit/serving/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from fastapi.testclient import TestClient
 
+from ml_lifecycle_platform.serving.model_store import get_model_store
 from ml_lifecycle_platform.serving.settings import get_settings
 
 
@@ -24,12 +25,8 @@ def client(monkeypatch: MonkeyPatch) -> Iterator[TestClient]:
     # Import after env vars are set.
     import ml_lifecycle_platform.serving.app as app_module
 
-    # Clear the global model cache between tests.
-    app_module.model_prod = None
-    app_module.model_candidate = None
-    app_module.prod_version = None
-    app_module.candidate_version = None
-    app_module._last_refresh_ts = 0.0
+    # Reset the model store and feature contract cache between tests.
+    get_model_store().reset()
     app_module._load_feature_contract.cache_clear()
 
     try:

--- a/tests/unit/serving/tests/test_readiness.py
+++ b/tests/unit/serving/tests/test_readiness.py
@@ -27,18 +27,17 @@ def test_livez_does_not_require_mlflow_configuration_on_startup(
     get_settings.cache_clear()
 
     import ml_lifecycle_platform.serving.app as app_module
+    import ml_lifecycle_platform.serving.model_store as model_store_module
 
-    app_module.model_prod = None
-    app_module.model_candidate = None
-    app_module.prod_version = None
-    app_module.candidate_version = None
-    app_module._last_refresh_ts = 0.0
+    from ml_lifecycle_platform.serving.model_store import get_model_store
+
+    get_model_store().reset()
     app_module._load_feature_contract.cache_clear()
 
     def fail_configure_mlflow() -> None:
         raise AssertionError("configure_mlflow should not run during FastAPI startup")
 
-    monkeypatch.setattr(app_module, "configure_mlflow", fail_configure_mlflow)
+    monkeypatch.setattr(model_store_module, "configure_mlflow", fail_configure_mlflow)
 
     try:
         with TestClient(app_module.app) as test_client:

--- a/tests/unit/test_feature_contracts.py
+++ b/tests/unit/test_feature_contracts.py
@@ -6,7 +6,10 @@ from ml_lifecycle_platform.core.feature_contracts import (
     FeatureContractValidationError,
     validate_rows_against_contract,
 )
-from ml_lifecycle_platform.core.model_specs import FeatureContractSpec, FeatureFieldSpec
+from ml_lifecycle_platform.core.model_spec_types import (
+    FeatureContractSpec,
+    FeatureFieldSpec,
+)
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_model_specs.py
+++ b/tests/unit/test_model_specs.py
@@ -8,11 +8,8 @@ from ml_lifecycle_platform.common.constants import (
     MODEL_SPEC_SCHEMA_VERSION,
     TAG_CONFIG_HASH,
 )
-from ml_lifecycle_platform.core.model_specs import (
-    default_policy_spec,
-    load_model_spec,
-    model_spec_from_dict,
-)
+from ml_lifecycle_platform.core.model_spec_types import default_policy_spec
+from ml_lifecycle_platform.core.model_specs import load_model_spec, model_spec_from_dict
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_release_policy.py
+++ b/tests/unit/test_release_policy.py
@@ -20,7 +20,7 @@ from ml_lifecycle_platform.common.constants import (
     TAG_SOURCE_RUN_ID,
     TAG_TRAINING_RUN_ID,
 )
-from ml_lifecycle_platform.core.model_specs import (
+from ml_lifecycle_platform.core.model_spec_types import (
     MetricThresholdSpec,
     PolicySpec,
     default_policy_spec,


### PR DESCRIPTION
## Summary

- Extracted \`ModelStore\` class to \`model_store.py\` — thread-safe prod/candidate model cache with \`threading.Lock\`, replacing racy module-level globals in \`app.py\`
- Extracted \`run_prediction()\` to \`prediction.py\` — validation, primary + shadow prediction, MAE metric emission, returning typed \`PredictionResult\` dataclass
- \`app.py\` reduced from ~587 to ~280 lines; contains only routing, middleware, and response shaping
- Unit tests updated: \`get_model_store().reset()\` replaces direct attribute resets; \`configure_mlflow\` patch moved to \`model_store\` module

## Test plan

- [x] \`make check\` — 129 passed, 8 deselected