### PR TITLE
docs: reset repo story and architecture truth for OSS contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Keep changes small, test-backed, and easy to review.
 
+You do not need a GCP account to contribute. The normal contribution path is local-only: clone, `uv sync --dev`, `make check`, `make e2e`. The hosted GCP staging path is a maintainer-only advanced path and is not required for any normal PR.
+
 ## Before opening a PR
 
 Match verification to the scope of the change:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![CI](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml)
 [![Local E2E](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
-[![Staging Verification](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml)
 [![CodeQL](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/codeql.yml)
 [![Secrets](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/gitleaks.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/gitleaks.yml)
 [![Coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)
+[![Staging Verification](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml)
 
 An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. The current implementation is local-first with Terraform-managed GCP foundation and staging infra plus GitHub Actions-produced runtime images ready for hosted rollout.
 
@@ -26,8 +26,12 @@ hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging
 ## Handbook Entry Points
 
 - [`docs/README.md`](docs/README.md): handbook index
+- [`docs/runbooks/local-bootstrap.md`](docs/runbooks/local-bootstrap.md): fresh-clone local setup and golden path
 - [`docs/architecture/overview.md`](docs/architecture/overview.md): system boundaries and current topology
-- [`docs/ci.md`](docs/ci.md): presubmit, postsubmit, CD, and staging validation contract
+- [`docs/ci.md`](docs/ci.md): contributor checks and CI lane reference
+
+Advanced (hosted — maintainer only):
+
 - [`docs/runbooks/hosted-golden-path.md`](docs/runbooks/hosted-golden-path.md): canonical hosted staging validation path
 - [`docs/runbooks/gcp-bootstrap.md`](docs/runbooks/gcp-bootstrap.md): bootstrap and hosted foundation setup
 
@@ -158,12 +162,15 @@ Quality:
 - `make test-integration`
 - `make test-all`
 
-Infra:
+Local infra:
 
 - `make up`
 - `make down`
 - `make logs`
 - `make build`
+
+Advanced (hosted infra — maintainer only):
+
 - `make terraform-gcp-fmt`
 - `make terraform-gcp-init`
 - `make terraform-gcp-plan`

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 Start here if you want to run or change the local platform.
 
+**Contributor path in three steps:** clone the repo → `uv sync --dev` → `make e2e`.
+That is the full local golden path. You do not need a GCP account.
+The hosted staging path is a separate advanced path documented under [Advanced hosted runbooks](#advanced-hosted-runbooks) below.
+
 ## Golden path
 
 1. Read [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md).
@@ -12,28 +16,33 @@ Start here if you want to run or change the local platform.
 ## Architecture
 
 - [`simplification-charter.md`](./simplification-charter.md): what "simpler" means in this repo, execution order, refactor guardrails, and core OSS vs hosted surface split
-- [`architecture/how-it-works.md`](./architecture/how-it-works.md): fastest current explanation of the local path, hosted staging path, operator flows, and live boundaries
+- [`architecture/how-it-works.md`](./architecture/how-it-works.md): fastest current explanation of the local path, operator flows, and live boundaries
 - [`architecture/overview.md`](./architecture/overview.md): current local and hosted topology, boundaries, and lifecycle
 - [`architecture/local-runtime.md`](./architecture/local-runtime.md): runtime profiles, model specs, serving contract, local paths
 - [`architecture/current-state.md`](./architecture/current-state.md): current implemented scope and non-goals
-- [`architecture/m2-staging-platform.md`](./architecture/m2-staging-platform.md): fixed decisions and execution order for the first hosted GCP staging platform
+- [`architecture/m2-staging-platform.md`](./architecture/m2-staging-platform.md): fixed decisions for the first hosted GCP staging platform (advanced — maintainer only)
 
-## Runbooks
+## Local runbooks
 
 - [`runbooks/local-bootstrap.md`](./runbooks/local-bootstrap.md): fresh-clone local setup and golden path
+- [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
+- [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
+- [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model
+
+## Advanced hosted runbooks
+
+These runbooks cover the GCP staging path. You do not need them for normal local contribution.
+
+- [`runbooks/hosted-golden-path.md`](./runbooks/hosted-golden-path.md): canonical hosted GCP publish-deploy-validate path
 - [`runbooks/gcp-bootstrap.md`](./runbooks/gcp-bootstrap.md): adopt the existing GCP project and Terraform backend
 - [`runbooks/gcp-foundation.md`](./runbooks/gcp-foundation.md): create the first hosted GCP foundation resources
 - [`runbooks/gcp-staging-infra.md`](./runbooks/gcp-staging-infra.md): provision the stateful staging infra for hosted MLflow
 - [`runbooks/deploy-mlflow.md`](./runbooks/deploy-mlflow.md): build, deploy, and verify hosted MLflow staging
 - [`runbooks/deploy-serving.md`](./runbooks/deploy-serving.md): deploy the serving API to hosted staging and run authenticated smoke checks
 - [`runbooks/deploy-platform-jobs.md`](./runbooks/deploy-platform-jobs.md): deploy hosted Cloud Run jobs and run them manually
-- [`runbooks/hosted-golden-path.md`](./runbooks/hosted-golden-path.md): run the canonical hosted GCP publish-deploy-validate path
 - [`runbooks/schedule-platform-jobs.md`](./runbooks/schedule-platform-jobs.md): inspect, pause, resume, and verify Cloud Scheduler for hosted jobs
-- [`runbooks/serving-staging-baseline.md`](./runbooks/serving-staging-baseline.md): run the first advisory k6 baseline against hosted serving staging
+- [`runbooks/serving-staging-baseline.md`](./runbooks/serving-staging-baseline.md): advisory k6 baseline against hosted serving staging
 - [`runbooks/gcp-ci-auth.md`](./runbooks/gcp-ci-auth.md): verify GitHub Actions OIDC auth into GCP
-- [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
-- [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
-- [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model
 
 ## Delivery docs
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last verified: 2026-03-17
+Last verified: 2026-04-17
 
 ## Summary
 
@@ -69,7 +69,7 @@ models:/<model_name>@prod
   - daily hosted maintenance cadence
   - paused hosted pipeline cadence placeholder
 
-## Current hosted staging state
+## Current hosted staging state (advanced — maintainer only)
 
 - hosted MLflow staging is live and verified
 - hosted serving staging deploy path exists and is wired to hosted MLflow
@@ -82,6 +82,8 @@ models:/<model_name>@prod
 
 ## Code layout
 
+Core OSS surface (local golden path):
+
 - `src/ml_lifecycle_platform/pipeline/`: pipeline steps and orchestration
 - `src/ml_lifecycle_platform/registry/`: register, promote, rollback, reproduce
 - `src/ml_lifecycle_platform/policy/`: promotion policy
@@ -90,6 +92,11 @@ models:/<model_name>@prod
 - `src/ml_lifecycle_platform/core/`: model specs and protocol definitions
 - `src/ml_lifecycle_platform/contracts/`: lineage and repro payloads
 - `src/ml_lifecycle_platform/backends/local/`: local adapters
+- `src/ml_lifecycle_platform/common/`: shared config constants and MLflow helpers
+
+Advanced hosted surface (maintainer only):
+
+- `src/ml_lifecycle_platform/ci/`: hosted CI helpers for GitHub Actions workflows
 
 ## Defaults
 

--- a/docs/architecture/how-it-works.md
+++ b/docs/architecture/how-it-works.md
@@ -1,6 +1,6 @@
 # How It Works Now
 
-Last verified: 2026-03-17
+Last verified: 2026-04-17
 
 This page is the shortest current explanation of how the repo works in practice.
 
@@ -8,7 +8,7 @@ Use it when you want the operator path and current boundaries without reading ev
 
 ## Two real paths
 
-The repo now has two real operating paths:
+The repo has two operating paths. The local path is the contributor default. The hosted staging path is an advanced maintainer path — you do not need it to contribute.
 
 ### Local path
 
@@ -33,7 +33,7 @@ Main entrypoint:
 
 - [`../runbooks/local-bootstrap.md`](../runbooks/local-bootstrap.md)
 
-## Hosted staging path
+## Hosted staging path (advanced — maintainer only)
 
 Used for:
 
@@ -235,7 +235,14 @@ Still out of scope:
 
 ## Where to read next
 
+Local contributor path:
+
+- [`../runbooks/local-bootstrap.md`](../runbooks/local-bootstrap.md)
 - [`./current-state.md`](./current-state.md)
+- [`./overview.md`](./overview.md)
+
+Advanced hosted path (maintainer only):
+
 - [`./m2-staging-platform.md`](./m2-staging-platform.md)
 - [`../runbooks/deploy-platform-jobs.md`](../runbooks/deploy-platform-jobs.md)
 - [`../runbooks/schedule-platform-jobs.md`](../runbooks/schedule-platform-jobs.md)

--- a/docs/architecture/m2-staging-platform.md
+++ b/docs/architecture/m2-staging-platform.md
@@ -1,6 +1,8 @@
 # M2 Staging Platform
 
-Last verified: 2026-03-17
+> **Advanced — maintainer only.** This document covers the hosted GCP staging path. You do not need it to contribute locally.
+
+Last verified: 2026-04-17
 
 This document locks the intended shape for `M2`: the first hosted GCP staging platform.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,7 @@
 # Overview
 
+The local path is the contributor default. The hosted GCP staging path is an advanced maintainer-only path — you do not need it to contribute. See [`how-it-works.md`](./how-it-works.md) for the contributor-oriented explanation.
+
 This repo currently has one real local path and one real hosted staging path:
 
 ```text
@@ -23,6 +25,8 @@ The local path is fully operational. The hosted staging path is operational for 
 - Cloud Scheduler drives the conservative maintenance cadence.
 
 ## Current topology
+
+The `developer shell` section below is the local contributor path. The `GitHub Actions` and `GCP staging infra` sections are the advanced hosted path.
 
 ```text
 developer shell

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,10 +1,24 @@
 # CI and CD
 
+## Contributor checks
+
+These are the commands you run locally before opening a PR:
+
+- `make check`: format, lint, typecheck, fast tests
+- `make docs-check`: handbook link and local doc path validation
+- `make test-integration`: integration lane
+- `make e2e`: full local golden path with teardown
+- `make test-e2e`: same flow, keeps the stack up for debugging
+
+You do not need a GCP account or any hosted credentials for these checks.
+
+## Full workflow matrix
+
 The repo uses three workflow groups:
 
 - `CI`: fast developer feedback plus the local nightly E2E lane
-- `CD`: hosted image publication, staged deploy, and staged release validation
-- `Ops`: manual staging validation, debugging, and recovery workflows
+- `CD`: hosted image publication, staged deploy, and staged release validation (maintainer only)
+- `Ops`: manual staging validation, debugging, and recovery workflows (maintainer only)
 
 Current lanes:
 
@@ -26,14 +40,9 @@ Current lanes:
 | `Ops / Run Platform Job / Staging` | manual dispatch and reusable workflow call | executes one deployed Cloud Run Job in staging with an optional args override |
 | `Ops / Serving Baseline / Staging` | manual dispatch | runs an advisory k6 baseline against the direct hosted serving staging URL and uploads artifacts |
 
-## Local mapping
+Local mirror of `CI / Infra Validation`:
 
-- `make check`: format, lint, typecheck, fast tests
-- `make docs-check`: handbook link and local doc path validation
-- `make test-integration`: integration lane
-- `make e2e`: full local golden path with teardown
-- `make test-e2e`: same flow, keeps the stack up for debugging
-- `make terraform-gcp-fmt` + `make terraform-gcp-validate`: local mirror of `CI / Infra Validation`
+- `make terraform-gcp-fmt` + `make terraform-gcp-validate`
 
 ## Default rule set
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,10 +7,8 @@ It covers what exists today:
 - local runtime profiles
 - env var overrides
 - serving-only env vars
-- hosted staging secrets created by Terraform
-- hosted MLflow and serving runtime env contracts
-
-It does not pretend hosted deploy config already exists. That belongs to later M2 PRs.
+- hosted staging secrets created by Terraform (advanced — maintainer only)
+- hosted MLflow and serving runtime env contracts (advanced — maintainer only)
 
 ## Source of truth order
 
@@ -129,7 +127,7 @@ Non-obvious constraint:
 - `MODEL_NAME` and `MLP_MODEL_SPEC_PATH` must describe the same model.
 - If they drift, serving fails on startup or request validation with an explicit error.
 
-## Hosted staging secrets
+## Hosted staging secrets (advanced — maintainer only)
 
 `UP-16` created the active staged MLflow secret contract:
 
@@ -156,7 +154,7 @@ Legacy foundation placeholders still exist:
 
 Treat those as reserved foundation names, not the active hosted-staging contract.
 
-## Hosted MLflow runtime env
+## Hosted MLflow runtime env (advanced — maintainer only)
 
 The hosted MLflow Cloud Run service uses a narrower env surface than the local Compose server.
 
@@ -181,7 +179,7 @@ Hosted MLflow does not use the local Compose-only settings such as:
 
 Those remain local-runtime concerns.
 
-## Hosted serving runtime env
+## Hosted serving runtime env (advanced — maintainer only)
 
 The hosted serving Cloud Run service uses plain env vars, not new secrets.
 


### PR DESCRIPTION
## Summary

- **README.md**: Staging Verification badge moved to last; handbook entry points split into local (bootstrap, overview, ci) and Advanced (hosted golden path, GCP bootstrap); Terraform commands separated from local infra under "Advanced (hosted infra)"
- **docs/README.md**: three-line contributor map added at top (clone → `uv sync --dev` → `make e2e`, no GCP needed); runbooks split into Local (4) and Advanced hosted (10) sections; `m2-staging-platform.md` labeled as advanced
- **CONTRIBUTING.md**: explicit note added up front — no GCP account needed, hosted path is maintainer-only
- **docs/ci.md**: contributor checks (5 local `make` commands + no-GCP note) moved to top; full 14-lane workflow matrix demoted below under "Full workflow matrix"
- **docs/architecture/how-it-works.md**: hosted staging section labeled "(advanced — maintainer only)"; "Where to read next" split into local and advanced subsections; date updated to 2026-04-17
- **docs/architecture/current-state.md**: hosted staging state section labeled "(advanced — maintainer only)"; code layout expanded with `common/` (core OSS) and `ci/` (advanced hosted); date updated to 2026-04-17
- **docs/architecture/overview.md**: note added at top pointing contributors to `how-it-works.md`; topology section clarifies which parts are local vs hosted
- **docs/architecture/m2-staging-platform.md**: "Advanced — maintainer only" callout added at top; date updated to 2026-04-17
- **docs/reference/configuration.md**: stale "belongs to later M2 PRs" language removed; hosted staging secrets, hosted MLflow env, and hosted serving env sections labeled "(advanced — maintainer only)"

## Test plan

- [x] `make docs-check` passes

Closes #121