### PR TITLE
feat: bootstrap Grafana Cloud observability backend

### DIFF
--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -114,6 +114,40 @@ resource "google_cloud_run_v2_job" "platform" {
           name  = "LOG_LEVEL"
           value = "INFO"
         }
+
+        env {
+          name  = "GOOGLE_CLOUD_PROJECT"
+          value = data.google_project.current.project_id
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value = var.grafana_cloud_otlp_endpoint
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+            value = "http/protobuf"
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name = "OTEL_EXPORTER_OTLP_HEADERS"
+            value_source {
+              secret_key_ref {
+                secret  = google_secret_manager_secret.otlp_auth_header[0].secret_id
+                version = "latest"
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -121,6 +155,7 @@ resource "google_cloud_run_v2_job" "platform" {
   depends_on = [
     google_project_service.required["run.googleapis.com"],
     google_cloud_run_v2_service.mlflow,
+    google_secret_manager_secret_iam_member.runtime_otlp_auth_accessor,
   ]
 }
 

--- a/deployments/gcp/terraform/run_serving.tf
+++ b/deployments/gcp/terraform/run_serving.tf
@@ -102,6 +102,40 @@ resource "google_cloud_run_v2_service" "serving" {
         value = "INFO"
       }
 
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = data.google_project.current.project_id
+      }
+
+      dynamic "env" {
+        for_each = local.otlp_enabled ? [1] : []
+        content {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.grafana_cloud_otlp_endpoint
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.otlp_enabled ? [1] : []
+        content {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "http/protobuf"
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.otlp_enabled ? [1] : []
+        content {
+          name = "OTEL_EXPORTER_OTLP_HEADERS"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.otlp_auth_header[0].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
       startup_probe {
         failure_threshold = 30
         period_seconds    = 10
@@ -129,6 +163,7 @@ resource "google_cloud_run_v2_service" "serving" {
   depends_on = [
     google_project_service.required["run.googleapis.com"],
     google_cloud_run_v2_service.mlflow,
+    google_secret_manager_secret_iam_member.runtime_otlp_auth_accessor,
   ]
 }
 

--- a/deployments/gcp/terraform/secrets_grafana.tf
+++ b/deployments/gcp/terraform/secrets_grafana.tf
@@ -1,0 +1,38 @@
+locals {
+  otlp_enabled = (
+    length(trimspace(var.grafana_cloud_otlp_auth_header)) > 0
+    && length(trimspace(var.grafana_cloud_otlp_endpoint)) > 0
+  )
+  otlp_auth_secret_id = "${local.foundation_name_prefix}-staging-otlp-auth-header"
+}
+
+resource "google_secret_manager_secret" "otlp_auth_header" {
+  count = local.otlp_enabled ? 1 : 0
+
+  project   = data.google_project.current.project_id
+  secret_id = local.otlp_auth_secret_id
+
+  labels = merge(local.common_labels, { purpose = "otlp_auth_header" })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "otlp_auth_header" {
+  count = local.otlp_enabled ? 1 : 0
+
+  secret      = google_secret_manager_secret.otlp_auth_header[0].id
+  secret_data = var.grafana_cloud_otlp_auth_header
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_otlp_auth_accessor" {
+  count = local.otlp_enabled ? 1 : 0
+
+  project   = google_secret_manager_secret.otlp_auth_header[0].project
+  secret_id = google_secret_manager_secret.otlp_auth_header[0].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -110,3 +110,16 @@ variable "platform_image" {
   type        = string
   default     = ""
 }
+
+variable "grafana_cloud_otlp_endpoint" {
+  description = "Grafana Cloud OTLP/HTTP gateway base URL, e.g. https://otlp-gateway-prod-eu-west-0.grafana.net/otlp. Empty disables OTLP export on hosted Cloud Run."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_cloud_otlp_auth_header" {
+  description = "Value for OTEL_EXPORTER_OTLP_HEADERS (e.g. 'Authorization=Basic <base64>'). Stored in Secret Manager and mounted into hosted Cloud Run services."
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/deployments/grafana/terraform/contact_point.tf
+++ b/deployments/grafana/terraform/contact_point.tf
@@ -1,0 +1,7 @@
+resource "grafana_contact_point" "default_email" {
+  name = "mlp-staging-default-email"
+
+  email {
+    addresses = [var.notification_email]
+  }
+}

--- a/deployments/grafana/terraform/datasources.tf
+++ b/deployments/grafana/terraform/datasources.tf
@@ -1,0 +1,25 @@
+resource "grafana_data_source" "prometheus" {
+  type = "prometheus"
+  name = "grafana-cloud-prometheus"
+  url  = var.prometheus_url
+
+  basic_auth_enabled  = true
+  basic_auth_username = var.prometheus_user
+
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = var.prometheus_token
+  })
+}
+
+resource "grafana_data_source" "tempo" {
+  type = "tempo"
+  name = "grafana-cloud-tempo"
+  url  = var.tempo_url
+
+  basic_auth_enabled  = true
+  basic_auth_username = var.tempo_user
+
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = var.tempo_token
+  })
+}

--- a/deployments/grafana/terraform/outputs.tf
+++ b/deployments/grafana/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "prometheus_datasource_uid" {
+  description = "Grafana UID of the hosted Prometheus datasource; referenced by UP-24 dashboard JSON."
+  value       = grafana_data_source.prometheus.uid
+}
+
+output "tempo_datasource_uid" {
+  description = "Grafana UID of the hosted Tempo datasource; referenced by UP-24 dashboard JSON."
+  value       = grafana_data_source.tempo.uid
+}
+
+output "default_contact_point_name" {
+  description = "Name of the default email contact point; referenced by UP-25 alert policies."
+  value       = grafana_contact_point.default_email.name
+}

--- a/deployments/grafana/terraform/providers.tf
+++ b/deployments/grafana/terraform/providers.tf
@@ -1,0 +1,4 @@
+provider "grafana" {
+  url  = var.grafana_stack_url
+  auth = var.grafana_service_account_token
+}

--- a/deployments/grafana/terraform/terraform.tfvars.example
+++ b/deployments/grafana/terraform/terraform.tfvars.example
@@ -1,0 +1,15 @@
+# Copy to terraform.tfvars (gitignored) and fill with values from the Grafana
+# Cloud UI. See docs/runbooks/observability-setup.md for the exact steps.
+
+grafana_stack_url             = "https://<org>.grafana.net"
+grafana_service_account_token = "glsa_XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+prometheus_url   = "https://prometheus-prod-XX-prod-eu-west-0.grafana.net/api/prom"
+prometheus_user  = "1234567"
+prometheus_token = "glc_XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+tempo_url   = "https://tempo-prod-XX-prod-eu-west-0.grafana.net"
+tempo_user  = "7654321"
+tempo_token = "glc_XXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+notification_email = "jwillekes18@gmail.com"

--- a/deployments/grafana/terraform/variables.tf
+++ b/deployments/grafana/terraform/variables.tf
@@ -1,0 +1,93 @@
+variable "grafana_stack_url" {
+  description = "Grafana Cloud stack URL, e.g. https://<org>.grafana.net."
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://", var.grafana_stack_url))
+    error_message = "grafana_stack_url must be an https URL."
+  }
+}
+
+variable "grafana_service_account_token" {
+  description = "Stack-scoped Grafana Cloud service account token used by the provider to manage datasources and contact points."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.grafana_service_account_token)) > 0
+    error_message = "grafana_service_account_token must not be empty."
+  }
+}
+
+variable "prometheus_url" {
+  description = "Grafana Cloud hosted Prometheus base URL, e.g. https://prometheus-prod-XX-prod-eu-west-0.grafana.net/api/prom."
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://", var.prometheus_url))
+    error_message = "prometheus_url must be an https URL."
+  }
+}
+
+variable "prometheus_user" {
+  description = "Grafana Cloud hosted Prometheus instance ID used as the Basic Auth username."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.prometheus_user)) > 0
+    error_message = "prometheus_user must not be empty."
+  }
+}
+
+variable "prometheus_token" {
+  description = "Grafana Cloud hosted Prometheus access token used as the Basic Auth password."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.prometheus_token)) > 0
+    error_message = "prometheus_token must not be empty."
+  }
+}
+
+variable "tempo_url" {
+  description = "Grafana Cloud hosted Tempo base URL, e.g. https://tempo-prod-XX-prod-eu-west-0.grafana.net."
+  type        = string
+
+  validation {
+    condition     = can(regex("^https://", var.tempo_url))
+    error_message = "tempo_url must be an https URL."
+  }
+}
+
+variable "tempo_user" {
+  description = "Grafana Cloud hosted Tempo instance ID used as the Basic Auth username."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.tempo_user)) > 0
+    error_message = "tempo_user must not be empty."
+  }
+}
+
+variable "tempo_token" {
+  description = "Grafana Cloud hosted Tempo access token used as the Basic Auth password."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.tempo_token)) > 0
+    error_message = "tempo_token must not be empty."
+  }
+}
+
+variable "notification_email" {
+  description = "Email address for the default contact point; UP-25 binds alert rules to it."
+  type        = string
+  default     = "jwillekes18@gmail.com"
+
+  validation {
+    condition     = can(regex("^[^@]+@[^@]+\\.[^@]+$", var.notification_email))
+    error_message = "notification_email must look like an email address."
+  }
+}

--- a/deployments/grafana/terraform/versions.tf
+++ b/deployments/grafana/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = "~> 1.5.7"
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "= 3.14.1"
+    }
+  }
+
+  backend "gcs" {}
+}

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -76,6 +76,7 @@ models:/<model_name>@prod
 - hosted Cloud Run Jobs for platform actions are live and manually validated
 - Cloud Scheduler now triggers conservative maintenance cadence on top of those jobs
 - bootstrap IAM for `mlp-ci` bucket access is still partially out-of-band and documented in the runbooks
+- Grafana Cloud account, stack, and access-policy token are partially out-of-band (created in the Grafana Cloud UI, fed to Terraform via env vars); datasources, contact points, and the Cloud Run OTLP wiring are managed by the `deployments/grafana/terraform/` and `deployments/gcp/terraform/` roots, documented in [docs/runbooks/observability-setup.md](../runbooks/observability-setup.md)
 - current operating target is:
   - local green
   - GCP staging green

--- a/docs/runbooks/observability-setup.md
+++ b/docs/runbooks/observability-setup.md
@@ -1,0 +1,140 @@
+# Observability Setup
+
+Last verified: 2026-04-18
+
+This runbook covers the one-time, partially out-of-band bootstrap for the
+Grafana Cloud backend that staging exports to. Once this is done,
+[observability.md](observability.md) is the day-to-day reference.
+
+Two things are managed out-of-band (same pattern as the `mlp-ci` bucket IAM
+in [gcp-bootstrap.md](gcp-bootstrap.md)):
+
+- the Grafana Cloud account and stack (created in the web UI)
+- a service account token scoped to the stack (created in the web UI, then
+  fed to Terraform via an env var)
+
+Everything else — datasources, the email contact point, and the Cloud Run
+env vars that point serving and jobs at the OTLP gateway — is Terraform-managed.
+
+## What lands
+
+Two Terraform roots are involved:
+
+- `deployments/grafana/terraform/` — manages datasources (hosted Prometheus,
+  hosted Tempo) and a default email contact point inside the Grafana Cloud
+  stack
+- `deployments/gcp/terraform/` — stores the OTLP auth header in Secret
+  Manager and wires `OTEL_EXPORTER_OTLP_ENDPOINT`,
+  `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_EXPORTER_OTLP_HEADERS` onto the
+  hosted serving service and every platform job
+
+No dashboards (UP-24) and no alert rules (UP-25) land here.
+
+## One-time: create the Grafana Cloud stack
+
+1. Sign up at <https://grafana.com> using the free tier. 10k active series,
+   14-day retention. Use the EU region to stay local to `europe-west1`.
+2. In **My Account**, create a stack. Note the stack URL, it has the form
+   `https://<org>.grafana.net`.
+3. In the stack, open **Connections → Data sources → Hosted Prometheus**
+   and capture:
+   - the remote-write / query URL (`https://prometheus-prod-XX-prod-eu-west-0.grafana.net/api/prom`)
+   - the instance ID (numeric username)
+4. Do the same for **Hosted Tempo**:
+   - the base URL (`https://tempo-prod-XX-prod-eu-west-0.grafana.net`)
+   - the instance ID
+5. Open **Security → Access policies**. Create an access policy with
+   scopes `metrics:write`, `traces:write`, and `stacks:read`. Mint a token
+   from it. This is the value you will export as `TF_VAR_grafana_service_account_token`.
+6. For the Prom and Tempo datasources, also mint read tokens (stack-scoped
+   with `metrics:read` / `traces:read`). These are the `prometheus_token`
+   and `tempo_token` tfvar values.
+7. Open **Connections → OpenTelemetry**. Capture:
+   - the OTLP/HTTP endpoint
+     (`https://otlp-gateway-prod-eu-west-0.grafana.net/otlp`)
+   - the `Authorization: Basic <...>` header value minted for OTLP ingest.
+     Format: `Authorization=Basic <base64 of "instance_id:token">`. This
+     is what goes into Secret Manager.
+
+## Apply the Grafana Cloud Terraform root
+
+```bash
+cd deployments/grafana/terraform
+
+export TF_VAR_grafana_stack_url="https://<org>.grafana.net"
+export TF_VAR_grafana_service_account_token="glsa_..."
+export TF_VAR_prometheus_url="https://prometheus-prod-XX-prod-eu-west-0.grafana.net/api/prom"
+export TF_VAR_prometheus_user="1234567"
+export TF_VAR_prometheus_token="glc_..."
+export TF_VAR_tempo_url="https://tempo-prod-XX-prod-eu-west-0.grafana.net"
+export TF_VAR_tempo_user="7654321"
+export TF_VAR_tempo_token="glc_..."
+
+terraform init -backend-config="bucket=fpl-tf-state-jelle" \
+  -backend-config="prefix=ml-lifecycle-platform/grafana"
+terraform plan
+terraform apply
+```
+
+`terraform.tfvars.example` documents the same set for local use.
+
+## Apply the GCP OTLP wiring
+
+Add to the GCP root's tfvars (or export as `TF_VAR_*`):
+
+```hcl
+grafana_cloud_otlp_endpoint    = "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp"
+grafana_cloud_otlp_auth_header = "Authorization=Basic <base64>"
+```
+
+Then from `deployments/gcp/terraform/`:
+
+```bash
+terraform plan
+terraform apply
+```
+
+The plan should show additions only: the new `otlp-auth-header` secret,
+secret version, IAM binding, and three env vars on each Cloud Run service
+and job.
+
+Leaving `grafana_cloud_otlp_endpoint` empty skips the entire wiring — the
+apps fall back to the no-op exporter path from
+[telemetry.py](../../src/ml_lifecycle_platform/common/telemetry.py) and
+continue to boot cleanly.
+
+## Verify end-to-end
+
+After redeploying serving and the jobs image:
+
+1. Hit a few requests against the serving URL.
+2. Trigger a dry-run promote via the Cloud Run Job:
+   `gcloud run jobs execute mlp-promote-staging --region europe-west1 \
+    --args='--model-name,breast_cancer_clf,--dry-run,--format,json'`.
+3. In Grafana Cloud open **Explore → grafana-cloud-prometheus** and query
+   `requests_total` — non-zero samples labelled
+   `service_name="serving"` confirm the metric path.
+4. Open **Explore → grafana-cloud-tempo** and search traces for
+   `service.name = promote`. The dry-run run should appear as a single
+   trace with a `promote.main` span.
+
+If no data appears after two minutes, check Cloud Logging for
+`otel trace exporter init failed` or `otel metric exporter init failed`
+warnings from the service — those are emitted by `telemetry.py` when the
+endpoint is unreachable or the auth header is malformed.
+
+## Rotate the OTLP auth header
+
+1. Mint a new OTLP write token in the Grafana Cloud UI.
+2. Compose the new header value: `Authorization=Basic <base64 of "instance_id:token">`.
+3. Update the `grafana_cloud_otlp_auth_header` tfvar and
+   `terraform apply`. The Secret Manager secret version is replaced;
+   serving and jobs pick up the new value on next revision.
+4. Revoke the old Grafana Cloud token once the new revision is healthy.
+
+## Rotate the Grafana provider token
+
+The service account token used by the Grafana Terraform provider is held
+only in the operator's shell (`TF_VAR_grafana_service_account_token`). To
+rotate: mint a new token, re-run `terraform apply`, delete the old token
+in the Grafana Cloud UI. No state changes.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -6,12 +6,17 @@ from the serving API and from every Cloud Run Job (`pipeline`, `promote`,
 the collector named in `OTEL_EXPORTER_OTLP_ENDPOINT`; the serving Prometheus
 `/metrics` endpoint stays available for local scrape.
 
+Bootstrap for the hosted Grafana Cloud backend and how to wire staging to
+it are in [observability-setup.md](observability-setup.md). This page is
+the day-to-day reference for the telemetry surface itself.
+
 ## Environment
 
 | Variable | Purpose |
 | --- | --- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | gRPC collector endpoint, e.g. `http://otel-collector:4317`. When unset, boot still succeeds and exporters become no-ops. |
-| `OTEL_EXPORTER_OTLP_HEADERS` | Auth header for Grafana Cloud, e.g. `authorization=Basic <token>`. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint. For local dev, gRPC, e.g. `http://otel-collector:4317`. For Grafana Cloud staging, the OTLP/HTTP gateway, e.g. `https://otlp-gateway-prod-eu-west-0.grafana.net/otlp`. When unset, boot still succeeds and exporters become no-ops. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default, for the local collector) or `http/protobuf` (required by Grafana Cloud). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Auth header for Grafana Cloud, e.g. `Authorization=Basic <token>`. |
 | `GOOGLE_CLOUD_PROJECT` | When set, logs emit `logging.googleapis.com/trace` as `projects/<id>/traces/<trace_id>` so Cloud Logging Explorer resolves the jump to trace. |
 | `MLP_RUN_ID` | Overrides the generated run_id inside `start_job`. Set this to the Cloud Run execution ID so one log/trace group per run is visible end-to-end. |
 
@@ -46,8 +51,9 @@ Workflow in Cloud Logging Explorer:
 
 1. Filter for the service: `jsonPayload.service="serving"` (or `promote`, etc.).
 2. Open a log record and click the trace icon. Cloud Logging resolves the
-   trace ID and opens the matching span in Cloud Trace (or the linked
-   Grafana Tempo view in M3 once Grafana Cloud is wired up in UP-27).
+   trace ID and opens the matching span in Cloud Trace. Full-detail trace
+   view lives in Grafana Cloud Tempo once staging is wired up per
+   [observability-setup.md](observability-setup.md).
 3. From the span, use the same trace ID to find every other log line in the
    request or job run.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "numpy>=2.4.1",
     "opentelemetry-api>=1.29,<2.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.29,<2.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.29,<2.0",
     "opentelemetry-instrumentation-fastapi>=0.50b0,<1.0",
     "opentelemetry-sdk>=1.29,<2.0",
     "pandas>=2.3.3",

--- a/src/ml_lifecycle_platform/common/telemetry.py
+++ b/src/ml_lifecycle_platform/common/telemetry.py
@@ -5,6 +5,10 @@ metrics, reading the endpoint from ``OTEL_EXPORTER_OTLP_ENDPOINT``. All
 exporter setup is best-effort: if the collector is unreachable or the
 endpoint is unset, boot continues with a no-op tracer/meter.
 
+Protocol selection follows the OTel SDK convention via
+``OTEL_EXPORTER_OTLP_PROTOCOL``: ``grpc`` (default, used by the local
+collector) or ``http/protobuf`` (used by Grafana Cloud's OTLP gateway).
+
 The Prometheus ``/metrics`` endpoint remains the local scrape surface
 (metrics are dual-emitted to Prometheus and to OTel), so compose stays
 unchanged.
@@ -28,6 +32,40 @@ def _otlp_enabled() -> bool:
     return bool(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip())
 
 
+def _otlp_protocol() -> str:
+    return os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").strip().lower()
+
+
+def _build_span_exporter() -> Any:
+    if _otlp_protocol() == "http/protobuf":
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter as HttpSpanExporter,
+        )
+
+        return HttpSpanExporter()
+
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as GrpcSpanExporter,
+    )
+
+    return GrpcSpanExporter()
+
+
+def _build_metric_exporter() -> Any:
+    if _otlp_protocol() == "http/protobuf":
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter as HttpMetricExporter,
+        )
+
+        return HttpMetricExporter()
+
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+        OTLPMetricExporter as GrpcMetricExporter,
+    )
+
+    return GrpcMetricExporter()
+
+
 def _install_trace_provider(service: str, resource: Resource) -> None:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -35,11 +73,7 @@ def _install_trace_provider(service: str, resource: Resource) -> None:
     provider = TracerProvider(resource=resource)
     if _otlp_enabled():
         try:
-            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-                OTLPSpanExporter,
-            )
-
-            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+            provider.add_span_processor(BatchSpanProcessor(_build_span_exporter()))
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning(
                 "otel trace exporter init failed; traces will be dropped: %s",
@@ -55,11 +89,7 @@ def _install_meter_provider(service: str, resource: Resource) -> None:
     readers: list[Any] = []
     if _otlp_enabled():
         try:
-            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
-                OTLPMetricExporter,
-            )
-
-            readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
+            readers.append(PeriodicExportingMetricReader(_build_metric_exporter()))
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning(
                 "otel metric exporter init failed; metrics will be dropped: %s",

--- a/uv.lock
+++ b/uv.lock
@@ -1314,7 +1314,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -1326,6 +1326,7 @@ dependencies = [
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
@@ -1361,6 +1362,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "opentelemetry-api", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.29,<2.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29,<2.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0,<1.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29,<2.0" },
     { name = "pandas", specifier = ">=2.3.3" },
@@ -1617,6 +1619,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `deployments/grafana/terraform/` root: `grafana/grafana` provider, hosted Prometheus + Tempo datasources, default email contact point.
- New `deployments/gcp/terraform/secrets_grafana.tf`: Secret Manager secret for the OTLP Basic auth header, gated on the var being set, with runtime SA accessor.
- `run_serving.tf` and `jobs_platform.tf` now set `GOOGLE_CLOUD_PROJECT` unconditionally and `OTEL_EXPORTER_OTLP_ENDPOINT` / `PROTOCOL` / `HEADERS` when the Grafana Cloud vars are set.
- `common/telemetry.py` picks the HTTP/protobuf exporter when `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`; gRPC stays the local default.
- `docs/runbooks/observability-setup.md` documents account bootstrap, Terraform apply, verification, and rotation. `observability.md` and `architecture/current-state.md` link to it.

## Test plan

- [x] `make check`
- [x] `make docs-check`
- [x] `terraform fmt -recursive deployments/`
- [ ] `make e2e-clean`
- [ ] In staging: `terraform plan` in `deployments/grafana/terraform/` with the UI-captured vars shows additions only.
- [ ] In staging: `terraform plan` in `deployments/gcp/terraform/` with the OTLP vars set shows additions only (secret, secret version, IAM, env vars).
- [ ] Post-apply: requests against serving and a dry-run promote produce metrics in Explore → `grafana-cloud-prometheus` and traces in Explore → `grafana-cloud-tempo`.

Closes #172