### PR TITLE
chore: track terraform lockfile for observability root

### DIFF
--- a/deployments/observability/terraform/.terraform.lock.hcl
+++ b/deployments/observability/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.22.0"
+  constraints = "7.22.0"
+  hashes = [
+    "h1:B+5SNVoCQlMcaJvssp6LxcrxqewC1gYMgM8zTFqPuy0=",
+    "zh:167f86ebef8fe59a5c5e49d9627912f8f51ab474d3c677daba58b4d1a8b7e989",
+    "zh:314e1ab9ca6b0410660c651960243c7db26b60f00285bc5cda0c3dee63bf4ab8",
+    "zh:35768100a1f5ff315c3185f99f0aad4ce660018c5a018c722d84fa8e362b0542",
+    "zh:3fb613ab80c06b301aa7d626de56b88dc783da808a0b7a810c97762bf4da7491",
+    "zh:453f7ab7fe1315f0caac9cc00bb70220f7b31082d2ee03edb63a4883fd5512b6",
+    "zh:5e21fce93fd735f3eee9cf7b7bccf6829f117a9369714ea120280e98bf2a2628",
+    "zh:a883031feca659d62cf4a776f3a99c4b5e48d83704cb24128a0ca3a88c3cc74d",
+    "zh:b6d114fd146fedf5b5b455308c8fdef155b7ae090b57e9e1510fe7a50fa3fe2d",
+    "zh:f11baebd88b7c25dd2b88c82898be920d907ab1435a918f5cf8f8c70ecfb9533",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f62ab43c4d37e73818b9019b83fa9a8d6da12eb7e4570ca18b275ce871de74a3",
+    "zh:ff0415d8a2e95baa7dcc0cf21d386c9fdb35a641bc2e35cb9b240e1a42e919c4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/deployments/observability/terraform/config.tf
+++ b/deployments/observability/terraform/config.tf
@@ -2,12 +2,12 @@ locals {
   config_bucket_name = "${var.project_id}-${var.config_bucket_suffix}"
 
   config_files = {
-    "docker-compose.yml"                                  = "${path.module}/../docker-compose.yml"
-    "otel-collector.yaml"                                 = "${path.module}/../otel-collector.yaml"
-    "prometheus.yml"                                      = "${path.module}/../prometheus.yml"
-    "tempo.yaml"                                          = "${path.module}/../tempo.yaml"
-    "grafana/provisioning/datasources/datasources.yaml"   = "${path.module}/../grafana/provisioning/datasources/datasources.yaml"
-    "grafana/provisioning/dashboards/dashboards.yaml"     = "${path.module}/../grafana/provisioning/dashboards/dashboards.yaml"
+    "docker-compose.yml"                                = "${path.module}/../docker-compose.yml"
+    "otel-collector.yaml"                               = "${path.module}/../otel-collector.yaml"
+    "prometheus.yml"                                    = "${path.module}/../prometheus.yml"
+    "tempo.yaml"                                        = "${path.module}/../tempo.yaml"
+    "grafana/provisioning/datasources/datasources.yaml" = "${path.module}/../grafana/provisioning/datasources/datasources.yaml"
+    "grafana/provisioning/dashboards/dashboards.yaml"   = "${path.module}/../grafana/provisioning/dashboards/dashboards.yaml"
   }
 }
 

--- a/deployments/observability/terraform/vm.tf
+++ b/deployments/observability/terraform/vm.tf
@@ -91,7 +91,7 @@ resource "google_compute_instance" "observability" {
   machine_type = var.vm_machine_type
   zone         = var.zone
 
-  tags = [local.name_prefix]
+  tags   = [local.name_prefix]
   labels = merge(local.common_labels, { purpose = "observability_stack" })
 
   boot_disk {


### PR DESCRIPTION
## Summary

- Track `deployments/observability/terraform/.terraform.lock.hcl` (was left untracked after #181 merged)
- Apply `terraform fmt` to `config.tf` and `vm.tf`

Follow-up to #181.

## Test plan

- [x] `terraform fmt -check -recursive` in `deployments/observability/terraform/`