### PR TITLE
feat: add observability dashboards for serving, jobs, and releases

### DIFF
--- a/deployments/observability/docker-compose.yml
+++ b/deployments/observability/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - "3000:3000"
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     env_file:
       - ./grafana.env

--- a/deployments/observability/grafana/dashboards/jobs.json
+++ b/deployments/observability/grafana/dashboards/jobs.json
@@ -1,0 +1,137 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 3600},
+              {"color": "red", "value": 7200}
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "time() - max by (job) (maintenance_job_last_success_seconds)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Maintenance: time since last success",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 16, "x": 8, "y": 0},
+      "id": 2,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.95, sum by (le, service_name) (rate(traces_spanmetrics_latency_bucket{service_name=~\"pipeline|promote|rollback|reproduce|maintenance\"}[15m])))",
+          "legendFormat": "{{service_name}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Job entrypoint span duration (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "bars", "lineWidth": 1, "fillOpacity": 80},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (service_name) (increase(traces_spanmetrics_calls_total{service_name=~\"pipeline|promote|rollback|reproduce|maintenance\",status_code=\"STATUS_CODE_ERROR\"}[1h]))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Job failures per hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (service_name) (rate(traces_spanmetrics_calls_total{service_name=~\"pipeline|promote|rollback|reproduce|maintenance\"}[15m]))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Job call rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["ml-lifecycle-platform", "jobs"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Jobs health",
+  "uid": "mlp-jobs",
+  "weekStart": ""
+}

--- a/deployments/observability/grafana/dashboards/releases.json
+++ b/deployments/observability/grafana/dashboards/releases.json
@@ -1,0 +1,120 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "bars", "lineWidth": 1, "fillOpacity": 80},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (op) (increase(releases_total[24h]))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Releases per 24h by op",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (op, model) (increase(releases_total[7d]))",
+          "legendFormat": "{{op}} / {{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Releases in last 7d",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 86400},
+              {"color": "red", "value": 604800}
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "time() - max(maintenance_job_last_success_seconds{job=\"maintenance\"})",
+          "legendFormat": "prod freshness",
+          "refId": "A"
+        }
+      ],
+      "title": "Prod-version freshness (since last maintenance verify)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["ml-lifecycle-platform", "releases"],
+  "templating": {"list": []},
+  "time": {"from": "now-30d", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Release cadence",
+  "uid": "mlp-releases",
+  "weekStart": ""
+}

--- a/deployments/observability/grafana/dashboards/serving.json
+++ b/deployments/observability/grafana/dashboards/serving.json
@@ -1,0 +1,149 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (endpoint) (rate(requests_total{service_name=\"serving\"}[5m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate by endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum(rate(requests_total{service_name=\"serving\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(requests_total{service_name=\"serving\"}[5m])), 1)",
+          "legendFormat": "5xx share",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum(rate(requests_total{service_name=\"serving\",status=~\"4..\"}[5m])) / clamp_min(sum(rate(requests_total{service_name=\"serving\"}[5m])), 1)",
+          "legendFormat": "4xx share",
+          "refId": "B"
+        }
+      ],
+      "title": "Error rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+      "id": 3,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(predict_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(predict_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(predict_latency_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "/predict latency p50 / p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "lineWidth": 2, "fillOpacity": 10},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "id": 4,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(serving_startup_seconds_bucket[30m])))",
+          "legendFormat": "p95 startup",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(serving_startup_seconds_bucket[30m])))",
+          "legendFormat": "p50 startup",
+          "refId": "B"
+        }
+      ],
+      "title": "Serving startup latency",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["ml-lifecycle-platform", "serving"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Serving health",
+  "uid": "mlp-serving",
+  "weekStart": ""
+}

--- a/deployments/observability/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deployments/observability/grafana/provisioning/dashboards/dashboards.yaml
@@ -9,5 +9,5 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:
-      path: /etc/grafana/provisioning/dashboards
+      path: /var/lib/grafana/dashboards
       foldersFromFilesStructure: true

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -94,3 +94,58 @@ under the same names and label keys:
 OTLP metrics flow through the collector into the self-hosted Prometheus
 TSDB. Tempo's `metrics_generator` adds `traces_spanmetrics_*` and
 `traces_service_graph_*` series automatically from span data.
+
+Additional OTel-only signals:
+
+- `serving_startup_seconds` — histogram recorded once per container boot,
+  measuring wall time from FastAPI lifespan start to ready.
+- `releases_total{op,model}` — counter incremented on successful
+  `promote`, `rollback`, and `reproduce` registry operations.
+- `maintenance_job_last_success_seconds{job}` — observable gauge set to
+  the Unix timestamp of the most recent successful maintenance check.
+  Render staleness as `time() - maintenance_job_last_success_seconds`.
+
+## Dashboards
+
+Three dashboards ship in-repo and are loaded via Grafana's file-based
+provisioning:
+
+- **Serving health** (`mlp-serving`) — request rate, error rate, latency
+  p50/p95/p99, startup latency.
+- **Jobs health** (`mlp-jobs`) — maintenance freshness, per-job span
+  duration and failure counts from Tempo's span metrics.
+- **Release cadence** (`mlp-releases`) — promote / rollback / reproduce
+  counts, prod-version freshness.
+
+Start here when something feels off. Every panel resolves trace exemplars
+in Tempo via the Prometheus ↔ Tempo datasource link.
+
+### Authoring workflow
+
+The provisioning provider runs with `allowUiUpdates: true`, so UI edits
+persist to Grafana's local DB but **not** to the committed JSON. A
+container restart reloads from disk and UI-only edits are lost. That is
+the enforcement mechanism.
+
+To change a dashboard:
+
+1. Edit it in the Grafana UI.
+2. Share → Export → Save to file.
+3. Normalise and commit:
+
+   ```bash
+   python scripts/normalize_grafana_dashboard.py \
+     < ~/Downloads/serving-<timestamp>.json \
+     > deployments/observability/grafana/dashboards/serving.json
+   ```
+
+   The normalise script strips `id`, `version`, `iteration`, `gnetId` so
+   the diff reflects real changes only.
+
+4. Commit, open a PR, merge, redeploy the stack. On the observability
+   VM:
+
+   ```bash
+   docker compose -f deployments/observability/docker-compose.yml \
+     restart grafana
+   ```

--- a/scripts/normalize_grafana_dashboard.py
+++ b/scripts/normalize_grafana_dashboard.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Strip volatile fields from a Grafana dashboard export so the committed JSON
+stays stable across UI edits.
+
+Usage:
+
+    python scripts/normalize_grafana_dashboard.py < export.json > serving.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+VOLATILE_TOP_LEVEL = ("id", "version", "iteration", "gnetId")
+
+
+def normalize(payload: dict) -> dict:
+    cleaned = {
+        key: value for key, value in payload.items() if key not in VOLATILE_TOP_LEVEL
+    }
+    cleaned.setdefault("uid", payload.get("uid", ""))
+    return cleaned
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"invalid dashboard JSON on stdin: {exc}", file=sys.stderr)
+        return 2
+
+    json.dump(normalize(payload), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ml_lifecycle_platform/common/jobs.py
+++ b/src/ml_lifecycle_platform/common/jobs.py
@@ -17,7 +17,7 @@ from ml_lifecycle_platform.common.logging import (
     clear_log_context,
     configure_logging,
 )
-from ml_lifecycle_platform.common.telemetry import init_telemetry
+from ml_lifecycle_platform.common.telemetry import force_flush, init_telemetry
 
 
 @contextmanager
@@ -46,4 +46,5 @@ def start_job(name: str, *, level: int | str = logging.INFO) -> Iterator[str]:
         try:
             yield run_id
         finally:
+            force_flush()
             clear_log_context()

--- a/src/ml_lifecycle_platform/common/telemetry.py
+++ b/src/ml_lifecycle_platform/common/telemetry.py
@@ -126,6 +126,31 @@ def init_telemetry(service: str) -> None:
         logger.warning("init_telemetry(%s) failed: %s", service, exc)
 
 
+def force_flush(timeout_millis: int = 5000) -> None:
+    """Flush pending traces and metrics before process exit.
+
+    Best-effort: short-lived jobs (maintenance, promote, rollback, reproduce,
+    pipeline) exit before the periodic metric reader's next interval, so
+    without a flush the last observations are dropped.
+    """
+
+    tracer_provider = trace.get_tracer_provider()
+    flush_traces = getattr(tracer_provider, "force_flush", None)
+    if callable(flush_traces):
+        try:
+            flush_traces(timeout_millis)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("otel trace flush failed: %s", exc)
+
+    meter_provider = metrics.get_meter_provider()
+    flush_metrics = getattr(meter_provider, "force_flush", None)
+    if callable(flush_metrics):
+        try:
+            flush_metrics(timeout_millis)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("otel metric flush failed: %s", exc)
+
+
 def reset_for_tests() -> None:
     """Clear the init cache; for unit tests only."""
 

--- a/src/ml_lifecycle_platform/jobs/maintenance.py
+++ b/src/ml_lifecycle_platform/jobs/maintenance.py
@@ -7,7 +7,14 @@ import argparse
 import json
 import logging
 import sys
+import time
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
+from functools import lru_cache
+from typing import Any
+
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.metrics import CallbackOptions, Observation
 
 from ml_lifecycle_platform.common.constants import ALIAS_PROD
 from ml_lifecycle_platform.common.jobs import start_job
@@ -21,6 +28,30 @@ from ml_lifecycle_platform.runtime.bootstrap import (
 )
 
 logger = logging.getLogger(__name__)
+
+_last_success_epoch: float | None = None
+
+
+def _observe_last_success(
+    options: CallbackOptions,  # noqa: ARG001
+) -> Iterable[Observation]:
+    if _last_success_epoch is None:
+        return ()
+    return (Observation(_last_success_epoch, {"job": "maintenance"}),)
+
+
+@lru_cache(maxsize=1)
+def _register_last_success_gauge() -> Any:
+    meter = otel_metrics.get_meter("ml_lifecycle_platform.jobs.maintenance")
+    return meter.create_observable_gauge(
+        "maintenance_job_last_success_seconds",
+        callbacks=[_observe_last_success],
+        description=(
+            "Unix timestamp of the most recent successful maintenance check. "
+            "Use `time() - maintenance_job_last_success_seconds` for staleness."
+        ),
+        unit="s",
+    )
 
 
 @dataclass(frozen=True)
@@ -42,6 +73,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def run_maintenance_check(*, alias: str = ALIAS_PROD) -> MaintenanceReport:
+    global _last_success_epoch
+
     runtime = get_runtime_context()
     configure_mlflow(runtime)
 
@@ -56,6 +89,9 @@ def run_maintenance_check(*, alias: str = ALIAS_PROD) -> MaintenanceReport:
             alias=alias,
         )
     )
+
+    _register_last_success_gauge()
+    _last_success_epoch = time.time()
 
     return MaintenanceReport(
         tracking_uri=tracking_uri,

--- a/src/ml_lifecycle_platform/registry/metrics.py
+++ b/src/ml_lifecycle_platform/registry/metrics.py
@@ -1,0 +1,27 @@
+"""OTel counter emitted by registry release ops (promote, rollback, reproduce)
+so dashboards can track release cadence without parsing MLflow audit events."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from opentelemetry import metrics as otel_metrics
+
+
+@lru_cache(maxsize=1)
+def _release_counter() -> Any:
+    meter = otel_metrics.get_meter("ml_lifecycle_platform.registry")
+    return meter.create_counter(
+        "releases_total",
+        description="Count of successful registry release operations.",
+    )
+
+
+def record_release(op: str, model: str) -> None:
+    """Increment the release counter for ``op`` on ``model``.
+
+    ``op`` is one of ``promote``, ``rollback``, ``reproduce``.
+    """
+
+    _release_counter().add(1, {"op": op, "model": model})

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -45,6 +45,7 @@ from ml_lifecycle_platform.policy.policy_engine import (
     PolicyDecision,
     evaluate_promotion_policy,
 )
+from ml_lifecycle_platform.registry.metrics import record_release
 from ml_lifecycle_platform.registry.release_evidence import emit_release_evidence
 
 logger = logging.getLogger(__name__)
@@ -185,6 +186,8 @@ def apply_promotion(client: MlflowClient, plan: PromotionPlan) -> PromotionResul
         ALIAS_PROD,
         ALIAS_CHAMPION,
     )
+
+    record_release("promote", plan.model_name)
 
     return PromotionResult(
         plan=plan,

--- a/src/ml_lifecycle_platform/registry/reproduce.py
+++ b/src/ml_lifecycle_platform/registry/reproduce.py
@@ -52,6 +52,7 @@ from ml_lifecycle_platform.pipeline.train import (
     load_training_inputs,
     train_from_inputs,
 )
+from ml_lifecycle_platform.registry.metrics import record_release
 from ml_lifecycle_platform.registry.release_evidence import emit_release_evidence
 
 logger = logging.getLogger(__name__)
@@ -589,6 +590,7 @@ def reproduce_model(
         report["checks"]["metrics"] = result.metrics
         report["status"] = "matched"
         report["reason"] = None
+        record_release("reproduce", model_name)
         return report
 
 

--- a/src/ml_lifecycle_platform/registry/rollback.py
+++ b/src/ml_lifecycle_platform/registry/rollback.py
@@ -36,6 +36,7 @@ from ml_lifecycle_platform.contracts.release_reports import (
     render_model_card,
     utc_now_iso,
 )
+from ml_lifecycle_platform.registry.metrics import record_release
 from ml_lifecycle_platform.registry.release_evidence import (
     emit_release_evidence,
     load_release_manifest,
@@ -182,6 +183,8 @@ def rollback_prod(client: MlflowClient, model_name: str) -> None:
         previous_prod,
         current_prod.version,
     )
+
+    record_release("rollback", model_name)
 
     if not current_source_run_id:
         raise RuntimeError(

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -40,7 +40,7 @@ from .constants import (
     HEADER_MODEL_VERSION,
     HEADER_REQUEST_ID,
 )
-from .metrics import record_predict_latency, record_request
+from .metrics import record_predict_latency, record_request, record_startup_latency
 from .model_store import get_model_store
 from .prediction import run_prediction
 from .router import (
@@ -62,9 +62,11 @@ def _configure_logging(settings: Settings) -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+    t0 = time.perf_counter()
     settings = get_settings()
     _configure_logging(settings)
     init_telemetry("serving")
+    record_startup_latency(time.perf_counter() - t0)
     logger.info("serving started")
     yield
     logger.info("serving stopped")

--- a/src/ml_lifecycle_platform/serving/metrics.py
+++ b/src/ml_lifecycle_platform/serving/metrics.py
@@ -52,6 +52,16 @@ def _otel_instruments() -> tuple[Any, Any, Any]:  # type: ignore[valid-type]
     )
 
 
+@lru_cache(maxsize=1)
+def _startup_histogram() -> Any:
+    meter = otel_metrics.get_meter("ml_lifecycle_platform.serving")
+    return meter.create_histogram(
+        "serving_startup_seconds",
+        description="Wall time from lifespan start to serving ready, in seconds.",
+        unit="s",
+    )
+
+
 def record_request(endpoint: str, mode: str, status: str) -> None:
     REQUESTS_TOTAL.labels(endpoint=endpoint, mode=mode, status=status).inc()
     counter, _, _ = _otel_instruments()
@@ -72,3 +82,7 @@ def record_shadow_diff(mode: str, mae: float) -> None:
     SHADOW_DIFF_MAE.labels(mode=mode).observe(mae)
     _, _, shadow = _otel_instruments()
     shadow.record(mae, {"mode": mode})
+
+
+def record_startup_latency(latency_s: float) -> None:
+    _startup_histogram().record(latency_s)

--- a/tests/unit/test_registry_metrics.py
+++ b/tests/unit/test_registry_metrics.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+import ml_lifecycle_platform.registry.metrics as registry_metrics
+from ml_lifecycle_platform.registry.metrics import record_release
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def reader(monkeypatch: pytest.MonkeyPatch) -> Iterator[InMemoryMetricReader]:
+    instance = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[instance])
+    registry_metrics._release_counter.cache_clear()
+    monkeypatch.setattr(
+        registry_metrics.otel_metrics,
+        "get_meter",
+        lambda name: provider.get_meter(name),
+    )
+    yield instance
+    registry_metrics._release_counter.cache_clear()
+
+
+def test_record_release_increments_counter(reader: InMemoryMetricReader) -> None:
+    record_release("promote", "breast_cancer_clf")
+    record_release("rollback", "breast_cancer_clf")
+    record_release("promote", "breast_cancer_clf")
+
+    data = reader.get_metrics_data()
+    assert data is not None
+
+    by_op: dict[str, float] = {}
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != "releases_total":
+                    continue
+                for point in metric.data.data_points:
+                    attrs = point.attributes or {}
+                    if attrs.get("model") != "breast_cancer_clf":
+                        continue
+                    op = str(attrs.get("op", ""))
+                    by_op[op] = by_op.get(op, 0) + float(point.value)  # type: ignore[union-attr]
+
+    assert by_op == {"promote": 2, "rollback": 1}


### PR DESCRIPTION
## Summary

- add three Grafana dashboards (`serving`, `jobs`, `releases`) loaded via file-based provisioning from `deployments/observability/grafana/dashboards/`
- add `releases_total{op,model}` counter incremented by promote/rollback/reproduce on success
- add `maintenance_job_last_success_seconds` observable gauge set in the maintenance job; flush OTel providers on job exit so short-lived containers export the value
- add `serving_startup_seconds` histogram recorded in the FastAPI lifespan
- bind-mount `grafana/dashboards` separately from provisioning config; update the provider path accordingly
- add `scripts/normalize_grafana_dashboard.py` to strip `id`/`version`/`iteration`/`gnetId` before commit
- extend `docs/runbooks/observability.md` with the dashboard authoring workflow

## Test plan

- [x] `make check`
- [x] `make docs-check`
- [x] unit test for `record_release` counting by `op` / `model`
- [ ] `make e2e-clean` (requires Docker — run locally)
- [ ] `docker compose -f deployments/observability/docker-compose.yml up`, verify all three dashboards render after one staging cycle (pipeline → promote → predict)
- [ ] edit a dashboard in the UI, restart grafana, confirm UI-only edits are reverted (enforces commit-back discipline)

Closes #173