### PR TITLE
ci: define CI/CD cadence and trigger policy for hosted golden path (P01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI / Presubmit and Postsubmit
 
 on:
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: Local E2E
+name: CI / Local E2E
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/hosted-golden-path-staging.yml
+++ b/.github/workflows/hosted-golden-path-staging.yml
@@ -1,6 +1,6 @@
-name: Staging Verification
+name: CD / Release Validation / Staging
 
-run-name: staging release validation / ${{ github.event_name }} / ${{ github.ref_name }}
+run-name: release validation / ${{ github.event_name }} / ${{ github.ref_name }}
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # ML Lifecycle Platform
 
-[![CI](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml)
-[![Local E2E](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
-[![CodeQL](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/codeql.yml)
-[![Secrets](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/gitleaks.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/gitleaks.yml)
-[![Coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)
-[![Staging Verification](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml/badge.svg?branch=master)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml)
+[![ci](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/ci.yml?branch=master&label=ci)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml)
+[![e2e](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/e2e.yml?branch=master&label=e2e)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
+[![staging](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/hosted-golden-path-staging.yml?branch=master&label=staging)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml)
+[![coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)
+[![release](https://img.shields.io/github/v/release/jellewillekes/ml-lifecycle-platform?label=release)](https://github.com/jellewillekes/ml-lifecycle-platform/releases)
+[![python](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fjellewillekes%2Fml-lifecycle-platform%2Fmaster%2Fpyproject.toml&label=python)](pyproject.toml)
+[![license](https://img.shields.io/github/license/jellewillekes/ml-lifecycle-platform?label=license)](LICENSE)
+
+_Spec-driven ML lifecycle platform with MLflow as the control plane — local-first, with hosted GCP staging._
 
 An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. The current implementation is local-first with Terraform-managed GCP foundation and staging infra plus GitHub Actions-produced runtime images ready for hosted rollout.
+
+```text
+local path:   train -> register -> promote -> serve
+hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging validation
+```
 
 [Quick Start](#quick-start) · [Architecture](docs/architecture/overview.md) · [CI/CD](docs/ci.md) · [Hosted Staging Runbook](docs/runbooks/hosted-golden-path.md) · [Contributing](CONTRIBUTING.md)
 
@@ -17,11 +25,6 @@ An ML platform for training, evaluating, registering, promoting, serving, and re
 - hosted staging exists for image publication, staged deploy, and release validation
 - the supported first validation path is local `make e2e`
 - production rollout and multi-environment promotion remain out of scope
-
-```text
-local path:   train -> register -> promote -> serve
-hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging validation
-```
 
 ## Handbook Entry Points
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -30,34 +30,45 @@ local PR.
 
 ## Maintainer reference (hosted workflows)
 
-The remaining sections describe the hosted GCP workflows, branch-protection
-expectations, and trigger policy. They are not required reading for normal
-contribution.
+The remaining sections describe the hosted GCP workflows, the CI/CD cadence
+contract, branch-protection expectations, and the trigger policy. They are not
+required reading for normal contribution.
+
+### Workflow classification
+
+Every workflow in this repo belongs to exactly one of three lanes. The workflow
+`name:` field carries the lane prefix so the Actions sidebar makes intent
+obvious at a glance.
+
+- `CI`: fast developer feedback plus the local nightly E2E lane. Runs on every
+  pull request and every push to `master`. No GCP credentials required.
+- `CD`: hosted image publication, staged deploy, and staged release validation.
+  Maintainer only. Runs against staging when hosted-relevant paths change.
+- `Ops`: manual staging validation, debugging, and recovery workflows.
+  Maintainer only. Never auto-triggered on pull requests or pushes.
+
+Security-scanning workflows (`CodeQL`, `Gitleaks`, `Zizmor`) and repo-hygiene
+workflows (`PR Title`, `Release Please`) keep short standalone names because
+they target the repository itself, not a runtime environment.
 
 ### Full workflow matrix
 
-The repo uses three workflow groups:
-
-- `CI`: fast developer feedback plus the local nightly E2E lane
-- `CD`: hosted image publication, staged deploy, and staged release validation (maintainer only)
-- `Ops`: manual staging validation, debugging, and recovery workflows (maintainer only)
-
-Current lanes:
-
-| Lane | Trigger | Purpose |
+| Workflow | Trigger | Purpose |
 | --- | --- | --- |
 | `CI / Presubmit and Postsubmit` | pull requests, push to `master`, manual dispatch | presubmit hygiene, lint, docs validation, typecheck, unit tests, Docker build safety, plus postsubmit integration tests on `master` |
-| `CI / Infra Validation` | pull requests and push to `master` when GCP Terraform paths change, manual dispatch | non-mutating Terraform fmt, backend-less init, and validate for the hosted staging foundation |
+| `CI / Infra Validation` | path-filtered pull requests and push to `master`, manual dispatch | non-mutating Terraform fmt, backend-less init, and validate for the hosted staging foundation |
 | `CI / Local E2E` | nightly and manual dispatch | dockerized local golden path |
 | `CodeQL` | pull requests, push to `master`, weekly, manual dispatch | native GitHub code scanning for source vulnerabilities and coding errors |
 | `Gitleaks` | pull requests, push to `master`, weekly, manual dispatch | secret scanning for committed credentials, keys, and tokens |
 | `Zizmor` | pull requests, push to `master`, weekly, manual dispatch | GitHub Actions security lint and SARIF upload |
-| `Ops / Verify GCP Auth` | push to `master` when auth or staging-foundation paths change, manual dispatch, path-filtered pull requests | GitHub OIDC to GCP WIF verification plus hosted-foundation prerequisite checks |
+| `PR Title` | pull requests | Conventional Commits PR title check |
+| `Release Please` | push to `master`, manual dispatch | release-please PR maintenance |
+| `Ops / Verify GCP Auth` | path-filtered pull requests, path-filtered push to `master`, manual dispatch | GitHub OIDC to GCP WIF verification plus hosted-foundation prerequisite checks |
 | `CD / Publish Hosted Images` | reusable workflow call and manual dispatch | builds, smoke-checks, and publishes hosted runtime images to Artifact Registry |
 | `CD / Deploy MLflow / Staging` | manual dispatch and reusable workflow call | deploys hosted MLflow from a digest-pinned image and runs authenticated smoke checks |
 | `CD / Deploy Serving / Staging` | manual dispatch and reusable workflow call | deploys hosted serving from a digest-pinned image and runs authenticated smoke checks |
 | `CD / Deploy Platform Jobs / Staging` | manual dispatch and reusable workflow call | deploys hosted Cloud Run Jobs from a digest-pinned platform image and preserves the current MLflow/serving images |
-| `CD / Release Validation / Staging` | push to `master` when hosted-relevant paths change, nightly, manual dispatch | canonical hosted publish-deploy-validate path with explicit staging fixture preparation |
+| `CD / Release Validation / Staging` | path-filtered push to `master`, nightly, manual dispatch | canonical hosted publish-deploy-validate path with explicit staging fixture preparation |
 | `Ops / Seed Staging Fixture` | manual dispatch and reusable workflow call | creates a deterministic hosted release fixture from a digest-pinned platform image: rollback-ready `prod` plus a fresh promotable `candidate` |
 | `Ops / Run Platform Job / Staging` | manual dispatch and reusable workflow call | executes one deployed Cloud Run Job in staging with an optional args override |
 | `Ops / Serving Baseline / Staging` | manual dispatch | runs an advisory k6 baseline against the direct hosted serving staging URL and uploads artifacts |
@@ -66,12 +77,68 @@ Local mirror of `CI / Infra Validation`:
 
 - `make terraform-gcp-fmt` + `make terraform-gcp-validate`
 
-### Default rule set
+### Trigger policy and cadence
 
-- pull requests get presubmit CI and security checks, not hosted staging deploys
-- `CD / Release Validation / Staging` runs automatically after merges to `master` only when hosted-relevant paths changed
-- `CD / Release Validation / Staging` also runs nightly on `master` for staging drift detection
-- manual dispatch remains the operator path for release readiness checks, post-incident verification, auth debugging, and targeted staged deploys
+The hosted golden path takes ~21 minutes end-to-end. That is acceptable for CD
+and release validation, and too slow for default PR CI. The trigger policy
+below keeps fast feedback fast and pushes hosted validation to the points
+where it actually adds signal.
+
+**On pull requests.** Run only fast, account-free checks:
+
+- `CI / Presubmit and Postsubmit` (lint, typecheck, docs, unit tests, Docker
+  build safety)
+- `CI / Infra Validation` when Terraform paths change
+- `CodeQL`, `Gitleaks`, `Zizmor` for security
+- `PR Title` for Conventional Commits
+- `Ops / Verify GCP Auth` when auth-relevant paths change
+
+Do not require or auto-trigger any `CD / *` workflow on pull requests.
+
+**On push to `master`.** `CD / Release Validation / Staging` auto-triggers
+only when hosted-relevant paths change. The current path filter covers:
+
+- `.github/workflows/hosted-golden-path-staging.yml` and the reusable hosted
+  workflows it calls
+- `Dockerfile`, `pyproject.toml`, `uv.lock`
+- `configs/env/staging.yaml`, `configs/models/**`
+- `deployments/gcp/**`
+- hosted validation scripts (`scripts/resolve_cloud_run_service_contract.py`,
+  `scripts/retry_terraform_gcp_init.sh`, `scripts/verify_*.py`)
+- `src/ml_lifecycle_platform/**`
+
+Docs-only changes, local-only workflow changes, and pure unit-test refactors
+do not auto-trigger hosted validation.
+
+**On a schedule.** `CD / Release Validation / Staging` runs nightly on
+`master` at 02:00 UTC for drift detection. It catches staging drift, broken
+workload identity or auth, expired or missing secrets, Artifact Registry or
+deploy wiring regressions, and Cloud Run validation regressions before an
+operator needs them.
+
+`CI / Local E2E` runs nightly at 04:00 UTC as an independent local-path check
+with no cloud dependency.
+
+**On manual dispatch.** Keep manual triggers available for:
+
+- release readiness checks before cutting a release
+- post-incident verification after recovering staging
+- IAM, WIF, or secret rotation validation
+- targeted staged deploys (`CD / Deploy MLflow|Serving|Platform Jobs / Staging`)
+- operator recovery (`Ops / Seed Staging Fixture`, `Ops / Run Platform Job`)
+- performance baselining (`Ops / Serving Baseline / Staging`)
+
+### Operator cadence expectations
+
+- the nightly run is the primary drift-detection signal; a red nightly run is
+  actionable before the next merge window
+- merging a hosted-relevant change to `master` triggers one staging validation
+  automatically; operators do not need to run it manually afterwards
+- one manual `CD / Release Validation / Staging` run before a release is
+  enough; the same workflow also runs nightly so a recent green run is
+  usually already available
+- `Ops / *` workflows are never required to be green on `master`; they are
+  operator tools, not release gates
 
 ### PR checks
 
@@ -88,10 +155,21 @@ Recommended required checks on `master`:
 - `CodeQL Analyze (Python)`
 - `Secret Scan`
 
-`Zizmor` is useful as an advisory security check, but it does not need to block every pull request on day one while older workflows are still being tightened.
+Branch protection matches on job names, not workflow names, so the lane
+prefix added to workflow `name:` fields does not affect required-check
+configuration.
 
-`CI / Infra Validation` should stay path-filtered. Do not make it a globally required check unless branch protection is updated to support conditional required checks for Terraform changes.
+`Zizmor` is useful as an advisory security check, but it does not need to
+block every pull request on day one while older workflows are still being
+tightened.
 
-Do not require `Postsubmit Integration`, `CI / Local E2E`, or `CD / Release Validation / Staging` on pull requests. They are slower and belong outside the fast review loop.
+`CI / Infra Validation` should stay path-filtered. Do not make it a globally
+required check unless branch protection is updated to support conditional
+required checks for Terraform changes.
 
-CodeQL, Gitleaks, and Zizmor also publish findings into GitHub code scanning when the token has permission to upload SARIF.
+Do not require `Postsubmit Integration`, `CI / Local E2E`, or
+`CD / Release Validation / Staging` on pull requests. They are slower and
+belong outside the fast review loop.
+
+CodeQL, Gitleaks, and Zizmor also publish findings into GitHub code scanning
+when the token has permission to upload SARIF.


### PR DESCRIPTION
## Summary

- prefix workflow `name:` fields with `CI /`, `CD /`, `Ops /` lanes so intent is obvious in the Actions sidebar (`ci.yml`, `e2e.yml`, `hosted-golden-path-staging.yml`)
- add explicit **Workflow classification**, **Trigger policy and cadence**, and **Operator cadence expectations** sections to `docs/ci.md`
- document that hosted validation auto-triggers on `master` only for hosted-relevant path changes, runs nightly for drift detection, and stays manual for release readiness / recovery
- refresh README badges to OSS convention: short shields.io labels (`ci`, `e2e`, `staging`, `coverage`, `release`, `python`, `license`), one-line tagline, topology diagram promoted above the fold
- no trigger or path-filter changes required: `hosted-golden-path-staging.yml` already enforced the policy; the gap was naming and documentation

## Test plan

- [x] `make check`
- [x] `make docs-check`
- [x] grep confirms no stale `Staging Verification` references remain

Closes #134