### PR TITLE
refactor: make pipeline path linear to read (P06)

### DIFF
--- a/src/ml_lifecycle_platform/cli/main.py
+++ b/src/ml_lifecycle_platform/cli/main.py
@@ -25,7 +25,7 @@ def _git_sha() -> str:
             cwd=_repo_root(),
             stderr=subprocess.DEVNULL,
         )
-    except Exception:
+    except (subprocess.SubprocessError, OSError):
         return "dev"
     return output.decode("utf-8").strip()
 

--- a/src/ml_lifecycle_platform/pipeline/evaluate.py
+++ b/src/ml_lifecycle_platform/pipeline/evaluate.py
@@ -21,7 +21,7 @@ from ml_lifecycle_platform.common.mlflow_utils import ensure_experiment, write_j
 from ml_lifecycle_platform.runtime.bootstrap import get_runtime_context
 from ml_lifecycle_platform.core.batch_contracts import validate_labeled_dataset
 from ml_lifecycle_platform.core.model_specs import load_model_spec
-from ml_lifecycle_platform.pipeline.train import compute_binary_metrics
+from ml_lifecycle_platform.pipeline.metrics import compute_binary_metrics
 
 
 def main() -> None:

--- a/src/ml_lifecycle_platform/pipeline/metrics.py
+++ b/src/ml_lifecycle_platform/pipeline/metrics.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
+
+
+def compute_binary_metrics(
+    *,
+    metric_names: tuple[str, ...],
+    y_true: pd.Series,
+    pred: Any,
+    proba: Any,
+    prefix: str,
+) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for metric_name in metric_names:
+        if metric_name == "accuracy":
+            value = accuracy_score(y_true, pred)
+        elif metric_name == "f1":
+            value = f1_score(y_true, pred)
+        elif metric_name == "roc_auc":
+            value = roc_auc_score(y_true, proba)
+        else:  # pragma: no cover
+            raise ValueError(f"Unsupported metric: {metric_name}")
+        metrics[f"{prefix}_{metric_name}"] = float(value)
+    return metrics

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -11,7 +11,6 @@ import mlflow
 import pandas as pd
 from mlflow.models.signature import infer_signature
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 from sklearn.pipeline import Pipeline
 
 from ml_lifecycle_platform.common.constants import (
@@ -44,6 +43,7 @@ from ml_lifecycle_platform.common.repro import (
     sha256_text,
 )
 from ml_lifecycle_platform.core.batch_contracts import validate_labeled_dataset
+from ml_lifecycle_platform.pipeline.metrics import compute_binary_metrics
 from ml_lifecycle_platform.contracts.dataset_fingerprint import (
     DatasetFingerprint,
     compute_fingerprint,
@@ -93,28 +93,6 @@ def trainer_params_for_spec(spec: ModelSpec) -> dict[str, str | int]:
         "class_weight": spec.trainer.class_weight,
         "random_state": spec.trainer.random_state,
     }
-
-
-def compute_binary_metrics(
-    *,
-    metric_names: tuple[str, ...],
-    y_true: pd.Series,
-    pred: Any,
-    proba: Any,
-    prefix: str,
-) -> dict[str, float]:
-    metrics: dict[str, float] = {}
-    for metric_name in metric_names:
-        if metric_name == "accuracy":
-            value = accuracy_score(y_true, pred)
-        elif metric_name == "f1":
-            value = f1_score(y_true, pred)
-        elif metric_name == "roc_auc":
-            value = roc_auc_score(y_true, proba)
-        else:  # pragma: no cover
-            raise ValueError(f"Unsupported metric: {metric_name}")
-        metrics[f"{prefix}_{metric_name}"] = float(value)
-    return metrics
 
 
 def load_training_inputs(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -352,13 +352,11 @@ def test_run_e2e_uses_ephemeral_host_ports_for_local_services(
 
     def fake_subprocess_run(
         command: list[str],
-        *,
-        check: bool,
-        cwd: Path,
-        env: dict[str, str],
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess[bytes]:
-        del check, cwd
-        teardown_envs.append(dict(env))
+        if kwargs.get("stdout") is not None:
+            return subprocess.CompletedProcess(command, 0, stdout=b"deadbeef")
+        teardown_envs.append(dict(kwargs.get("env") or {}))
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(cli_main, "_run", fake_run)


### PR DESCRIPTION
## Summary

- Extract `compute_binary_metrics` to `pipeline/metrics.py` so `evaluate.py` no longer imports from a sibling pipeline step
- Narrow `except Exception` to `(subprocess.SubprocessError, OSError)` in `_git_sha()`, consistent with P07b exception-handling pass
- Fix test mock in `test_cli.py` that was silently relying on the broad exception catch to swallow a `TypeError` from `subprocess.check_output`

## Test plan

- [x] `make check` — 129 passed, 0 failed

Closes #124