### PR TITLE
feat: gcp-native alert routing for grafana managed alerts

### DIFF
--- a/.github/workflows/build-alert-router.yml
+++ b/.github/workflows/build-alert-router.yml
@@ -1,0 +1,101 @@
+name: CD / Build Alert Router
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - deployments/observability/alert-router/**
+      - .github/workflows/build-alert-router.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-alert-router-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_WIF_PROVIDER: ${{ vars.GCP_WIF_PROVIDER }}
+  GCP_CI_SERVICE_ACCOUNT: ${{ vars.GCP_CI_SERVICE_ACCOUNT }}
+  GCP_REGION: europe-west1
+  ARTIFACT_REGISTRY_REPOSITORY: mlp-images
+
+jobs:
+  build-and-push:
+    name: Build And Push
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve image refs
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          repository="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPOSITORY}"
+          echo "sha_ref=${repository}/alert-router:${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "latest_ref=${repository}/alert-router:latest" >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          version: ">= 363.0.0"
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Log in to Artifact Registry
+        env:
+          REGISTRY_HOST: ${{ env.GCP_REGION }}-docker.pkg.dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud auth print-access-token | docker login \
+            --username oauth2accesstoken \
+            --password-stdin \
+            "https://${REGISTRY_HOST}"
+
+      - name: Build alert-router image
+        env:
+          SHA_REF: ${{ steps.refs.outputs.sha_ref }}
+          LATEST_REF: ${{ steps.refs.outputs.latest_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build \
+            --tag "${SHA_REF}" \
+            --tag "${LATEST_REF}" \
+            deployments/observability/alert-router
+
+      - name: Smoke test alert-router image
+        env:
+          SHA_REF: ${{ steps.refs.outputs.sha_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python "${SHA_REF}" -c "import main"
+
+      - name: Push alert-router image
+        env:
+          SHA_REF: ${{ steps.refs.outputs.sha_ref }}
+          LATEST_REF: ${{ steps.refs.outputs.latest_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker push "${SHA_REF}"
+          docker push "${LATEST_REF}"

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 deployments/gcp/terraform/terraform.tfvars
+deployments/observability/terraform/terraform.tfvars
 
 # Generated GitHub Actions GCP credentials
 gha-creds-*.json

--- a/deployments/observability/alert-router/Dockerfile
+++ b/deployments/observability/alert-router/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY main.py ./
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=8080
+
+USER 65532:65532
+
+EXPOSE 8080
+
+CMD ["python", "main.py"]

--- a/deployments/observability/alert-router/README.md
+++ b/deployments/observability/alert-router/README.md
@@ -1,0 +1,11 @@
+# alert-router
+
+Tiny HTTP receiver for Grafana managed-alert webhooks. Runs on Cloud Run.
+Verifies a shared bearer token, fans each alert out to stdout as a
+structured JSON log line, returns 204. A log-based metric + Cloud
+Monitoring alert policy turns those log entries into an email.
+
+Stdlib-only Python. One file. No dependencies.
+
+See [`docs/runbooks/observability-alerts.md`](../../../docs/runbooks/observability-alerts.md)
+for the end-to-end escalation path and bootstrap instructions.

--- a/deployments/observability/alert-router/main.py
+++ b/deployments/observability/alert-router/main.py
@@ -1,0 +1,90 @@
+"""Grafana webhook -> Cloud Logging structured entries.
+
+Grafana managed-alert webhooks POST JSON to this service. We verify a shared
+bearer token, fan each alert out to stdout as a structured JSON log line, and
+return 204. Cloud Run captures stdout into Cloud Logging; a log-based metric
+counts the entries and a Cloud Monitoring alert policy routes the email.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import sys
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+MAX_BODY_BYTES = 1 * 1024 * 1024
+
+
+def emit(entry: dict) -> None:
+    sys.stdout.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+class Handler(BaseHTTPRequestHandler):
+    expected_auth: str = ""
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002
+        return
+
+    def _reply(self, status: HTTPStatus) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._reply(HTTPStatus.OK)
+
+    def do_POST(self) -> None:  # noqa: N802
+        auth = self.headers.get("Authorization", "")
+        if not hmac.compare_digest(auth, self.expected_auth):
+            self._reply(HTTPStatus.UNAUTHORIZED)
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._reply(HTTPStatus.BAD_REQUEST)
+            return
+
+        try:
+            payload = json.loads(self.rfile.read(length))
+        except json.JSONDecodeError:
+            self._reply(HTTPStatus.BAD_REQUEST)
+            return
+
+        alerts = payload.get("alerts") or []
+        for alert in alerts:
+            labels = alert.get("labels") or {}
+            status = alert.get("status", "unknown")
+            emit(
+                {
+                    "severity": "WARNING" if status == "firing" else "NOTICE",
+                    "message": "grafana_alert",
+                    "alertname": labels.get("alertname"),
+                    "status": status,
+                    "labels": labels,
+                    "annotations": alert.get("annotations") or {},
+                    "startsAt": alert.get("startsAt"),
+                    "endsAt": alert.get("endsAt"),
+                    "fingerprint": alert.get("fingerprint"),
+                    "generatorURL": alert.get("generatorURL"),
+                }
+            )
+
+        self._reply(HTTPStatus.NO_CONTENT)
+
+
+def main() -> None:
+    Handler.expected_auth = f"Bearer {os.environ['ALERT_ROUTER_TOKEN']}"
+    port = int(os.environ.get("PORT", "8080"))
+    server = ThreadingHTTPServer(("", port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/deployments/observability/grafana/provisioning/alerting/contact-points.yaml
+++ b/deployments/observability/grafana/provisioning/alerting/contact-points.yaml
@@ -2,11 +2,13 @@ apiVersion: 1
 
 contactPoints:
   - orgId: 1
-    name: noop
+    name: gcp-alert-router
     receivers:
-      - uid: noop-receiver
+      - uid: gcp-alert-router
         type: webhook
-        disableResolveMessage: true
+        disableResolveMessage: false
         settings:
-          url: http://localhost:0/unused
+          url: $__env{MLP_ALERT_ROUTER_URL}
           httpMethod: POST
+          authorization_scheme: Bearer
+          authorization_credentials: $__env{MLP_ALERT_ROUTER_TOKEN}

--- a/deployments/observability/grafana/provisioning/alerting/notification-policies.yaml
+++ b/deployments/observability/grafana/provisioning/alerting/notification-policies.yaml
@@ -2,7 +2,7 @@ apiVersion: 1
 
 policies:
   - orgId: 1
-    receiver: noop
+    receiver: gcp-alert-router
     group_by: ["grafana_folder", "alertname"]
     group_wait: 30s
     group_interval: 5m

--- a/deployments/observability/terraform/alert_router.tf
+++ b/deployments/observability/terraform/alert_router.tf
@@ -1,0 +1,97 @@
+resource "random_password" "alert_router_token" {
+  length  = 48
+  special = false
+}
+
+resource "google_secret_manager_secret" "alert_router_token" {
+  project   = data.google_project.current.project_id
+  secret_id = "${local.name_prefix}-alert-router-token"
+
+  labels = merge(local.common_labels, { purpose = "alert_router_token" })
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "alert_router_token" {
+  secret      = google_secret_manager_secret.alert_router_token.id
+  secret_data = random_password.alert_router_token.result
+}
+
+resource "google_service_account" "alert_router" {
+  project      = data.google_project.current.project_id
+  account_id   = "${local.name_prefix}-alert-router"
+  display_name = "ML lifecycle platform alert router"
+  description  = "Runtime identity for the Grafana webhook receiver on Cloud Run."
+}
+
+resource "google_secret_manager_secret_iam_member" "alert_router_token_accessor" {
+  project   = google_secret_manager_secret.alert_router_token.project
+  secret_id = google_secret_manager_secret.alert_router_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.alert_router.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "vm_alert_router_token_accessor" {
+  project   = google_secret_manager_secret.alert_router_token.project
+  secret_id = google_secret_manager_secret.alert_router_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.obs_vm.email}"
+}
+
+resource "google_cloud_run_v2_service" "alert_router" {
+  project  = data.google_project.current.project_id
+  name     = "${local.name_prefix}-alert-router"
+  location = var.region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  labels = merge(local.common_labels, { purpose = "alert_router" })
+
+  template {
+    service_account = google_service_account.alert_router.email
+
+    scaling {
+      max_instance_count = 2
+    }
+
+    containers {
+      image = var.alert_router_image
+
+      ports {
+        container_port = 8080
+      }
+
+      env {
+        name = "ALERT_ROUTER_TOKEN"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.alert_router_token.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+        cpu_idle          = true
+        startup_cpu_boost = false
+      }
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.alert_router_token_accessor,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "alert_router_public_invoker" {
+  project  = google_cloud_run_v2_service.alert_router.project
+  location = google_cloud_run_v2_service.alert_router.location
+  name     = google_cloud_run_v2_service.alert_router.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/deployments/observability/terraform/alert_routing.tf
+++ b/deployments/observability/terraform/alert_routing.tf
@@ -1,0 +1,85 @@
+resource "google_logging_metric" "grafana_alert_firing" {
+  project = data.google_project.current.project_id
+  name    = "${local.name_prefix}/grafana_alert_firing"
+
+  description = "Counts firing Grafana alerts fanned out by the alert-router Cloud Run service."
+
+  filter = <<-FILTER
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${google_cloud_run_v2_service.alert_router.name}"
+    jsonPayload.message="grafana_alert"
+    jsonPayload.status="firing"
+  FILTER
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "alertname"
+      value_type  = "STRING"
+      description = "Grafana alert rule name."
+    }
+  }
+
+  label_extractors = {
+    alertname = "EXTRACT(jsonPayload.alertname)"
+  }
+}
+
+resource "google_monitoring_notification_channel" "alert_email" {
+  project      = data.google_project.current.project_id
+  display_name = "${local.name_prefix} alert email"
+  type         = "email"
+
+  labels = {
+    email_address = var.alert_email
+  }
+
+  user_labels = local.common_labels
+}
+
+resource "google_monitoring_alert_policy" "grafana_alert_firing" {
+  project      = data.google_project.current.project_id
+  display_name = "Grafana alert firing (via alert-router)"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Grafana alert firing"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.grafana_alert_firing.name}\" resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["metric.label.alertname"]
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.alert_email.id]
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content   = <<-DOC
+      A Grafana managed alert has fired and been delivered to the alert-router.
+
+      Runbook: docs/runbooks/observability-alerts.md
+
+      Investigate in Grafana (Alerting > Alert rules) and follow the alert-specific
+      playbook in the runbook.
+    DOC
+    mime_type = "text/markdown"
+  }
+
+  user_labels = local.common_labels
+}

--- a/deployments/observability/terraform/outputs.tf
+++ b/deployments/observability/terraform/outputs.tf
@@ -27,3 +27,18 @@ output "grafana_admin_password_secret" {
   description = "Secret Manager secret ID holding the generated Grafana admin password."
   value       = google_secret_manager_secret.grafana_admin_password.secret_id
 }
+
+output "alert_router_url" {
+  description = "Cloud Run URL of the Grafana webhook receiver."
+  value       = google_cloud_run_v2_service.alert_router.uri
+}
+
+output "alert_router_token_secret" {
+  description = "Secret Manager secret ID holding the shared bearer token used by Grafana to authenticate to the alert-router."
+  value       = google_secret_manager_secret.alert_router_token.secret_id
+}
+
+output "alert_notification_channel" {
+  description = "Cloud Monitoring notification channel ID that routes alerts to the operator email."
+  value       = google_monitoring_notification_channel.alert_email.id
+}

--- a/deployments/observability/terraform/terraform.tfvars.example
+++ b/deployments/observability/terraform/terraform.tfvars.example
@@ -22,3 +22,9 @@ grafana_admin_cidr = "127.0.0.1/32"
 # after deploying serving / MLflow.
 serving_probe_url = ""
 mlflow_probe_url  = ""
+
+# Alert routing (GCP-native email escalation).
+# Build+push the router image first via `.github/workflows/build-alert-router.yml`,
+# then set the :<sha> tag here (or keep :latest for the most recent build).
+alert_email        = "you@example.com"
+alert_router_image = "europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/alert-router:latest"

--- a/deployments/observability/terraform/variables.tf
+++ b/deployments/observability/terraform/variables.tf
@@ -90,3 +90,23 @@ variable "mlflow_probe_url" {
   type        = string
   default     = ""
 }
+
+variable "alert_email" {
+  description = "Email address that receives Cloud Monitoring notifications when a Grafana alert fires. No default — set in terraform.tfvars."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", var.alert_email))
+    error_message = "alert_email must be a valid email address."
+  }
+}
+
+variable "alert_router_image" {
+  description = "Artifact Registry image ref for the Grafana webhook receiver (e.g. europe-west1-docker.pkg.dev/<project>/mlp-images/alert-router:latest). Build+push via .github/workflows/build-alert-router.yml before first apply."
+  type        = string
+
+  validation {
+    condition     = length(var.alert_router_image) > 0
+    error_message = "alert_router_image must be a non-empty image reference."
+  }
+}

--- a/deployments/observability/terraform/vm.tf
+++ b/deployments/observability/terraform/vm.tf
@@ -65,6 +65,7 @@ locals {
     HMAC_ACCESS=$(fetch_secret "${google_secret_manager_secret.tempo_hmac_access.secret_id}")
     HMAC_SECRET=$(fetch_secret "${google_secret_manager_secret.tempo_hmac_secret.secret_id}")
     GRAFANA_PASSWORD=$(fetch_secret "${google_secret_manager_secret.grafana_admin_password.secret_id}")
+    ALERT_ROUTER_TOKEN=$(fetch_secret "${google_secret_manager_secret.alert_router_token.secret_id}")
 
     cat > "$INSTALL_DIR/tempo.env" <<ENV
     TEMPO_BUCKET=${google_storage_bucket.tempo.name}
@@ -75,6 +76,8 @@ locals {
     cat > "$INSTALL_DIR/grafana.env" <<ENV
     GF_SECURITY_ADMIN_USER=admin
     GF_SECURITY_ADMIN_PASSWORD=$GRAFANA_PASSWORD
+    MLP_ALERT_ROUTER_URL=${google_cloud_run_v2_service.alert_router.uri}
+    MLP_ALERT_ROUTER_TOKEN=$ALERT_ROUTER_TOKEN
     ENV
 
     chmod 600 "$INSTALL_DIR/tempo.env" "$INSTALL_DIR/grafana.env"
@@ -136,10 +139,13 @@ resource "google_compute_instance" "observability" {
     google_secret_manager_secret_version.grafana_admin_password,
     google_secret_manager_secret_version.tempo_hmac_access,
     google_secret_manager_secret_version.tempo_hmac_secret,
+    google_secret_manager_secret_version.alert_router_token,
     google_secret_manager_secret_iam_member.vm_grafana_admin_accessor,
     google_secret_manager_secret_iam_member.vm_tempo_hmac_access_accessor,
     google_secret_manager_secret_iam_member.vm_tempo_hmac_secret_accessor,
+    google_secret_manager_secret_iam_member.vm_alert_router_token_accessor,
     google_storage_bucket_iam_member.vm_config_reader,
     google_storage_bucket_iam_member.vm_tempo_writer,
+    google_cloud_run_v2_service.alert_router,
   ]
 }

--- a/docs/runbooks/observability-alerts.md
+++ b/docs/runbooks/observability-alerts.md
@@ -9,10 +9,43 @@ Alerts are provisioned from
 and evaluated by Grafana OSS against the Prometheus datasource on the
 self-hosted observability VM (see [`observability-setup.md`](observability-setup.md)).
 
-**Notifications are deferred.** Alerts fire inside Grafana and are visible
-in the alerting UI; no email, Slack, or paging path is wired yet. Someone
-has to be looking at Grafana — or come here from a dashboard red marker —
-for an alert to produce action. Routing is tracked in [#189](https://github.com/jellewillekes/ml-lifecycle-platform/issues/189).
+## Escalation path
+
+Firing alerts reach a human via a GCP-native chain — no third-party SaaS,
+no tokens outside Secret Manager:
+
+```
+Grafana alert → webhook contact point
+             → Cloud Run `mlp-obs-alert-router` (shared-bearer auth)
+             → structured log entry (severity=WARNING, message=grafana_alert)
+             → log-based metric mlp-obs/grafana_alert_firing
+             → Cloud Monitoring alert policy "Grafana alert firing (via alert-router)"
+             → email notification channel (alert_email var)
+```
+
+Expect total time-to-email of roughly three to four minutes: Grafana's
+evaluation window, plus the log-based metric's ~60s aggregation, plus
+Cloud Monitoring's alignment period. That's acceptable for the SLOs in
+scope today; if it starts mattering, push evaluation intervals down
+first — the log-based metric floor is what it is.
+
+### Rotating the shared token
+
+```
+gcloud secrets versions add mlp-obs-alert-router-token --data-file=-
+# then redeploy the observability VM (or bounce the startup script) so
+# grafana.env re-reads the secret.
+```
+
+Terraform regenerates the token on `random_password` drift; running
+`terraform apply` with `-replace=random_password.alert_router_token`
+forces a rotation.
+
+### Silencing during incident work
+
+Use Grafana's built-in silence UI (Alerting → Silences) for per-alert or
+per-label muting. Silence at the Grafana layer, not at Cloud Monitoring —
+muting at CM means you lose the log record that the alert ever fired.
 
 ## Where to look first
 
@@ -85,7 +118,7 @@ reboot, or run `gcloud storage rsync` manually in an SSH session).
 
 ## Intentionally breaking staging
 
-To exercise the acceptance path:
+To exercise the acceptance path end-to-end (including email delivery):
 
 1. `gcloud run services update mlp-staging-serving --region=europe-west1
    --update-env-vars=FORCE_5XX=1` (or deploy an image that always 500s).
@@ -93,7 +126,24 @@ To exercise the acceptance path:
    inside its evaluation window (~5m pending + 1m eval).
 3. `ServingHealthProbeDown` will also flip once the probe catches a failing
    `/health`.
-4. Roll back the change; both alerts should resolve within one window.
+4. Check the alert-router's Cloud Run logs
+   (`gcloud logging read 'resource.labels.service_name=mlp-obs-alert-router AND jsonPayload.message=grafana_alert' --limit=10`);
+   one entry per firing alert should appear within a minute of the
+   Grafana transition.
+5. An email from `Cloud Monitoring <no-reply@google.com>` should arrive
+   at the configured `alert_email` within the next eval window.
+6. Roll back the change; Grafana alerts resolve; no further emails fire.
 
-This test is blocked on [#185](https://github.com/jellewillekes/ml-lifecycle-platform/issues/185)
-landing so dashboards reach the VM.
+## Bootstrap (first-time setup)
+
+Before the first `terraform apply` of `deployments/observability/terraform/`:
+
+1. Build and push the alert-router image:
+   `gh workflow run build-alert-router.yml` (or wait for a push to
+   `master` that touches `deployments/observability/alert-router/**`).
+   Verify the `:latest` tag exists in Artifact Registry.
+2. Set `alert_email` and `alert_router_image` in `terraform.tfvars`.
+3. `terraform apply` — creates the router, secret, log-based metric,
+   alert policy, and email notification channel.
+4. Cloud Monitoring sends a verification email to `alert_email` on first
+   creation of the notification channel. Confirm it to activate delivery.


### PR DESCRIPTION
## Summary
- Adds a stdlib-Python Cloud Run receiver (`alert-router`) that accepts Grafana webhook POSTs, verifies a shared bearer token, and emits one structured log line per alert.
- Wires a log-based metric + Cloud Monitoring alert policy + email notification channel so firing Grafana alerts reach an inbox end-to-end — fully GCP-native, no third-party tokens.
- Flips Grafana's provisioned contact point from the `noop` placeholder to the real webhook; URL and token are injected into `grafana.env` by the VM startup script and resolved via `$__env{}`.
- New `build-alert-router.yml` workflow builds and pushes the image on path-filtered master commits.
- Runbook updated with the escalation path, bootstrap order, token rotation, and a revised end-to-end acceptance test.

## Test plan
- [x] `make check`
- [x] `make docs-check`
- [x] `terraform init -backend=false && terraform validate` (observability root)
- [ ] After merge: `gh workflow run build-alert-router.yml`, confirm `:latest` tag exists in Artifact Registry
- [ ] `terraform apply` with `alert_email` and `alert_router_image` set in `terraform.tfvars`
- [ ] Confirm the Cloud Monitoring verification email on notification-channel creation
- [ ] Run the "Intentionally breaking staging" procedure in `docs/runbooks/observability-alerts.md` and verify email delivery within one alert window

Closes #189