### PR TITLE
feat: upload grafana dashboard json to observability config bucket

### DIFF
--- a/deployments/observability/terraform/config.tf
+++ b/deployments/observability/terraform/config.tf
@@ -1,7 +1,7 @@
 locals {
   config_bucket_name = "${var.project_id}-${var.config_bucket_suffix}"
 
-  config_files = {
+  static_config_files = {
     "docker-compose.yml"                                = "${path.module}/../docker-compose.yml"
     "otel-collector.yaml"                               = "${path.module}/../otel-collector.yaml"
     "prometheus.yml"                                    = "${path.module}/../prometheus.yml"
@@ -9,6 +9,13 @@ locals {
     "grafana/provisioning/datasources/datasources.yaml" = "${path.module}/../grafana/provisioning/datasources/datasources.yaml"
     "grafana/provisioning/dashboards/dashboards.yaml"   = "${path.module}/../grafana/provisioning/dashboards/dashboards.yaml"
   }
+
+  dashboard_files = {
+    for f in fileset("${path.module}/../grafana/dashboards", "*.json") :
+    "grafana/dashboards/${f}" => "${path.module}/../grafana/dashboards/${f}"
+  }
+
+  config_files = merge(local.static_config_files, local.dashboard_files)
 }
 
 resource "google_storage_bucket" "config" {

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -142,10 +142,35 @@ To change a dashboard:
    The normalise script strips `id`, `version`, `iteration`, `gnetId` so
    the diff reflects real changes only.
 
-4. Commit, open a PR, merge, redeploy the stack. On the observability
-   VM:
+4. Commit, open a PR, merge. Then apply to staging as in
+   [Apply a dashboard change to staging](#apply-a-dashboard-change-to-staging).
 
-   ```bash
-   docker compose -f deployments/observability/docker-compose.yml \
-     restart grafana
-   ```
+## Apply a dashboard change to staging
+
+Dashboard JSONs under `deployments/observability/grafana/dashboards/`
+are uploaded to the observability config bucket by a dynamic
+`fileset(...)` map in
+`deployments/observability/terraform/config.tf`, so a new or edited
+file is picked up on the next `terraform apply` with no Terraform
+edit. The VM startup script only syncs the bucket to
+`/opt/observability/` on boot; post-boot changes need a manual
+rsync.
+
+From a checkout on master:
+
+```bash
+cd deployments/observability/terraform
+terraform apply   # uploads changed JSONs to gs://<project>-<config_bucket_suffix>
+```
+
+Then on the observability VM:
+
+```bash
+sudo gcloud storage rsync --recursive --delete-unmatched-destination-objects \
+  gs://<project>-<config_bucket_suffix> /opt/observability
+sudo docker compose -f /opt/observability/docker-compose.yml up -d
+```
+
+`docker compose up -d` re-reads the bind-mounted dashboard directory
+without a full restart. Use `restart grafana` only if provisioning
+config (not dashboard JSON) changed.


### PR DESCRIPTION
## Summary

- Replace the static dashboard entry in `deployments/observability/terraform/config.tf` with a dynamic `fileset(...)` merge over `grafana/dashboards/*.json`, so new dashboards get picked up automatically.
- Add an **Apply a dashboard change to staging** section to `docs/runbooks/observability.md` covering `terraform apply` → VM `gcloud storage rsync` → `docker compose up -d`, and clarify that the VM startup script only syncs the bucket on boot.

Closes the operational gap from #184: locally the dashboards render via bind-mount, but on the staging VM the rsync source (GCS config bucket) had no dashboard objects to serve.

## Test plan

- [x] `terraform -chdir=deployments/observability/terraform fmt -check` clean
- [x] `terraform -chdir=deployments/observability/terraform validate` passes
- [x] `make check`
- [x] `make docs-check`
- [ ] `cd deployments/observability/terraform && terraform plan` shows exactly 3 new `google_storage_bucket_object` resources (`grafana/dashboards/serving.json`, `jobs.json`, `releases.json`) and no other diffs
- [ ] After `terraform apply` + VM rsync + `docker compose up -d`, all three dashboards visible in the Grafana UI under the provisioned provider

Closes #185