### PR TITLE
docs: verify post-cleanup state and close M2

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The command writes:
 src/ml_lifecycle_platform/
   backends/     local runtime adapters
   cli/          operator CLI
-  common/       config, constants, MLflow helpers
+  common/       shared string constants (MLflow alias names)
   contracts/    reproducibility and lineage payloads
   core/         model specs and protocol definitions
   pipeline/     ingest, featurize, train, evaluate, orchestrate

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last verified: 2026-04-17
+Last verified: 2026-04-18
 
 ## Summary
 
@@ -92,7 +92,7 @@ Core OSS surface (local golden path):
 - `src/ml_lifecycle_platform/core/`: model specs and protocol definitions
 - `src/ml_lifecycle_platform/contracts/`: lineage and repro payloads
 - `src/ml_lifecycle_platform/backends/local/`: local adapters
-- `src/ml_lifecycle_platform/common/`: shared config constants and MLflow helpers
+- `src/ml_lifecycle_platform/common/`: shared string constants (MLflow alias names)
 
 Advanced hosted surface (maintainer only):
 

--- a/docs/architecture/how-it-works.md
+++ b/docs/architecture/how-it-works.md
@@ -1,6 +1,6 @@
 # How It Works Now
 
-Last verified: 2026-04-17
+Last verified: 2026-04-18
 
 This page is the shortest current explanation of how the repo works in practice.
 

--- a/docs/architecture/local-runtime.md
+++ b/docs/architecture/local-runtime.md
@@ -1,5 +1,7 @@
 # Local Runtime
 
+Last verified: 2026-04-18
+
 This document covers the concrete local runtime path shipped in `M0`.
 
 ## Runtime profile resolution

--- a/docs/architecture/m0-portability-charter.md
+++ b/docs/architecture/m0-portability-charter.md
@@ -1,5 +1,7 @@
 # M0 Portability Charter
 
+Last verified: 2026-04-18
+
 Status: accepted roadmap scope
 
 ## Intent

--- a/docs/architecture/m2-staging-platform.md
+++ b/docs/architecture/m2-staging-platform.md
@@ -2,7 +2,7 @@
 
 > **Advanced — maintainer only.** This document covers the hosted GCP staging path. You do not need it to contribute locally.
 
-Last verified: 2026-04-17
+Last verified: 2026-04-18
 
 This document locks the intended shape for `M2`: the first hosted GCP staging platform.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,7 @@
 # Overview
 
+Last verified: 2026-04-18
+
 The local path is the contributor default. The hosted GCP staging path is an advanced maintainer-only path — you do not need it to contribute. See [`how-it-works.md`](./how-it-works.md) for the contributor-oriented explanation.
 
 This repo currently has one real local path and one real hosted staging path:


### PR DESCRIPTION
## Summary

- Bump `Last verified` dates on all `docs/architecture/` files to 2026-04-18 (added the header to three files that lacked it).
- Update `common/` description in [README.md](README.md) `Repository Layout` and [current-state.md](docs/architecture/current-state.md) — post-cleanup, `common/` holds only `constants.py`.
- Audited `docs/` for stale `src/ml_lifecycle_platform/*` paths; none found outside the historical simplification charter.
- Re-read ADR-0001 and ADR-0002; both still hold — no supersede.
- Final PR to close M2.

## Test plan

- [x] `make docs-check`
- [x] Manual grep of `docs/` + `README.md` for stale module paths
- [x] ADR re-read

Closes #165