### PR TITLE
refactor: python code polish for readability

### DIFF
--- a/src/ml_lifecycle_platform/backends/local/artifact_store.py
+++ b/src/ml_lifecycle_platform/backends/local/artifact_store.py
@@ -1,3 +1,6 @@
+"""File-backed `ArtifactStore` implementation used by the local runtime
+profile; rooted under the configured artifacts directory."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/ml_lifecycle_platform/backends/local/event_store.py
+++ b/src/ml_lifecycle_platform/backends/local/event_store.py
@@ -1,3 +1,6 @@
+"""Append-only JSONL `EventStore` used by the local runtime to log validated
+`RuntimeEvent` records for later inspection or replay."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/backends/local/job_runner.py
+++ b/src/ml_lifecycle_platform/backends/local/job_runner.py
@@ -1,3 +1,6 @@
+"""Local `JobRunner` implementation that launches pipeline/registry steps
+as `python -m <module>` subprocesses and returns the exit code."""
+
 from __future__ import annotations
 
 import os

--- a/src/ml_lifecycle_platform/backends/local/secrets.py
+++ b/src/ml_lifecycle_platform/backends/local/secrets.py
@@ -1,3 +1,6 @@
+"""Environment-variable-backed `Secrets` adapter for the local runtime
+profile; pulls values directly from `os.environ`."""
+
 from __future__ import annotations
 
 import os

--- a/src/ml_lifecycle_platform/cli/main.py
+++ b/src/ml_lifecycle_platform/cli/main.py
@@ -1,3 +1,6 @@
+"""`mlp` CLI entrypoint — drives the local docker-compose stack and runs
+pipeline, registry, and serving commands inside the selected runtime profile."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -1,3 +1,7 @@
+"""Repo-wide constants: contract schema versions, registry alias names,
+MLflow tag keys, release-artifact filenames, and environment variable names
+shared across pipeline, registry, serving, and hosted CI."""
+
 from __future__ import annotations
 
 # Contracts schema versions

--- a/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
+++ b/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
@@ -1,3 +1,6 @@
+"""Stable dataset fingerprint (content and schema hashes) plus git-SHA
+capture, used by the pipeline for reproducible run lineage."""
+
 from __future__ import annotations
 
 import hashlib

--- a/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
+++ b/src/ml_lifecycle_platform/contracts/dataset_fingerprint.py
@@ -90,7 +90,7 @@ def get_git_sha() -> str:
             ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
         )
         return out.decode("utf-8").strip()
-    except Exception:
+    except (OSError, subprocess.CalledProcessError):
         return "unknown"
 
 

--- a/src/ml_lifecycle_platform/contracts/feature_stats.py
+++ b/src/ml_lifecycle_platform/contracts/feature_stats.py
@@ -1,3 +1,6 @@
+"""Schema-versioned feature distribution stats contract (per-feature
+summary statistics) logged alongside a training run."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/contracts/feature_stats.py
+++ b/src/ml_lifecycle_platform/contracts/feature_stats.py
@@ -32,7 +32,7 @@ class FeatureStats:
         raw = payload.get("stats")
         if not isinstance(raw, dict):
             raise TypeError("FeatureStats.stats must be a dict")
-        return FeatureStats(stats={str(k): dict(v) for k, v in raw.items()})  # type: ignore[arg-type]
+        return FeatureStats(stats={str(k): dict(v) for k, v in raw.items()})
 
     @staticmethod
     def from_json(payload: str) -> FeatureStats:

--- a/src/ml_lifecycle_platform/contracts/model_ref.py
+++ b/src/ml_lifecycle_platform/contracts/model_ref.py
@@ -1,3 +1,6 @@
+"""Schema-versioned reference to a model in the registry — identified by
+name plus alias, version, or source run id."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/contracts/release_reports.py
+++ b/src/ml_lifecycle_platform/contracts/release_reports.py
@@ -1,3 +1,6 @@
+"""Typed schemas for the promotion and rollback release-report bundles that
+get written to MLflow artifacts (decision, manifest, rollback target, card)."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/contracts/release_reports.py
+++ b/src/ml_lifecycle_platform/contracts/release_reports.py
@@ -12,6 +12,7 @@ from ml_lifecycle_platform.common.constants import (
     ART_ROLLBACK_TARGET_JSON,
     RELEASE_REPORT_SCHEMA_VERSION,
 )
+from ml_lifecycle_platform.policy.policy_engine import PolicyDecision
 
 
 def utc_now_iso() -> str:
@@ -38,7 +39,7 @@ class PolicyOutcome:
         }
 
     @classmethod
-    def from_policy_decision(cls, decision: Any) -> PolicyOutcome:
+    def from_policy_decision(cls, decision: PolicyDecision) -> PolicyOutcome:
         return cls(
             status="evaluated",
             allowed=bool(decision.allowed),

--- a/src/ml_lifecycle_platform/contracts/release_reports.py
+++ b/src/ml_lifecycle_platform/contracts/release_reports.py
@@ -164,20 +164,8 @@ class ReleaseManifest:
             git_sha=_optional_str(raw.get("git_sha")),
             current_prod_version=_optional_str(raw.get("current_prod_version")),
             previous_prod_version=_optional_str(raw.get("previous_prod_version")),
-            policy_outcome=PolicyOutcome(
-                status=str(policy.get("status", "")),
-                allowed=_optional_bool(policy.get("allowed")),
-                errors=_tuple_of_dicts(policy.get("errors")),
-                warnings=_tuple_of_dicts(policy.get("warnings")),
-                context=_dict_or_empty(policy.get("context")),
-                reason=_optional_str(policy.get("reason")),
-            ),
-            result=OperationResult(
-                status=str(result.get("status", "")),
-                code=_optional_str(result.get("code")),
-                message=_optional_str(result.get("message")),
-                details=_dict_or_empty(result.get("details")),
-            ),
+            policy_outcome=_parse_policy_outcome(policy),
+            result=_parse_operation_result(result),
             metrics={str(key): float(value) for key, value in metrics.items()},
         )
 
@@ -259,6 +247,26 @@ def render_model_card(bundle: ReleaseReportBundle) -> str:
         for key, value in sorted(manifest.metrics.items()):
             lines.append(f"- {key}: `{value}`")
     return "\n".join(lines) + "\n"
+
+
+def _parse_policy_outcome(policy: dict[str, Any]) -> PolicyOutcome:
+    return PolicyOutcome(
+        status=str(policy.get("status", "")),
+        allowed=_optional_bool(policy.get("allowed")),
+        errors=_tuple_of_dicts(policy.get("errors")),
+        warnings=_tuple_of_dicts(policy.get("warnings")),
+        context=_dict_or_empty(policy.get("context")),
+        reason=_optional_str(policy.get("reason")),
+    )
+
+
+def _parse_operation_result(result: dict[str, Any]) -> OperationResult:
+    return OperationResult(
+        status=str(result.get("status", "")),
+        code=_optional_str(result.get("code")),
+        message=_optional_str(result.get("message")),
+        details=_dict_or_empty(result.get("details")),
+    )
 
 
 def _optional_str(value: Any) -> str | None:

--- a/src/ml_lifecycle_platform/contracts/repro_contract.py
+++ b/src/ml_lifecycle_platform/contracts/repro_contract.py
@@ -1,3 +1,6 @@
+"""Reproducibility contract capturing the minimum evidence (git SHA, spec,
+dataset fingerprint, env lock hash, seed) needed to replay a training run."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/contracts/runtime_event.py
+++ b/src/ml_lifecycle_platform/contracts/runtime_event.py
@@ -1,3 +1,6 @@
+"""Pydantic model for typed runtime events written to the append-only
+event log by the local `EventStore`."""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/src/ml_lifecycle_platform/core/batch_contracts.py
+++ b/src/ml_lifecycle_platform/core/batch_contracts.py
@@ -1,3 +1,6 @@
+"""Pandera-backed dataset-level contracts used by pipeline steps to validate
+training and evaluation dataframes against the model spec."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/ml_lifecycle_platform/core/batch_contracts.py
+++ b/src/ml_lifecycle_platform/core/batch_contracts.py
@@ -17,6 +17,8 @@ class BatchContractValidationError(ValueError):
     pass
 
 
+# Returns Any because Pandera accepts a runtime dtype class reference
+# (type/int/float/bool/str) rather than a single static type.
 def _pandera_dtype(feature: FeatureFieldSpec) -> Any:
     if feature.dtype == "float":
         return float
@@ -61,23 +63,17 @@ def _format_schema_error(error: SchemaError | SchemaErrors) -> str:
     parts: list[str] = []
     records = failure_cases.head(5).to_dict(orient="records")
     for record in records:
-        column = record.get("column")
-        check = record.get("check")
-        failure_case = record.get("failure_case")
-        index = record.get("index")
-
-        detail = []
-        if column not in (None, "None", ""):
-            detail.append(f"column={column}")
-        if check not in (None, "None", ""):
-            detail.append(f"check={check}")
-        if failure_case not in (None, "None", ""):
-            detail.append(f"failure_case={failure_case}")
-        if index not in (None, "None", ""):
-            detail.append(f"row={index}")
-
+        fields = [
+            ("column", record.get("column")),
+            ("check", record.get("check")),
+            ("failure_case", record.get("failure_case")),
+            ("row", record.get("index")),
+        ]
+        detail = [
+            f"{name}={value}" for name, value in fields if value not in (None, "")
+        ]
         if detail:
-            parts.append(", ".join(str(item) for item in detail))
+            parts.append(", ".join(detail))
 
     if not parts:
         return str(error)

--- a/src/ml_lifecycle_platform/core/feature_contracts.py
+++ b/src/ml_lifecycle_platform/core/feature_contracts.py
@@ -93,6 +93,59 @@ def _validate_value(value: Any, feature: FeatureFieldSpec) -> tuple[bool, Any]:
     return False, value
 
 
+def _validate_row(
+    row_idx: int,
+    row: Mapping[str, Any],
+    contract: FeatureContractSpec,
+    allowed_names: set[str],
+) -> tuple[dict[str, Any], list[FeatureContractIssue]]:
+    row_payload = dict(row)
+    validated_row: dict[str, Any] = {}
+    issues: list[FeatureContractIssue] = []
+
+    for feature in contract.features:
+        if feature.name not in row_payload:
+            if feature.required:
+                issues.append(
+                    FeatureContractIssue(
+                        row=row_idx,
+                        field=feature.name,
+                        code="missing_field",
+                        message="Required feature is missing from request row.",
+                        expected_type=feature.dtype,
+                    )
+                )
+            continue
+
+        ok, normalized_value = _validate_value(row_payload[feature.name], feature)
+        if not ok:
+            issues.append(
+                FeatureContractIssue(
+                    row=row_idx,
+                    field=feature.name,
+                    code="type_mismatch",
+                    message="Feature value does not match the declared contract type.",
+                    expected_type=feature.dtype,
+                    actual_type=_actual_type(row_payload[feature.name]),
+                )
+            )
+            continue
+        validated_row[feature.name] = normalized_value
+
+    if not contract.allow_unknown_fields:
+        for field_name in sorted(set(row_payload) - allowed_names):
+            issues.append(
+                FeatureContractIssue(
+                    row=row_idx,
+                    field=field_name,
+                    code="unknown_field",
+                    message="Request row contains a field that is not declared in the feature contract.",
+                )
+            )
+
+    return validated_row, issues
+
+
 def validate_rows_against_contract(
     rows: Sequence[Mapping[str, Any]],
     contract: FeatureContractSpec,
@@ -101,56 +154,15 @@ def validate_rows_against_contract(
         return [dict(row) for row in rows]
 
     allowed_names = {feature.name for feature in contract.features}
-    issues: list[FeatureContractIssue] = []
+    all_issues: list[FeatureContractIssue] = []
     validated_rows: list[dict[str, Any]] = []
 
     for row_idx, row in enumerate(rows):
-        row_payload = dict(row)
-        validated_row: dict[str, Any] = {}
-
-        for feature in contract.features:
-            if feature.name not in row_payload:
-                if feature.required:
-                    issues.append(
-                        FeatureContractIssue(
-                            row=row_idx,
-                            field=feature.name,
-                            code="missing_field",
-                            message="Required feature is missing from request row.",
-                            expected_type=feature.dtype,
-                        )
-                    )
-                continue
-
-            ok, normalized_value = _validate_value(row_payload[feature.name], feature)
-            if not ok:
-                issues.append(
-                    FeatureContractIssue(
-                        row=row_idx,
-                        field=feature.name,
-                        code="type_mismatch",
-                        message="Feature value does not match the declared contract type.",
-                        expected_type=feature.dtype,
-                        actual_type=_actual_type(row_payload[feature.name]),
-                    )
-                )
-                continue
-            validated_row[feature.name] = normalized_value
-
-        if not contract.allow_unknown_fields:
-            for field_name in sorted(set(row_payload) - allowed_names):
-                issues.append(
-                    FeatureContractIssue(
-                        row=row_idx,
-                        field=field_name,
-                        code="unknown_field",
-                        message="Request row contains a field that is not declared in the feature contract.",
-                    )
-                )
-
+        validated_row, row_issues = _validate_row(row_idx, row, contract, allowed_names)
+        all_issues.extend(row_issues)
         validated_rows.append(validated_row)
 
-    if issues:
-        raise FeatureContractValidationError(contract=contract, issues=issues)
+    if all_issues:
+        raise FeatureContractValidationError(contract=contract, issues=all_issues)
 
     return validated_rows

--- a/src/ml_lifecycle_platform/core/feature_contracts.py
+++ b/src/ml_lifecycle_platform/core/feature_contracts.py
@@ -1,3 +1,6 @@
+"""Row-level feature-contract validation used by the serving layer to
+reject malformed ``/predict`` inputs and by the pipeline for dataset checks."""
+
 from __future__ import annotations
 
 import math

--- a/src/ml_lifecycle_platform/core/model_spec_types.py
+++ b/src/ml_lifecycle_platform/core/model_spec_types.py
@@ -1,3 +1,6 @@
+"""Typed dataclass schema for a model spec (task, source, trainer, features,
+metrics, policy) — the parsed representation of a `configs/models/*.yaml`."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/ml_lifecycle_platform/core/model_specs.py
+++ b/src/ml_lifecycle_platform/core/model_specs.py
@@ -1,3 +1,6 @@
+"""Parse model-spec YAML payloads into strongly-typed ``ModelSpec``
+dataclasses, enforcing the model-spec schema version."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/src/ml_lifecycle_platform/core/ports.py
+++ b/src/ml_lifecycle_platform/core/ports.py
@@ -1,3 +1,7 @@
+"""Runtime port Protocols: structural types for the artifact store, event
+store, job runner, secrets, and runtime metadata. Backend adapters (local,
+hosted) implement these without inheritance."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/ml_lifecycle_platform/hosted_ci/cloud_run_service.py
+++ b/src/ml_lifecycle_platform/hosted_ci/cloud_run_service.py
@@ -1,3 +1,7 @@
+"""Resolve a deployed Cloud Run service's URL and container image via
+`gcloud run services describe`, used by staging CI to pin load-test baselines
+to a known revision."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -27,6 +31,8 @@ def _is_not_found_error(stderr: str) -> bool:
     return "not found" in lowered or "was not found" in lowered
 
 
+# Returns Any because gcloud's JSON output shape varies by subcommand
+# (dict, list, nested); callers narrow to the shape they expect.
 def _run_gcloud_json(args: list[str], *, expectation: str) -> Any:
     completed = _run_command(args)
     if completed.returncode != 0:

--- a/src/ml_lifecycle_platform/hosted_ci/gcp_auth_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/gcp_auth_verifier.py
@@ -1,3 +1,7 @@
+"""CI preflight checks that the hosted GCP service account can reach the
+Artifact Registry, GCS buckets, and Secret Manager entries required by the
+staging pipeline."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -42,6 +46,8 @@ def _run_command(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, check=False, capture_output=True, text=True)
 
 
+# Returns Any because gcloud's JSON output shape varies by subcommand
+# (dict, list, nested); callers narrow to the shape they expect.
 def _run_gcloud_json(args: list[str], *, expectation: str) -> Any:
     completed = _run_command(args)
     if completed.returncode != 0:

--- a/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
@@ -1,3 +1,7 @@
+"""Verify that the hosted MLflow registry still resolves a given alias
+(default: `prod`) to a concrete model version — used by the maintenance
+job and CI staging readiness checks."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
@@ -6,6 +6,8 @@ import mlflow
 from mlflow import MlflowClient
 from mlflow.exceptions import MlflowException
 
+from ml_lifecycle_platform.common.constants import ALIAS_PROD
+
 
 class VerificationError(RuntimeError):
     """Raised when hosted MLflow model alias verification fails."""
@@ -16,7 +18,7 @@ class HostedModelAliasVerificationConfig:
     tracking_uri: str
     tracking_token: str
     model_name: str
-    alias: str = "prod"
+    alias: str = ALIAS_PROD
 
 
 def verify_model_alias(config: HostedModelAliasVerificationConfig) -> str:

--- a/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/hosted_model_alias_verifier.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import mlflow
 from mlflow import MlflowClient
+from mlflow.exceptions import MlflowException
 
 
 class VerificationError(RuntimeError):
@@ -24,7 +25,7 @@ def verify_model_alias(config: HostedModelAliasVerificationConfig) -> str:
 
     try:
         version = client.get_model_version_by_alias(config.model_name, config.alias)
-    except Exception as error:
+    except MlflowException as error:
         raise VerificationError(
             "hosted MLflow is missing required model alias "
             f"'{config.model_name}@{config.alias}': {error}"

--- a/src/ml_lifecycle_platform/hosted_ci/hosted_release_fixture_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/hosted_release_fixture_verifier.py
@@ -1,3 +1,7 @@
+"""Verify that the hosted MLflow instance has a promotable release fixture:
+a candidate that clears promotion policy and a rollback target resolvable
+from the previous prod version."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/hosted_ci/mlflow_cloud_run_auth.py
+++ b/src/ml_lifecycle_platform/hosted_ci/mlflow_cloud_run_auth.py
@@ -1,3 +1,7 @@
+"""Attach a Google-signed OIDC identity token to MLflow outbound requests so
+hosted CI jobs can authenticate to a private Cloud Run-hosted MLflow server;
+handles caching, refresh, and tracking-store cache invalidation on rotation."""
+
 from __future__ import annotations
 
 import base64

--- a/src/ml_lifecycle_platform/hosted_ci/mlflow_staging_verifier.py
+++ b/src/ml_lifecycle_platform/hosted_ci/mlflow_staging_verifier.py
@@ -1,3 +1,7 @@
+"""HTTP reachability and round-trip smoke test for hosted MLflow staging —
+retries through Cloud Run cold starts, then logs and reads back a tiny
+artifact to prove tracking + artifact storage are both healthy."""
+
 from __future__ import annotations
 
 import time

--- a/src/ml_lifecycle_platform/hosted_ci/serving_staging_baseline.py
+++ b/src/ml_lifecycle_platform/hosted_ci/serving_staging_baseline.py
@@ -1,3 +1,7 @@
+"""Assemble the k6 baseline-context JSON that drives the serving staging
+load test — pins service URL, image, git SHA, and traffic scenarios for
+the next load run."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/jobs/maintenance.py
+++ b/src/ml_lifecycle_platform/jobs/maintenance.py
@@ -6,6 +6,7 @@ import logging
 import sys
 from dataclasses import asdict, dataclass
 
+from ml_lifecycle_platform.common.constants import ALIAS_PROD
 from ml_lifecycle_platform.hosted_ci.hosted_model_alias_verifier import (
     HostedModelAliasVerificationConfig,
     verify_model_alias,
@@ -31,12 +32,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run safe hosted staging maintenance checks."
     )
-    parser.add_argument("--alias", default="prod")
+    parser.add_argument("--alias", default=ALIAS_PROD)
     parser.add_argument("--format", choices=["json", "text"], default="json")
     return parser.parse_args(argv)
 
 
-def run_maintenance_check(*, alias: str = "prod") -> MaintenanceReport:
+def run_maintenance_check(*, alias: str = ALIAS_PROD) -> MaintenanceReport:
     runtime = get_runtime_context()
     configure_mlflow(runtime)
 

--- a/src/ml_lifecycle_platform/jobs/maintenance.py
+++ b/src/ml_lifecycle_platform/jobs/maintenance.py
@@ -1,3 +1,6 @@
+"""Periodic hosted-staging maintenance check that the configured model alias
+still resolves to a registered version on the hosted MLflow tracking server."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/ml_lifecycle_platform/pipeline/evaluate.py
+++ b/src/ml_lifecycle_platform/pipeline/evaluate.py
@@ -1,3 +1,6 @@
+"""Load the trained model from MLflow, score it on the held-out test split,
+emit evaluation artifacts, and write the gate marker when the gate passes."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/pipeline/featurize.py
+++ b/src/ml_lifecycle_platform/pipeline/featurize.py
@@ -1,3 +1,6 @@
+"""Split the raw dataset into train/test, fit the preprocessor, and persist
+both CSVs plus the ``preprocessor.joblib`` artifact for downstream steps."""
+
 from __future__ import annotations
 
 import joblib

--- a/src/ml_lifecycle_platform/pipeline/ingest.py
+++ b/src/ml_lifecycle_platform/pipeline/ingest.py
@@ -1,3 +1,6 @@
+"""Load the raw dataset from the model spec's source (sklearn builtin or CSV)
+and persist it to ``data/raw.csv`` with lineage tags on the MLflow run."""
+
 from __future__ import annotations
 
 import mlflow

--- a/src/ml_lifecycle_platform/pipeline/metrics.py
+++ b/src/ml_lifecycle_platform/pipeline/metrics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
+import numpy as np
 import pandas as pd
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
 
@@ -10,8 +9,8 @@ def compute_binary_metrics(
     *,
     metric_names: tuple[str, ...],
     y_true: pd.Series,
-    pred: Any,
-    proba: Any,
+    pred: np.ndarray,
+    proba: np.ndarray,
     prefix: str,
 ) -> dict[str, float]:
     metrics: dict[str, float] = {}

--- a/src/ml_lifecycle_platform/pipeline/metrics.py
+++ b/src/ml_lifecycle_platform/pipeline/metrics.py
@@ -1,3 +1,6 @@
+"""Binary classification metric helpers shared by the train and evaluate
+pipeline steps."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -1,3 +1,6 @@
+"""Drive the local pipeline end-to-end by running ingest, featurize, train,
+evaluate, and register as child MLflow runs under a single parent run."""
+
 from __future__ import annotations
 
 import mlflow

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -228,6 +228,85 @@ def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
+def _log_training_tags(
+    *,
+    run_id: str,
+    spec: ModelSpec,
+    config_hash: str,
+    params: Mapping[str, Any],
+) -> None:
+    mlflow.set_tag(TAG_STEP, STEP_TRAIN)
+    mlflow.set_tag(TAG_MODEL_NAME, spec.model_name)
+    mlflow.set_tag(TAG_TRAINING_RUN_ID, run_id)
+    mlflow.set_tag(TAG_CONFIG_HASH, config_hash)
+    mlflow.set_tag(TAG_DETERMINISTIC_SEED, str(params["random_state"]))
+
+
+def _compute_fingerprint_and_tags(
+    inputs: TrainingInputs,
+    data_source_uri: str,
+) -> tuple[DatasetFingerprint, str]:
+    fp = compute_fingerprint(
+        train_df=inputs.train_df,
+        test_df=inputs.test_df,
+        data_source_uri=data_source_uri,
+        index_cols=None,
+    )
+    dataset_fingerprint_hash = sha256_text(fp.to_json())
+    mlflow.set_tags(fp.as_tags())
+    mlflow.set_tag(TAG_DATASET_FINGERPRINT, dataset_fingerprint_hash)
+    mlflow.set_tag(TAG_ENV_LOCK_HASH, get_uv_lock_hash())
+    return fp, dataset_fingerprint_hash
+
+
+def _record_repro_contract(
+    *,
+    art_dir: Path,
+    data_dir: Path,
+    result: TrainingResult,
+    repro_contract: ReproContract,
+    fp: DatasetFingerprint,
+) -> tuple[Path, Path]:
+    fp_path = art_dir / ART_DATASET_FINGERPRINT_JSON
+    write_fingerprint_json(fp, fp_path)
+    mlflow.log_artifact(str(fp_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
+
+    summary_path = art_dir / ART_TRAIN_SUMMARY_JSON
+    _write_json(summary_path, result.metrics)
+    mlflow.log_artifact(str(summary_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
+
+    contract_path = art_dir / ART_REPRO_CONTRACT_JSON
+    contract_path.write_text(repro_contract.to_json(), encoding="utf-8")
+    mlflow.log_artifact(str(contract_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPRO)
+
+    probe_inputs_path = art_dir / ART_REPRO_PROBE_INPUTS_CSV
+    result.probe_inputs.to_csv(probe_inputs_path, index=False)
+    mlflow.log_artifact(
+        str(probe_inputs_path), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+    )
+
+    expected_predictions_path = art_dir / ART_REPRO_EXPECTED_PREDICTIONS_JSON
+    _write_json(
+        expected_predictions_path,
+        {"probabilities": result.expected_probabilities},
+    )
+    mlflow.log_artifact(
+        str(expected_predictions_path), artifact_path=REPRO_OUTPUTS_ARTIFACT_PATH
+    )
+
+    mlflow.log_artifact(str(get_uv_lock_path()), artifact_path=REPRO_ENV_ARTIFACT_PATH)
+    mlflow.log_artifact(
+        str(data_dir / TRAIN_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+    )
+    mlflow.log_artifact(
+        str(data_dir / TEST_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+    )
+    mlflow.log_artifact(
+        str(art_dir / ART_PREPROCESSOR), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+    )
+    return fp_path, contract_path
+
+
 def main() -> None:
     ctx = get_runtime_context()
     logging.basicConfig(level=ctx.log_level)
@@ -243,24 +322,15 @@ def main() -> None:
     inputs = load_training_inputs()
 
     with mlflow.start_run(run_name="train") as run:
-        mlflow.set_tag(TAG_STEP, STEP_TRAIN)
-        mlflow.set_tag(TAG_MODEL_NAME, spec.model_name)
-        mlflow.set_tag(TAG_TRAINING_RUN_ID, run.info.run_id)
-        mlflow.set_tag(TAG_CONFIG_HASH, config_hash)
-        mlflow.set_tag(TAG_DETERMINISTIC_SEED, str(params["random_state"]))
-
-        fp = compute_fingerprint(
-            train_df=inputs.train_df,
-            test_df=inputs.test_df,
-            data_source_uri=data_source_uri,
-            index_cols=None,
+        _log_training_tags(
+            run_id=run.info.run_id,
+            spec=spec,
+            config_hash=config_hash,
+            params=params,
         )
-        dataset_fingerprint_hash = sha256_text(fp.to_json())
-
-        mlflow.set_tags(fp.as_tags())
-        mlflow.set_tag(TAG_DATASET_FINGERPRINT, dataset_fingerprint_hash)
-        mlflow.set_tag(TAG_ENV_LOCK_HASH, get_uv_lock_hash())
-
+        fp, dataset_fingerprint_hash = _compute_fingerprint_and_tags(
+            inputs, data_source_uri
+        )
         result = train_from_inputs(inputs, spec)
         repro_contract = build_repro_contract(
             training_run_id=run.info.run_id,
@@ -276,47 +346,12 @@ def main() -> None:
         art_dir = ctx.artifacts_dir
         art_dir.mkdir(parents=True, exist_ok=True)
 
-        fp_path = art_dir / ART_DATASET_FINGERPRINT_JSON
-        write_fingerprint_json(fp, fp_path)
-        mlflow.log_artifact(str(fp_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS)
-
-        summary_path = art_dir / ART_TRAIN_SUMMARY_JSON
-        _write_json(summary_path, result.metrics)
-        mlflow.log_artifact(
-            str(summary_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPORTS
-        )
-
-        contract_path = art_dir / ART_REPRO_CONTRACT_JSON
-        contract_path.write_text(repro_contract.to_json(), encoding="utf-8")
-        mlflow.log_artifact(
-            str(contract_path), artifact_path=MLFLOW_ARTIFACT_PATH_REPRO
-        )
-
-        probe_inputs_path = art_dir / ART_REPRO_PROBE_INPUTS_CSV
-        result.probe_inputs.to_csv(probe_inputs_path, index=False)
-        mlflow.log_artifact(
-            str(probe_inputs_path), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
-        )
-
-        expected_predictions_path = art_dir / ART_REPRO_EXPECTED_PREDICTIONS_JSON
-        _write_json(
-            expected_predictions_path,
-            {"probabilities": result.expected_probabilities},
-        )
-        mlflow.log_artifact(
-            str(expected_predictions_path), artifact_path=REPRO_OUTPUTS_ARTIFACT_PATH
-        )
-
-        uv_lock_path = get_uv_lock_path()
-        mlflow.log_artifact(str(uv_lock_path), artifact_path=REPRO_ENV_ARTIFACT_PATH)
-        mlflow.log_artifact(
-            str(ctx.data_dir / TRAIN_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
-        )
-        mlflow.log_artifact(
-            str(ctx.data_dir / TEST_CSV), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
-        )
-        mlflow.log_artifact(
-            str(art_dir / ART_PREPROCESSOR), artifact_path=REPRO_INPUTS_ARTIFACT_PATH
+        fp_path, contract_path = _record_repro_contract(
+            art_dir=art_dir,
+            data_dir=ctx.data_dir,
+            result=result,
+            repro_contract=repro_contract,
+            fp=fp,
         )
 
         mlflow.log_params(dict(params))

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -1,3 +1,7 @@
+"""Train the pipeline defined by the model spec, log metrics and
+reproducibility evidence to MLflow, and write the training run id for
+downstream steps."""
+
 from __future__ import annotations
 
 import hashlib

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -11,6 +11,7 @@ import joblib
 import mlflow
 import pandas as pd
 from mlflow.models.signature import infer_signature
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import Pipeline
 
@@ -91,7 +92,7 @@ REPRO_ENV_ARTIFACT_PATH: Final[str] = f"{MLFLOW_ARTIFACT_PATH_REPRO}/env"
 class TrainingInputs:
     train_df: pd.DataFrame
     test_df: pd.DataFrame
-    preprocessor: Any
+    preprocessor: BaseEstimator
 
 
 @dataclass

--- a/src/ml_lifecycle_platform/policy/policy_engine.py
+++ b/src/ml_lifecycle_platform/policy/policy_engine.py
@@ -228,6 +228,105 @@ def _try_get_alias_version(
     return str(mv.version)
 
 
+@dataclass(frozen=True)
+class _SourceRunState:
+    run: Any | None
+    lookup_ok: bool
+    run_id: str
+
+
+def _evaluate_warning_rules(
+    client: PromotionPolicyClient,
+    candidate_tags: Mapping[str, str],
+) -> tuple[list[Violation], _SourceRunState]:
+    warnings: list[Violation] = []
+    source_run_id = str(candidate_tags.get(TAG_SOURCE_RUN_ID, "")).strip()
+    if not source_run_id:
+        warnings.append(
+            Violation(
+                code="MISSING_SOURCE_RUN_ID",
+                message="Missing source_run_id tag; promotion will be less auditable.",
+                details={"tag": TAG_SOURCE_RUN_ID},
+            )
+        )
+        return warnings, _SourceRunState(
+            run=None, lookup_ok=False, run_id=source_run_id
+        )
+
+    try:
+        source_run = client.get_run(source_run_id)
+    except MlflowException:
+        warnings.append(
+            Violation(
+                code="SOURCE_RUN_ID_NOT_FOUND",
+                message="source_run_id tag is present but the MLflow run could not be fetched.",
+                details={"run_id": source_run_id},
+            )
+        )
+        return warnings, _SourceRunState(
+            run=None, lookup_ok=False, run_id=source_run_id
+        )
+
+    return warnings, _SourceRunState(
+        run=source_run, lookup_ok=True, run_id=source_run_id
+    )
+
+
+def _evaluate_error_rules(
+    *,
+    candidate_tags: Mapping[str, str],
+    policy: PolicySpec,
+    candidate_version: str,
+    current_prod_version: str | None,
+    source_run_state: _SourceRunState,
+) -> list[Violation]:
+    errors: list[Violation] = []
+    for violation in (
+        evaluate_required_metadata_rule(candidate_tags, policy),
+        evaluate_gate_rule(candidate_tags),
+        evaluate_release_status_rule(candidate_tags, policy),
+        evaluate_noop_promotion_rule(
+            candidate_version=candidate_version,
+            current_prod_version=current_prod_version,
+            policy=policy,
+        ),
+    ):
+        if violation is not None:
+            errors.append(violation)
+
+    errors.extend(
+        evaluate_reproducibility_rule(
+            candidate_tags=candidate_tags,
+            policy=policy,
+            source_run_lookup_ok=source_run_state.lookup_ok,
+        )
+    )
+    errors.extend(
+        evaluate_metric_thresholds_rule(
+            source_run=source_run_state.run,
+            source_run_id=source_run_state.run_id,
+            policy=policy,
+        )
+    )
+    return errors
+
+
+def _candidate_tags_subset(candidate_tags: Mapping[str, str]) -> dict[str, str]:
+    keys = (
+        TAG_GATE,
+        TAG_RELEASE_STATUS,
+        TAG_SOURCE_RUN_ID,
+        TAG_DATASET_FINGERPRINT,
+        TAG_GIT_SHA,
+        TAG_CONFIG_HASH,
+        TAG_TRAINING_RUN_ID,
+        TAG_ENV_LOCK_HASH,
+        TAG_DETERMINISTIC_SEED,
+        TAG_REPRO_SCHEMA_VERSION,
+    )
+    return {key: candidate_tags.get(key, "") for key in keys}
+
+
 def evaluate_promotion_policy(
     client: PromotionPolicyClient,
     model_name: str,
@@ -237,8 +336,6 @@ def evaluate_promotion_policy(
     to_alias: str = ALIAS_PROD,
 ) -> PolicyDecision:
     active_policy = default_policy_spec() if policy is None else policy
-    errors: list[Violation] = []
-    warnings: list[Violation] = []
 
     candidate_version = _try_get_alias_version(client, model_name, from_alias)
     current_prod_version = _try_get_alias_version(client, model_name, to_alias)
@@ -252,85 +349,30 @@ def evaluate_promotion_policy(
     }
 
     if candidate_version is None:
-        errors.append(
-            Violation(
-                code="MISSING_ALIAS",
-                message=f"Promotion blocked: alias '{from_alias}' does not exist.",
-                details={"alias": from_alias},
-            )
-        )
         return PolicyDecision(
             allowed=False,
-            errors=tuple(errors),
-            warnings=tuple(warnings),
+            errors=(
+                Violation(
+                    code="MISSING_ALIAS",
+                    message=f"Promotion blocked: alias '{from_alias}' does not exist.",
+                    details={"alias": from_alias},
+                ),
+            ),
+            warnings=(),
             context=context,
         )
 
     candidate = client.get_model_version(model_name, candidate_version)
     candidate_tags = candidate.tags or {}
-    context["candidate_tags_subset"] = {
-        TAG_GATE: candidate_tags.get(TAG_GATE, ""),
-        TAG_RELEASE_STATUS: candidate_tags.get(TAG_RELEASE_STATUS, ""),
-        TAG_SOURCE_RUN_ID: candidate_tags.get(TAG_SOURCE_RUN_ID, ""),
-        TAG_DATASET_FINGERPRINT: candidate_tags.get(TAG_DATASET_FINGERPRINT, ""),
-        TAG_GIT_SHA: candidate_tags.get(TAG_GIT_SHA, ""),
-        TAG_CONFIG_HASH: candidate_tags.get(TAG_CONFIG_HASH, ""),
-        TAG_TRAINING_RUN_ID: candidate_tags.get(TAG_TRAINING_RUN_ID, ""),
-        TAG_ENV_LOCK_HASH: candidate_tags.get(TAG_ENV_LOCK_HASH, ""),
-        TAG_DETERMINISTIC_SEED: candidate_tags.get(TAG_DETERMINISTIC_SEED, ""),
-        TAG_REPRO_SCHEMA_VERSION: candidate_tags.get(TAG_REPRO_SCHEMA_VERSION, ""),
-    }
+    context["candidate_tags_subset"] = _candidate_tags_subset(candidate_tags)
 
-    for violation in (
-        evaluate_required_metadata_rule(candidate_tags, active_policy),
-        evaluate_gate_rule(candidate_tags),
-        evaluate_release_status_rule(candidate_tags, active_policy),
-        evaluate_noop_promotion_rule(
-            candidate_version=candidate_version,
-            current_prod_version=current_prod_version,
-            policy=active_policy,
-        ),
-    ):
-        if violation is not None:
-            errors.append(violation)
-
-    source_run = None
-    source_run_lookup_ok = False
-    source_run_id = str(candidate_tags.get(TAG_SOURCE_RUN_ID, "")).strip()
-    if not source_run_id:
-        warnings.append(
-            Violation(
-                code="MISSING_SOURCE_RUN_ID",
-                message="Missing source_run_id tag; promotion will be less auditable.",
-                details={"tag": TAG_SOURCE_RUN_ID},
-            )
-        )
-    else:
-        try:
-            source_run = client.get_run(source_run_id)
-            source_run_lookup_ok = True
-        except MlflowException:
-            warnings.append(
-                Violation(
-                    code="SOURCE_RUN_ID_NOT_FOUND",
-                    message="source_run_id tag is present but the MLflow run could not be fetched.",
-                    details={"run_id": source_run_id},
-                )
-            )
-
-    errors.extend(
-        evaluate_reproducibility_rule(
-            candidate_tags=candidate_tags,
-            policy=active_policy,
-            source_run_lookup_ok=source_run_lookup_ok,
-        )
-    )
-    errors.extend(
-        evaluate_metric_thresholds_rule(
-            source_run=source_run,
-            source_run_id=source_run_id,
-            policy=active_policy,
-        )
+    warnings, source_run_state = _evaluate_warning_rules(client, candidate_tags)
+    errors = _evaluate_error_rules(
+        candidate_tags=candidate_tags,
+        policy=active_policy,
+        candidate_version=candidate_version,
+        current_prod_version=current_prod_version,
+        source_run_state=source_run_state,
     )
 
     return PolicyDecision(

--- a/src/ml_lifecycle_platform/policy/policy_engine.py
+++ b/src/ml_lifecycle_platform/policy/policy_engine.py
@@ -1,3 +1,7 @@
+"""Rules engine that validates a candidate model version against promotion
+policy: required metadata tags, gate status, release status, reproducibility
+evidence, and minimum metric thresholds."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/src/ml_lifecycle_platform/policy/policy_engine.py
+++ b/src/ml_lifecycle_platform/policy/policy_engine.py
@@ -309,7 +309,7 @@ def evaluate_promotion_policy(
         try:
             source_run = client.get_run(source_run_id)
             source_run_lookup_ok = True
-        except Exception:
+        except MlflowException:
             warnings.append(
                 Violation(
                     code="SOURCE_RUN_ID_NOT_FOUND",

--- a/src/ml_lifecycle_platform/policy/policy_engine.py
+++ b/src/ml_lifecycle_platform/policy/policy_engine.py
@@ -32,6 +32,8 @@ REPRODUCIBILITY_EVIDENCE_TAGS: tuple[str, ...] = (
 
 
 class PromotionPolicyClient(Protocol):
+    # Returns kept as Any: real callers pass mlflow.ModelVersion / mlflow.Run,
+    # but unit tests fake this surface with SimpleNamespace.
     def get_model_version_by_alias(self, model_name: str, alias: str) -> Any: ...
 
     def get_model_version(self, model_name: str, version: str) -> Any: ...

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -1,3 +1,6 @@
+"""CLI to promote a candidate model version to prod after running it through
+the promotion policy engine and writing a release-report bundle."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/ml_lifecycle_platform/registry/register.py
+++ b/src/ml_lifecycle_platform/registry/register.py
@@ -1,3 +1,6 @@
+"""Register the most recent train run's model into the MLflow registry,
+tag it with reproducibility evidence, and point the candidate alias at it."""
+
 from __future__ import annotations
 
 import logging

--- a/src/ml_lifecycle_platform/registry/release_evidence.py
+++ b/src/ml_lifecycle_platform/registry/release_evidence.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.constants import (
@@ -124,7 +125,7 @@ def _mirror_local_bundle(*, root_path: str, file_contents: dict[str, bytes]) -> 
         relative_path = f"{root_path}/{file_name}"
         try:
             runtime.artifact_store.write_bytes(relative_path, content)
-        except Exception:
+        except (MlflowException, OSError):
             logger.warning(
                 "Could not mirror release evidence locally: %s", relative_path
             )
@@ -172,5 +173,5 @@ def _append_event(
     }
     try:
         runtime.event_store.append_event(event_type, payload)
-    except Exception:
+    except (MlflowException, OSError):
         logger.warning("Could not append release evidence event: %s", event_type)

--- a/src/ml_lifecycle_platform/registry/release_evidence.py
+++ b/src/ml_lifecycle_platform/registry/release_evidence.py
@@ -1,3 +1,6 @@
+"""Write release-report bundles (promotion decision, rollback target,
+release manifest, model card) to MLflow artifacts for a model version."""
+
 from __future__ import annotations
 
 import logging

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -16,6 +16,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
 from ml_lifecycle_platform.common.constants import (
+    ALIAS_PROD,
     ART_REPRO_CONTRACT_JSON,
     ART_REPRO_REPORT_JSON,
     TAG_CONFIG_HASH,
@@ -213,7 +214,7 @@ def _print_report(report: dict[str, Any], fmt: str) -> None:
 
 def _resolve_current_prod_version(client: MlflowClient, model_name: str) -> str | None:
     try:
-        prod = client.get_model_version_by_alias(model_name, "prod")
+        prod = client.get_model_version_by_alias(model_name, ALIAS_PROD)
     except MlflowException:
         return None
     return str(prod.version)

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -1,3 +1,6 @@
+"""Replay a training run from its reproducibility contract and verify that
+the produced model matches the registered one."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -107,6 +107,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+# Returns Any because MLflow's get_model_version* return a mlflow.ModelVersion
+# at runtime, but unit tests substitute a SimpleNamespace with the same surface.
 def _resolve_model_version(
     client: MlflowClient,
     model_name: str,
@@ -347,6 +349,174 @@ def _report_details(report: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _verify_environment_hashes(contract: ReproContract, report: dict[str, Any]) -> None:
+    current_git_sha = get_git_sha()
+    report["checks"]["git_sha"] = {
+        "expected": contract.git_sha,
+        "actual": current_git_sha,
+        "matched": current_git_sha == contract.git_sha,
+    }
+    if current_git_sha != contract.git_sha:
+        raise ReproduceFailure(
+            code="git_sha_mismatch",
+            message="Current checkout does not match the training run git SHA.",
+            details=report["checks"]["git_sha"],
+        )
+
+    current_env_lock_hash = get_uv_lock_hash()
+    report["checks"]["env_lock_hash"] = {
+        "expected": contract.env_lock_hash,
+        "actual": current_env_lock_hash,
+        "matched": current_env_lock_hash == contract.env_lock_hash,
+    }
+    if current_env_lock_hash != contract.env_lock_hash:
+        raise ReproduceFailure(
+            code="env_lock_mismatch",
+            message="Current uv.lock hash does not match the source training run.",
+            details=report["checks"]["env_lock_hash"],
+        )
+
+
+def _verify_config_hash(
+    contract: ReproContract, spec: Any, report: dict[str, Any]
+) -> None:
+    recomputed_config_hash = config_hash_for_spec(spec)
+    report["checks"]["config_hash"] = {
+        "expected": contract.config_hash,
+        "actual": recomputed_config_hash,
+        "matched": recomputed_config_hash == contract.config_hash,
+    }
+    if recomputed_config_hash != contract.config_hash:
+        raise ReproduceFailure(
+            code="config_hash_mismatch",
+            message="Repro contract params do not reproduce the logged config hash.",
+            details=report["checks"]["config_hash"],
+        )
+
+
+@dataclass
+class _DownloadedArtifacts:
+    train_path: Path
+    preprocessor_path: Path
+    probe_inputs_path: Path
+    expected_predictions_path: Path
+    uv_lock_path: Path
+
+
+def _download_contract_artifacts(
+    client: MlflowClient,
+    source_run_id: str,
+    contract: ReproContract,
+    work_dir: Path,
+) -> _DownloadedArtifacts:
+    train_path = _download_required_artifact(
+        client, source_run_id, contract.train_dataset_artifact, work_dir
+    )
+    _ = _download_required_artifact(
+        client, source_run_id, contract.test_dataset_artifact, work_dir
+    )
+    preprocessor_path = _download_required_artifact(
+        client, source_run_id, contract.preprocessor_artifact, work_dir
+    )
+    probe_inputs_path = _download_required_artifact(
+        client, source_run_id, contract.probe_inputs_artifact, work_dir
+    )
+    expected_predictions_path = _download_required_artifact(
+        client, source_run_id, contract.expected_predictions_artifact, work_dir
+    )
+    uv_lock_path = _download_required_artifact(
+        client, source_run_id, contract.uv_lock_artifact, work_dir
+    )
+    return _DownloadedArtifacts(
+        train_path=train_path,
+        preprocessor_path=preprocessor_path,
+        probe_inputs_path=probe_inputs_path,
+        expected_predictions_path=expected_predictions_path,
+        uv_lock_path=uv_lock_path,
+    )
+
+
+def _verify_dataset_fingerprint(
+    contract: ReproContract,
+    artifacts: _DownloadedArtifacts,
+    report: dict[str, Any],
+) -> Any:
+    logged_env_lock_hash = sha256_file(artifacts.uv_lock_path)
+    report["checks"]["logged_env_lock_hash"] = {
+        "expected": contract.env_lock_hash,
+        "actual": logged_env_lock_hash,
+        "matched": logged_env_lock_hash == contract.env_lock_hash,
+    }
+    if logged_env_lock_hash != contract.env_lock_hash:
+        raise ReproduceFailure(
+            code="logged_env_lock_mismatch",
+            message="Logged uv.lock artifact does not match the contract hash.",
+            details=report["checks"]["logged_env_lock_hash"],
+        )
+
+    downloaded_inputs = load_training_inputs(
+        data_dir=artifacts.train_path.parent,
+        artifacts_dir=artifacts.preprocessor_path.parent,
+    )
+    recomputed_fp = compute_fingerprint(
+        train_df=downloaded_inputs.train_df,
+        test_df=downloaded_inputs.test_df,
+        data_source_uri=contract.data_source_uri,
+        git_sha=contract.git_sha,
+    )
+    recomputed_dataset_fingerprint = sha256_text(recomputed_fp.to_json())
+    report["checks"]["dataset_fingerprint"] = {
+        "expected": contract.dataset_fingerprint,
+        "actual": recomputed_dataset_fingerprint,
+        "matched": recomputed_dataset_fingerprint == contract.dataset_fingerprint,
+    }
+    if recomputed_dataset_fingerprint != contract.dataset_fingerprint:
+        raise ReproduceFailure(
+            code="dataset_fingerprint_mismatch",
+            message="Downloaded training inputs do not match the logged dataset fingerprint.",
+            details=report["checks"]["dataset_fingerprint"],
+        )
+    return downloaded_inputs
+
+
+def _verify_prediction_parity(
+    pipeline: Any,
+    artifacts: _DownloadedArtifacts,
+    report: dict[str, Any],
+) -> None:
+    probe_inputs = pd.read_csv(artifacts.probe_inputs_path)
+    expected_probabilities = _read_expected_predictions(
+        artifacts.expected_predictions_path
+    )
+    actual_probabilities = [
+        float(v) for v in pipeline.predict_proba(probe_inputs)[:, 1]
+    ]
+    max_abs_diff = max(
+        (
+            abs(expected - actual)
+            for expected, actual in zip(expected_probabilities, actual_probabilities)
+        ),
+        default=0.0,
+    )
+    prediction_match = np.allclose(
+        expected_probabilities,
+        actual_probabilities,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    report["checks"]["prediction_parity"] = {
+        "matched": bool(prediction_match),
+        "count": len(expected_probabilities),
+        "max_abs_diff": float(max_abs_diff),
+    }
+    if not prediction_match:
+        raise ReproduceFailure(
+            code="prediction_parity_failed",
+            message="Reproduced model predictions differ from the logged probe outputs.",
+            details=report["checks"]["prediction_parity"],
+        )
+
+
 def reproduce_model(
     client: MlflowClient,
     *,
@@ -393,47 +563,12 @@ def reproduce_model(
                 },
             )
 
-        current_git_sha = get_git_sha()
-        report["checks"]["git_sha"] = {
-            "expected": contract.git_sha,
-            "actual": current_git_sha,
-            "matched": current_git_sha == contract.git_sha,
-        }
-        if current_git_sha != contract.git_sha:
-            raise ReproduceFailure(
-                code="git_sha_mismatch",
-                message="Current checkout does not match the training run git SHA.",
-                details=report["checks"]["git_sha"],
-            )
-
-        current_env_lock_hash = get_uv_lock_hash()
-        report["checks"]["env_lock_hash"] = {
-            "expected": contract.env_lock_hash,
-            "actual": current_env_lock_hash,
-            "matched": current_env_lock_hash == contract.env_lock_hash,
-        }
-        if current_env_lock_hash != contract.env_lock_hash:
-            raise ReproduceFailure(
-                code="env_lock_mismatch",
-                message="Current uv.lock hash does not match the source training run.",
-                details=report["checks"]["env_lock_hash"],
-            )
+        _verify_environment_hashes(contract, report)
 
         spec = model_spec_from_dict(
             contract.model_spec, spec_path="contract://model-spec"
         )
-        recomputed_config_hash = config_hash_for_spec(spec)
-        report["checks"]["config_hash"] = {
-            "expected": contract.config_hash,
-            "actual": recomputed_config_hash,
-            "matched": recomputed_config_hash == contract.config_hash,
-        }
-        if recomputed_config_hash != contract.config_hash:
-            raise ReproduceFailure(
-                code="config_hash_mismatch",
-                message="Repro contract params do not reproduce the logged config hash.",
-                details=report["checks"]["config_hash"],
-            )
+        _verify_config_hash(contract, spec, report)
 
         if contract.deterministic_seed is None:
             raise ReproduceFailure(
@@ -442,94 +577,13 @@ def reproduce_model(
                 details={"training_run_id": source_run_id},
             )
 
-        train_path = _download_required_artifact(
-            client, source_run_id, contract.train_dataset_artifact, work_dir
+        artifacts = _download_contract_artifacts(
+            client, source_run_id, contract, work_dir
         )
-        _ = _download_required_artifact(
-            client, source_run_id, contract.test_dataset_artifact, work_dir
-        )
-        preprocessor_path = _download_required_artifact(
-            client, source_run_id, contract.preprocessor_artifact, work_dir
-        )
-        probe_inputs_path = _download_required_artifact(
-            client, source_run_id, contract.probe_inputs_artifact, work_dir
-        )
-        expected_predictions_path = _download_required_artifact(
-            client, source_run_id, contract.expected_predictions_artifact, work_dir
-        )
-        uv_lock_path = _download_required_artifact(
-            client, source_run_id, contract.uv_lock_artifact, work_dir
-        )
-
-        logged_env_lock_hash = sha256_file(uv_lock_path)
-        report["checks"]["logged_env_lock_hash"] = {
-            "expected": contract.env_lock_hash,
-            "actual": logged_env_lock_hash,
-            "matched": logged_env_lock_hash == contract.env_lock_hash,
-        }
-        if logged_env_lock_hash != contract.env_lock_hash:
-            raise ReproduceFailure(
-                code="logged_env_lock_mismatch",
-                message="Logged uv.lock artifact does not match the contract hash.",
-                details=report["checks"]["logged_env_lock_hash"],
-            )
-
-        inputs_dir = train_path.parent
-        downloaded_inputs = load_training_inputs(
-            data_dir=inputs_dir,
-            artifacts_dir=preprocessor_path.parent,
-        )
-        recomputed_fp = compute_fingerprint(
-            train_df=downloaded_inputs.train_df,
-            test_df=downloaded_inputs.test_df,
-            data_source_uri=contract.data_source_uri,
-            git_sha=contract.git_sha,
-        )
-        recomputed_dataset_fingerprint = sha256_text(recomputed_fp.to_json())
-        report["checks"]["dataset_fingerprint"] = {
-            "expected": contract.dataset_fingerprint,
-            "actual": recomputed_dataset_fingerprint,
-            "matched": recomputed_dataset_fingerprint == contract.dataset_fingerprint,
-        }
-        if recomputed_dataset_fingerprint != contract.dataset_fingerprint:
-            raise ReproduceFailure(
-                code="dataset_fingerprint_mismatch",
-                message="Downloaded training inputs do not match the logged dataset fingerprint.",
-                details=report["checks"]["dataset_fingerprint"],
-            )
+        downloaded_inputs = _verify_dataset_fingerprint(contract, artifacts, report)
 
         result = train_from_inputs(downloaded_inputs, spec)
-        probe_inputs = pd.read_csv(probe_inputs_path)
-        expected_probabilities = _read_expected_predictions(expected_predictions_path)
-        actual_probabilities = [
-            float(v) for v in result.pipeline.predict_proba(probe_inputs)[:, 1]
-        ]
-        max_abs_diff = max(
-            (
-                abs(expected - actual)
-                for expected, actual in zip(
-                    expected_probabilities, actual_probabilities
-                )
-            ),
-            default=0.0,
-        )
-        prediction_match = np.allclose(
-            expected_probabilities,
-            actual_probabilities,
-            rtol=1e-12,
-            atol=1e-12,
-        )
-        report["checks"]["prediction_parity"] = {
-            "matched": bool(prediction_match),
-            "count": len(expected_probabilities),
-            "max_abs_diff": float(max_abs_diff),
-        }
-        if not prediction_match:
-            raise ReproduceFailure(
-                code="prediction_parity_failed",
-                message="Reproduced model predictions differ from the logged probe outputs.",
-                details=report["checks"]["prediction_parity"],
-            )
+        _verify_prediction_parity(result.pipeline, artifacts, report)
 
         report["checks"]["metrics"] = result.metrics
         report["status"] = "matched"

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -1,3 +1,6 @@
+"""CLI to roll the prod alias back to a prior model version and emit audit
+evidence describing the rollback target."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -86,7 +86,7 @@ def _previous_prod_from_manifest(
                 manifest_path=manifest_path,
                 work_dir=Path(tmpdir),
             )
-        except Exception as exc:
+        except (json.JSONDecodeError, KeyError) as exc:
             logger.warning("Could not read release manifest for rollback: %s", exc)
             return None, "tag_fallback"
     return manifest.previous_prod_version, "manifest"

--- a/src/ml_lifecycle_platform/runtime/bootstrap.py
+++ b/src/ml_lifecycle_platform/runtime/bootstrap.py
@@ -1,3 +1,6 @@
+"""Build the process-local RuntimeContext from the active runtime profile and
+configure MLflow tracking/registry URIs for CLI and pipeline entrypoints."""
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/ml_lifecycle_platform/runtime/context.py
+++ b/src/ml_lifecycle_platform/runtime/context.py
@@ -1,3 +1,7 @@
+"""RuntimeContext dataclass — the frozen bundle of profile metadata, paths,
+and backend adapters (artifact store, event store, job runner, secrets)
+shared by CLI and runtime entrypoints."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/ml_lifecycle_platform/runtime/mlflow.py
+++ b/src/ml_lifecycle_platform/runtime/mlflow.py
@@ -1,3 +1,6 @@
+"""MlflowClient factory and experiment helper that honour the active runtime
+profile (tracking URI, registry URI, auth)."""
+
 from __future__ import annotations
 
 import mlflow

--- a/src/ml_lifecycle_platform/runtime/profile.py
+++ b/src/ml_lifecycle_platform/runtime/profile.py
@@ -1,3 +1,7 @@
+"""Runtime profile loader: reads the selected env YAML under configs/env/,
+applies `MLP_*` / `MLP_COMPOSE_*` env-var overrides, and validates the merged
+profile via pydantic before returning it to the bootstrap layer."""
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette.responses import Response
 
 try:
-    import mlflow  # type: ignore
+    import mlflow
     from mlflow.exceptions import MlflowException
 except Exception:  # pragma: no cover
     mlflow = None  # type: ignore[assignment]

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -1,3 +1,7 @@
+"""FastAPI service exposing ``/predict``, ``/metadata``, and ``/metrics``,
+with request-level routing across the prod, candidate, canary, and shadow
+model aliases loaded from the MLflow registry."""
+
 from __future__ import annotations
 
 import json

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -106,7 +106,7 @@ async def coarse_metrics_middleware(
             endpoint=endpoint, mode=mode_label, status=str(e.status_code)
         ).inc()
         raise
-    except Exception:
+    except (ValueError, RuntimeError):
         REQUESTS_TOTAL.labels(endpoint=endpoint, mode=mode_label, status="500").inc()
         raise
 
@@ -213,7 +213,7 @@ def _prod_model_loadable(settings: Settings) -> tuple[bool, str | None]:
     try:
         _ = store.get_model(settings, ALIAS_PROD, required=True)
         return True, None
-    except Exception as e:
+    except MlflowException as e:
         return False, f"prod model not loadable: {e}"
 
 
@@ -449,6 +449,7 @@ async def predict(
 
     except Exception as e:
         status_code = 500
+        logger.exception("predict failed: %s", e)
         raise HTTPException(status_code=500, detail="internal error") from e
 
     finally:

--- a/src/ml_lifecycle_platform/serving/constants.py
+++ b/src/ml_lifecycle_platform/serving/constants.py
@@ -1,3 +1,7 @@
+"""Serving-local constants: alias string literals, environment variable
+names, and HTTP header keys. Kept separate from `common.constants` because
+the serving image ships without the rest of the package."""
+
 from __future__ import annotations
 
 from typing import Literal

--- a/src/ml_lifecycle_platform/serving/metrics.py
+++ b/src/ml_lifecycle_platform/serving/metrics.py
@@ -1,3 +1,7 @@
+"""Prometheus counters and histograms exposed by the serving API (request
+counts, prediction latency, shadow-diff magnitude). Labels are kept bounded
+to avoid cardinality explosions."""
+
 from __future__ import annotations
 
 from prometheus_client import Counter, Histogram

--- a/src/ml_lifecycle_platform/serving/model_store.py
+++ b/src/ml_lifecycle_platform/serving/model_store.py
@@ -1,3 +1,6 @@
+"""Hot-swappable store of the prod and candidate models loaded from the
+MLflow registry by alias, with background refresh and a unit-test stub."""
+
 from __future__ import annotations
 
 import threading

--- a/src/ml_lifecycle_platform/serving/model_store.py
+++ b/src/ml_lifecycle_platform/serving/model_store.py
@@ -30,6 +30,8 @@ class _UnitTestModel:
         return [1.0] * len(df)
 
 
+# Returns Any because mlflow.pyfunc.load_model's return type is untyped and the
+# unit-testing branch returns a deterministic stub with a compatible .predict().
 def _load_model_from_registry(settings: Settings, alias: str) -> Any:
     if settings.unit_testing:
         return _UnitTestModel()
@@ -118,6 +120,8 @@ class ModelStore:
 
             self._last_refresh_ts = now
 
+    # Returns Any because the cached model is whatever _load_model_from_registry
+    # produced (mlflow pyfunc or test stub); no shared static type exists.
     def get_model(
         self,
         settings: Settings,

--- a/src/ml_lifecycle_platform/serving/prediction.py
+++ b/src/ml_lifecycle_platform/serving/prediction.py
@@ -1,3 +1,6 @@
+"""Build prediction payloads by running the primary model and, optionally,
+the shadow model for diff observability."""
+
 from __future__ import annotations
 
 import logging

--- a/src/ml_lifecycle_platform/serving/prediction.py
+++ b/src/ml_lifecycle_platform/serving/prediction.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import pandas as pd
+from mlflow.exceptions import MlflowException
 
 from ml_lifecycle_platform.core.feature_contracts import (
     validate_rows_against_contract,
@@ -55,7 +56,7 @@ def run_prediction(
                 y_shadow = [float(x) for x in model_shadow.predict(df)]
                 diffs = [abs(a - b) for a, b in zip(y_primary, y_shadow)]
                 shadow_mae = sum(diffs) / max(len(diffs), 1)
-            except Exception as e:
+            except (MlflowException, ValueError) as e:
                 logger.warning("shadow prediction failed: %s", e)
 
     if shadow_mae is not None and math.isfinite(shadow_mae):

--- a/src/ml_lifecycle_platform/serving/router.py
+++ b/src/ml_lifecycle_platform/serving/router.py
@@ -79,7 +79,7 @@ def choose_canary_bucket(ctx: BucketContext) -> BucketDecision:
             bucket=stable_bucket_from_rows(ctx.rows),
             seed_source=SeedSource.PAYLOAD_HASH,
         )
-    except Exception:
+    except (TypeError, ValueError):
         # Fallback if the payload is not JSON-serializable.
         seed = secrets.token_hex(16)
         return BucketDecision(

--- a/src/ml_lifecycle_platform/serving/router.py
+++ b/src/ml_lifecycle_platform/serving/router.py
@@ -8,7 +8,7 @@ import json
 import secrets
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Final, Literal, cast
+from typing import Any, Final, Literal
 
 from .constants import ALIAS_CANDIDATE, ALIAS_PROD
 
@@ -98,22 +98,18 @@ def decide_routing(mode: Mode, canary_pct: int, bucket: int) -> RoutingDecision:
 
     canary_pct = max(0, min(100, int(canary_pct)))
 
-    # Use serving.constants as the single source of truth.
-    prod: Alias = cast(Alias, ALIAS_PROD)
-    candidate: Alias = cast(Alias, ALIAS_CANDIDATE)
-
     if mode == MODE_PROD:
-        return RoutingDecision(chosen=prod, run_shadow=False)
+        return RoutingDecision(chosen=ALIAS_PROD, run_shadow=False)
 
     if mode == MODE_CANDIDATE:
-        return RoutingDecision(chosen=candidate, run_shadow=False)
+        return RoutingDecision(chosen=ALIAS_CANDIDATE, run_shadow=False)
 
     if mode == MODE_SHADOW:
-        return RoutingDecision(chosen=prod, run_shadow=True)
+        return RoutingDecision(chosen=ALIAS_PROD, run_shadow=True)
 
     if mode == MODE_CANARY:
         if bucket < canary_pct:
-            return RoutingDecision(chosen=candidate, run_shadow=True)
-        return RoutingDecision(chosen=prod, run_shadow=True)
+            return RoutingDecision(chosen=ALIAS_CANDIDATE, run_shadow=True)
+        return RoutingDecision(chosen=ALIAS_PROD, run_shadow=True)
 
     raise ValueError(f"Unknown mode: {mode}")

--- a/src/ml_lifecycle_platform/serving/router.py
+++ b/src/ml_lifecycle_platform/serving/router.py
@@ -1,3 +1,6 @@
+"""Deterministic request routing between model variants (prod, candidate,
+canary, shadow) using stable bucketing from the request id or payload hash."""
+
 from __future__ import annotations
 
 import hashlib

--- a/src/ml_lifecycle_platform/serving/settings.py
+++ b/src/ml_lifecycle_platform/serving/settings.py
@@ -1,3 +1,6 @@
+"""Pydantic `Settings` for the serving container — read straight from env
+vars, independent of the runtime profile loader used by the CLI."""
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/ml_lifecycle_platform/serving/smoke_test.py
+++ b/src/ml_lifecycle_platform/serving/smoke_test.py
@@ -10,7 +10,7 @@ import requests
 from ml_lifecycle_platform.runtime.bootstrap import configure_mlflow
 
 try:
-    import mlflow  # type: ignore
+    import mlflow
 except Exception:  # pragma: no cover
     mlflow = None  # type: ignore[assignment]
 

--- a/tests/unit/test_hosted_model_alias_verifier.py
+++ b/tests/unit/test_hosted_model_alias_verifier.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from mlflow.exceptions import MlflowException
 
 from ml_lifecycle_platform.hosted_ci.hosted_model_alias_verifier import (
     HostedModelAliasVerificationConfig,
@@ -55,7 +56,7 @@ def test_verify_model_alias_fails_with_actionable_message(
             self, model_name: str, alias: str
         ) -> SimpleNamespace:
             del model_name, alias
-            raise RuntimeError(
+            raise MlflowException(
                 "INVALID_PARAMETER_VALUE: Registered model alias prod not found."
             )
 


### PR DESCRIPTION
## Summary
- Narrow broad `except Exception` catches to specific exception types where the intent is clear.
- Extract focused helpers from `train.main` and `evaluate_promotion_policy` to keep orchestration functions short and one-pass readable.
- Drop stale `# type: ignore` comments that mypy `--warn-unused-ignores` flagged.
- Tighten `typing.Any` where a real type exists; document the remaining `Any` boundaries (MLflow pyfunc return, gcloud JSON output, Pandera dtype references).
- Route `"prod"` string literals through the `ALIAS_PROD` constant for consistency with `ALIAS_CANDIDATE`.
- Extract helpers in `reproduce.py`, `release_reports.py`, `feature_contracts.py` to flatten nested logic and shrink long functions.
- Remove redundant `cast(Alias, ALIAS_PROD)` in `serving/router.py` (the `Literal["prod"]` constant is already assignable to `Alias`).
- Add module docstrings to the 26 remaining library modules that lacked them (pipeline, serving, policy, registry, runtime, hosted_ci, backends, jobs, common, core, contracts).

## Test plan
- [x] `make check` — ruff format, ruff lint, mypy, 129 unit tests
- [x] `make test-integration` — 8 integration tests
- [x] Spot-checked module docstrings render the intent of each file

Closes #164