### PR TITLE
fix(observability): disable deletion_protection on alert-router

### DIFF
--- a/deployments/observability/terraform/alert_router.tf
+++ b/deployments/observability/terraform/alert_router.tf
@@ -41,10 +41,11 @@ resource "google_secret_manager_secret_iam_member" "vm_alert_router_token_access
 }
 
 resource "google_cloud_run_v2_service" "alert_router" {
-  project  = data.google_project.current.project_id
-  name     = "${local.name_prefix}-alert-router"
-  location = var.region
-  ingress  = "INGRESS_TRAFFIC_ALL"
+  project             = data.google_project.current.project_id
+  name                = "${local.name_prefix}-alert-router"
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
 
   labels = merge(local.common_labels, { purpose = "alert_router" })
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ The hosted staging path is a separate advanced path documented under [Advanced h
 
 These runbooks cover the GCP staging path. You do not need them for normal local contribution.
 
+- [`runbooks/oss-deploy.md`](./runbooks/oss-deploy.md): end-to-end walkthrough for deploying this platform to your own GCP project from a fork
+- [`environments/fpl-project-jelle/`](./environments/fpl-project-jelle/): concrete identifiers and cheatsheet for the primary maintainer's deployment
 - [`runbooks/hosted-golden-path.md`](./runbooks/hosted-golden-path.md): canonical hosted GCP publish-deploy-validate path
 - [`runbooks/gcp-bootstrap.md`](./runbooks/gcp-bootstrap.md): adopt the existing GCP project and Terraform backend
 - [`runbooks/gcp-foundation.md`](./runbooks/gcp-foundation.md): create the first hosted GCP foundation resources

--- a/docs/environments/fpl-project-jelle/README.md
+++ b/docs/environments/fpl-project-jelle/README.md
@@ -1,0 +1,171 @@
+# Environment: `fpl-project-jelle`
+
+Last verified: 2026-04-20
+
+This is the primary maintainer's deployment. The runbooks in
+[`../../runbooks/`](../../runbooks/) use these concrete values as examples.
+If you forked the repo, see [`oss-deploy.md`](../../runbooks/oss-deploy.md)
+instead — it walks through the same path with placeholders you swap.
+
+## Pinned identifiers
+
+| Variable | Value |
+|---|---|
+| `project_id` | `fpl-project-jelle` |
+| `region` | `europe-west1` |
+| `zone` | `europe-west1-b` |
+| Terraform state bucket | `fpl-tf-state-jelle` |
+| Artifact Registry repo | `europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images` |
+| `alert_email` | `jwillekes18@gmail.com` |
+| Hosted serving service | `mlp-serving-staging` |
+| Hosted MLflow service | `mlp-mlflow-staging` |
+| Alert router service | `mlp-obs-alert-router` |
+| Observability VM | `mlp-obs-vm` (internal IP `10.42.0.100`) |
+| GitHub repo | `jellewillekes/ml-lifecycle-platform` |
+
+## Terraform backend-configs
+
+Each root uses the same state bucket with a distinct prefix.
+
+### GCP bootstrap / foundation / staging-infra / MLflow / serving
+
+```bash
+cd deployments/gcp/terraform
+terraform init \
+  -backend-config="bucket=fpl-tf-state-jelle" \
+  -backend-config="prefix=ml-lifecycle-platform/gcp/bootstrap"
+```
+
+### Observability stack + alerts
+
+```bash
+cd deployments/observability/terraform
+terraform init \
+  -backend-config="bucket=fpl-tf-state-jelle" \
+  -backend-config="prefix=ml-lifecycle-platform/observability"
+```
+
+## Observability `terraform.tfvars`
+
+The file is gitignored. The committed template is
+[`deployments/observability/terraform/terraform.tfvars.example`](../../../deployments/observability/terraform/terraform.tfvars.example).
+Current pinned values:
+
+```hcl
+project_id = "fpl-project-jelle"
+region     = "europe-west1"
+zone       = "europe-west1-b"
+
+staging_network_name    = "mlp-staging-vpc"
+staging_subnetwork_name = "mlp-staging-subnet"
+
+vm_machine_type         = "e2-medium"
+vm_static_internal_ip   = "10.42.0.100"
+prometheus_disk_size_gb = 50
+
+grafana_admin_cidr = "127.0.0.1/32"
+
+alert_email        = "jwillekes18@gmail.com"
+alert_router_image = "europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/alert-router@sha256:<DIGEST>"
+```
+
+Pin `alert_router_image` by digest, not `:latest`. Find the current digest
+with:
+
+```bash
+gcloud artifacts docker images list \
+  europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/alert-router \
+  --include-tags --sort-by=~UPDATE_TIME --limit=1
+```
+
+## Cheatsheet
+
+### Trigger alert-router image build
+
+```bash
+gh workflow run build-alert-router.yml --ref master
+```
+
+### Synthetic webhook test (acceptance)
+
+```bash
+TOKEN=$(gcloud secrets versions access latest --secret=mlp-obs-alert-router-token)
+ROUTER_URL=$(terraform -chdir=deployments/observability/terraform output -raw alert_router_url)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+curl -X POST "$ROUTER_URL" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"SyntheticTest\"},\"annotations\":{\"summary\":\"manual check\"},\"startsAt\":\"$NOW\",\"fingerprint\":\"manual-$(date +%s)\"}]}"
+```
+
+Expect `204`. An email from `Cloud Monitoring <no-reply@google.com>` arrives
+at `jwillekes18@gmail.com` within ~3 minutes. A recovery email follows when
+the log-based metric drops back to zero.
+
+### Break staging serving on purpose (real alert path)
+
+```bash
+gcloud run services update mlp-serving-staging \
+  --region=europe-west1 \
+  --update-env-vars=FORCE_5XX=1
+# revert:
+gcloud run services update mlp-serving-staging \
+  --region=europe-west1 \
+  --remove-env-vars=FORCE_5XX
+```
+
+### Rotate the alert-router shared token
+
+```bash
+terraform -chdir=deployments/observability/terraform apply \
+  -replace=random_password.alert_router_token
+```
+
+Then SSH to `mlp-obs-vm` and re-run the startup script (or reboot) so
+`grafana.env` re-reads the new secret.
+
+### Grafana admin password
+
+```bash
+gcloud secrets versions access latest --secret=mlp-obs-grafana-admin-password
+```
+
+UI is at `http://<mlp-obs-vm-external-ip>:3000`, reachable only from the
+`grafana_admin_cidr` range set in tfvars.
+
+## Recovery recipes
+
+### Cloud Run v2 service tainted (alert-router)
+
+Symptom: `terraform apply` fails with
+`cannot destroy service without setting deletion_protection=false`. Flipping
+`deletionProtection` via `gcloud` or REST does not work — it is a
+Terraform-provider attribute, not a real Cloud Run API field.
+
+```bash
+cd deployments/observability/terraform
+terraform untaint google_cloud_run_v2_service.alert_router
+terraform apply
+```
+
+`deletion_protection = false` is already set in
+[`alert_router.tf`](../../../deployments/observability/terraform/alert_router.tf),
+so this is an in-place update.
+
+### `Image not found` during alert-router apply
+
+```bash
+# confirm the image exists
+gcloud artifacts docker images list \
+  europe-west1-docker.pkg.dev/fpl-project-jelle/mlp-images/alert-router \
+  --include-tags --limit=5
+
+# pin by digest in terraform.tfvars:
+# alert_router_image = "...alert-router@sha256:<DIGEST>"
+
+terraform apply
+```
+
+Tag-resolution against `:latest` can 404 even when the tag is present in
+Artifact Registry. Digest pins do not.

--- a/docs/runbooks/gcp-bootstrap.md
+++ b/docs/runbooks/gcp-bootstrap.md
@@ -2,6 +2,10 @@
 
 Last verified: 2026-03-10
 
+> Forking the repo? Start from [`oss-deploy.md`](./oss-deploy.md). It tells
+> you which identifiers in this runbook to swap and links back here at the
+> right step.
+
 This runbook covers the shared Terraform root that adopts the existing GCP project and remote state bucket and now also manages the first hosted foundation resources.
 
 Current adopted identifiers:

--- a/docs/runbooks/gcp-foundation.md
+++ b/docs/runbooks/gcp-foundation.md
@@ -2,6 +2,10 @@
 
 Last verified: 2026-03-10
 
+> Forking the repo? Start from [`oss-deploy.md`](./oss-deploy.md). The WIF
+> block in this runbook pins the primary maintainer's GitHub repo ID and
+> must be swapped for your fork's numeric ID before apply.
+
 This runbook creates the first hosted GCP foundation layer on top of the adopted project and Terraform backend from [`gcp-bootstrap.md`](./gcp-bootstrap.md).
 
 Current scope:

--- a/docs/runbooks/observability-alerts.md
+++ b/docs/runbooks/observability-alerts.md
@@ -2,6 +2,10 @@
 
 Last verified: 2026-04-20
 
+> Forking the repo? Start from [`oss-deploy.md`](./oss-deploy.md). The
+> Bootstrap section at the bottom of this doc is the final step of that
+> walkthrough.
+
 Something is red in Grafana — here's what to check.
 
 Alerts are provisioned from
@@ -120,7 +124,7 @@ reboot, or run `gcloud storage rsync` manually in an SSH session).
 
 To exercise the acceptance path end-to-end (including email delivery):
 
-1. `gcloud run services update mlp-staging-serving --region=europe-west1
+1. `gcloud run services update mlp-serving-staging --region=europe-west1
    --update-env-vars=FORCE_5XX=1` (or deploy an image that always 500s).
 2. Watch Grafana → Alerting. `ServingHighErrorRate` should flip to Firing
    inside its evaluation window (~5m pending + 1m eval).
@@ -141,9 +145,74 @@ Before the first `terraform apply` of `deployments/observability/terraform/`:
 1. Build and push the alert-router image:
    `gh workflow run build-alert-router.yml` (or wait for a push to
    `master` that touches `deployments/observability/alert-router/**`).
-   Verify the `:latest` tag exists in Artifact Registry.
-2. Set `alert_email` and `alert_router_image` in `terraform.tfvars`.
-3. `terraform apply` — creates the router, secret, log-based metric,
+   Verify the image exists in Artifact Registry, then capture the
+   digest:
+
+   ```bash
+   gcloud artifacts docker images list \
+     europe-west1-docker.pkg.dev/<PROJECT_ID>/mlp-images/alert-router \
+     --include-tags --sort-by=~UPDATE_TIME --limit=1
+   ```
+
+2. `terraform init` with an explicit backend-config (the state bucket
+   is external to this root):
+
+   ```bash
+   terraform init \
+     -backend-config="bucket=<TF_STATE_BUCKET>" \
+     -backend-config="prefix=ml-lifecycle-platform/observability"
+   ```
+
+3. Set `alert_email` and `alert_router_image` in `terraform.tfvars`.
+   Pin `alert_router_image` by digest (`@sha256:<DIGEST>`), not
+   `:latest` — tag-resolution against `:latest` can 404 even when the
+   tag is present.
+4. `terraform apply` — creates the router, secret, log-based metric,
    alert policy, and email notification channel.
-4. Cloud Monitoring sends a verification email to `alert_email` on first
-   creation of the notification channel. Confirm it to activate delivery.
+5. Email-type Cloud Monitoring channels do **not** send a verification
+   email on creation. The first real (or synthetic) alert is also the
+   first delivery — use the synthetic curl in the acceptance test below
+   to prove the chain end-to-end.
+
+### Acceptance test (synthetic webhook)
+
+Fastest proof the full chain works, without needing real traffic:
+
+```bash
+TOKEN=$(gcloud secrets versions access latest --secret=mlp-obs-alert-router-token)
+ROUTER_URL=$(terraform -chdir=deployments/observability/terraform output -raw alert_router_url)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+curl -X POST "$ROUTER_URL" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"SyntheticTest\"},\"annotations\":{\"summary\":\"acceptance check\"},\"startsAt\":\"$NOW\",\"fingerprint\":\"synthetic-$(date +%s)\"}]}"
+```
+
+Expect `204`. Within ~1 minute the log entry appears:
+
+```bash
+gcloud logging read \
+  'resource.labels.service_name=mlp-obs-alert-router AND jsonPayload.message=grafana_alert' \
+  --limit=5 --format=json
+```
+
+Email from `Cloud Monitoring <no-reply@google.com>` arrives within ~3
+minutes (check spam / Promotions). A recovery email follows when the
+log-based metric drops back to zero.
+
+### Recovery: Cloud Run v2 service tainted
+
+If an apply leaves `mlp-obs-alert-router` tainted and the next apply
+errors with `cannot destroy service without setting deletion_protection=false`:
+
+```bash
+terraform untaint google_cloud_run_v2_service.alert_router
+terraform apply
+```
+
+`deletion_protection = false` is already set in
+[`alert_router.tf`](../../deployments/observability/terraform/alert_router.tf),
+so this runs as an in-place update. Flipping `deletionProtection` via
+`gcloud` or the REST API does not work — it is a Terraform-provider
+attribute, not a real Cloud Run API field.

--- a/docs/runbooks/observability-setup.md
+++ b/docs/runbooks/observability-setup.md
@@ -2,6 +2,10 @@
 
 Last verified: 2026-04-18
 
+> Forking the repo? Start from [`oss-deploy.md`](./oss-deploy.md). It
+> sequences this root after the GCP foundation and staging infra, and
+> names the placeholders you swap.
+
 This runbook covers the one-time bootstrap for the self-hosted observability
 stack that staging exports to. Day-to-day telemetry reference lives in
 [observability.md](observability.md).

--- a/docs/runbooks/oss-deploy.md
+++ b/docs/runbooks/oss-deploy.md
@@ -1,0 +1,285 @@
+# OSS Deploy Walkthrough
+
+Last verified: 2026-04-20
+
+This runbook is the end-to-end path for deploying this platform to your own
+GCP project. If you are the primary maintainer (`fpl-project-jelle`), use
+the per-topic runbooks directly and the concrete values in
+[`docs/environments/fpl-project-jelle/`](../environments/fpl-project-jelle/).
+
+If you forked the repo and want a working hosted stack, start here. Every
+other runbook in [`docs/runbooks/`](./) uses the primary maintainer's
+identifiers as concrete examples; this doc tells you what to swap.
+
+## Who this is for
+
+You have:
+
+- forked `jellewillekes/ml-lifecycle-platform` to your own GitHub org
+- a GCP account with billing you can attach to a new project
+- `gcloud` (current stable), `terraform` 1.5.7, and `gh` CLI installed
+- ~1 hour for the first walkthrough
+
+You do not need to read the hosted runbooks first. Follow this doc and it
+will link into them at the right point.
+
+## What you'll have at the end
+
+- a GCP project with the platform's staging VPC, Artifact Registry repo,
+  and Workload Identity Federation pool wired to your fork
+- hosted MLflow and serving on Cloud Run
+- a self-hosted observability VM running Prometheus, Tempo, and Grafana
+- Grafana-managed alerts emailing you when staging serving errors or
+  latency cross thresholds
+
+The platform's local path (`make e2e`) does not need any of this.
+
+## Variables to choose
+
+Decide these up front. Use the same values consistently across every
+runbook you touch.
+
+| Variable | What it is | Example |
+|---|---|---|
+| `<PROJECT_ID>` | GCP project ID (globally unique) | `mlp-acme-prod` |
+| `<REGION>` | GCP region for all hosted resources | `europe-west1` |
+| `<ZONE>` | GCP zone inside `<REGION>` | `europe-west1-b` |
+| `<TF_STATE_BUCKET>` | GCS bucket holding Terraform state (globally unique) | `mlp-acme-tf-state` |
+| `<ALERT_EMAIL>` | Where Grafana alerts are emailed | `oncall@acme.com` |
+| `<GRAFANA_ADMIN_CIDR>` | Your public IP, `/32` | `203.0.113.4/32` |
+| `<GITHUB_OWNER>` | Your GitHub org or user | `acme` |
+| `<GITHUB_REPO>` | Repo name (typically unchanged) | `ml-lifecycle-platform` |
+| `<GITHUB_REPO_ID>` | Numeric repo ID (see below) | `123456789` |
+
+Find the numeric repo ID with:
+
+```bash
+gh api /repos/<GITHUB_OWNER>/<GITHUB_REPO> --jq .id
+```
+
+The numeric ID matters: the WIF trust condition pins authorization to the
+repo ID, not its name, so renames do not silently expand access. If you
+skip this, CI auth in your fork will fail with a 403.
+
+## Manual pre-Terraform steps
+
+Terraform cannot bootstrap its own state bucket, its own project, or its
+own billing. Do these once with an operator identity (your laptop).
+
+### 1. Create the project and attach billing
+
+```bash
+gcloud projects create <PROJECT_ID>
+gcloud beta billing projects link <PROJECT_ID> \
+  --billing-account=<YOUR_BILLING_ACCOUNT_ID>
+gcloud config set project <PROJECT_ID>
+```
+
+### 2. Create the Terraform state bucket
+
+```bash
+gcloud storage buckets create gs://<TF_STATE_BUCKET> \
+  --location=<REGION> \
+  --uniform-bucket-level-access \
+  --public-access-prevention
+```
+
+Enable object versioning so you can recover from accidental state edits:
+
+```bash
+gcloud storage buckets update gs://<TF_STATE_BUCKET> --versioning
+```
+
+### 3. Authenticate
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud auth application-default set-quota-project <PROJECT_ID>
+```
+
+### 4. Fork-pin the WIF condition
+
+The foundation Terraform root pins the GitHub Actions WIF trust to the
+maintainer's repo ID. In your fork, edit the Terraform HCL to use your
+`<GITHUB_OWNER>`, `<GITHUB_REPO>`, and `<GITHUB_REPO_ID>` before you apply
+the foundation root. See [`gcp-foundation.md`](./gcp-foundation.md) for
+the WIF block that needs updating.
+
+## Terraform roots, in order
+
+Apply these roots in this order. For each, use your `<TF_STATE_BUCKET>`
+and a distinct `prefix` per root so the state layouts stay separate.
+
+Each step below summarises *what to do differently from the linked
+runbook*. Defer to the linked runbook for the authoritative procedure.
+
+### Step 1 · Bootstrap
+
+Runbook: [`gcp-bootstrap.md`](./gcp-bootstrap.md)
+
+```bash
+cd deployments/gcp/terraform
+terraform init \
+  -backend-config="bucket=<TF_STATE_BUCKET>" \
+  -backend-config="prefix=ml-lifecycle-platform/gcp/bootstrap"
+```
+
+Set `project_id` and `region` in a local, gitignored `terraform.tfvars`.
+Apply.
+
+### Step 2 · Foundation
+
+Same root, same state. This step adds Artifact Registry, buckets, service
+accounts, and GitHub Actions WIF.
+
+Runbook: [`gcp-foundation.md`](./gcp-foundation.md)
+
+Before you apply: confirm you edited the WIF condition to your fork's
+repo. After the apply: capture the outputs (`workload_identity_provider_name`,
+`foundation_service_accounts`) — you will paste these into GitHub Actions
+secrets in step 3.
+
+### Step 3 · CI auth
+
+Runbook: [`gcp-ci-auth.md`](./gcp-ci-auth.md)
+
+Set the GitHub Actions repo secrets in your fork so CI workflows can
+impersonate the foundation CI service account.
+
+### Step 4 · Staging infra
+
+Runbook: [`gcp-staging-infra.md`](./gcp-staging-infra.md)
+
+Creates the staging VPC, subnet, and Cloud SQL. The observability VM
+later joins this VPC, so it must exist first.
+
+### Step 5 · MLflow
+
+Runbook: [`deploy-mlflow.md`](./deploy-mlflow.md)
+
+### Step 6 · Serving
+
+Runbook: [`deploy-serving.md`](./deploy-serving.md)
+
+### Step 7 · Observability stack
+
+Runbook: [`observability-setup.md`](./observability-setup.md)
+
+Use `<TF_STATE_BUCKET>` with prefix `ml-lifecycle-platform/observability`:
+
+```bash
+cd deployments/observability/terraform
+terraform init \
+  -backend-config="bucket=<TF_STATE_BUCKET>" \
+  -backend-config="prefix=ml-lifecycle-platform/observability"
+```
+
+Set `project_id`, `region`, `zone`, `grafana_admin_cidr` in a local
+`terraform.tfvars`. Apply. This brings up the VM, Prometheus, Tempo, and
+Grafana with no alerts wired yet.
+
+### Step 8 · Alert routing
+
+Runbook: [`observability-alerts.md`](./observability-alerts.md)
+
+**Before the first `terraform apply` on this root**: you must build and
+push the alert-router container image, otherwise the apply will fail with
+`Image not found` and leave the Cloud Run service tainted. See the
+Bootstrap section of `observability-alerts.md`.
+
+Set `alert_email = "<ALERT_EMAIL>"` in the same `terraform.tfvars`.
+
+## Common failures
+
+### `Image not found` on first alert-router apply
+
+The apply races the image build. Trigger the build workflow from your
+fork first, wait for it to complete, and pin the image by digest in
+`terraform.tfvars`:
+
+```hcl
+alert_router_image = "europe-west1-docker.pkg.dev/<PROJECT_ID>/mlp-images/alert-router@sha256:<DIGEST>"
+```
+
+Using `@sha256:` instead of `:latest` avoids tag-resolution flakiness
+that can 404 even when Artifact Registry lists the tag.
+
+### Cloud Run v2 service stuck tainted
+
+If a prior apply left the service tainted and the next apply errors with
+`cannot destroy service without setting deletion_protection=false`:
+
+```bash
+terraform untaint google_cloud_run_v2_service.alert_router
+terraform apply
+```
+
+After the fix landed in
+[`deployments/observability/terraform/alert_router.tf`](../../deployments/observability/terraform/alert_router.tf)
+this is an in-place update, not a destroy.
+
+Flipping `deletionProtection` via `gcloud` or the REST API does not work
+— it is a Terraform-provider attribute, not a real Cloud Run API field.
+
+### Workload Identity Federation rejects CI auth
+
+The WIF condition pins to the maintainer's numeric repo ID. A fresh fork
+will 403 with `Unable to acquire impersonation credentials`. Re-check
+`<GITHUB_REPO_ID>` from step 0 matches the value in the foundation
+Terraform and re-apply.
+
+### State bucket "not found" during `terraform init`
+
+The state bucket is external to every Terraform root (see
+[`gcp-bootstrap.md`](./gcp-bootstrap.md) for why). It must exist before
+`terraform init` runs. Re-do the pre-Terraform step 2.
+
+### Notification channel silent
+
+Cloud Monitoring email channels do not send a verification email. The
+first real alert is also the first delivery. Use the acceptance test
+below to prove the chain end-to-end instead of waiting for a
+verification link that will not arrive.
+
+## Acceptance test
+
+This is the fastest proof that the full chain works, without needing
+real serving traffic.
+
+```bash
+TOKEN=$(gcloud secrets versions access latest --secret=mlp-obs-alert-router-token)
+ROUTER_URL=$(terraform -chdir=deployments/observability/terraform output -raw alert_router_url)
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+curl -X POST "$ROUTER_URL" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"AcceptanceTest\"},\"annotations\":{\"summary\":\"oss-deploy.md acceptance test\"},\"startsAt\":\"$NOW\",\"fingerprint\":\"oss-deploy-acceptance\"}]}"
+```
+
+Expect `204`. Within ~1 minute:
+
+```bash
+gcloud logging read \
+  'resource.labels.service_name=mlp-obs-alert-router AND jsonPayload.message=grafana_alert' \
+  --limit=5 --format=json
+```
+
+Should show one entry with `alertname=AcceptanceTest`. An email from
+`Cloud Monitoring <no-reply@google.com>` should arrive at `<ALERT_EMAIL>`
+within ~3 minutes total — check spam and Promotions tabs, first delivery
+often lands there.
+
+A recovery email follows automatically when the log-based metric drops
+back to zero.
+
+## Next steps
+
+- Customise alert thresholds in
+  [`deployments/observability/grafana/provisioning/alerting/rules.yaml`](../../deployments/observability/grafana/provisioning/alerting/rules.yaml)
+  and re-apply the observability root.
+- Point Grafana dashboards at your own serving traffic by deploying the
+  hosted serving path from step 6 and generating load.
+- Read [`observability-alerts.md`](./observability-alerts.md) for the
+  per-alert playbooks so future on-call rotations have a reference.


### PR DESCRIPTION
## Summary
- Set `deletion_protection = false` on the alert-router Cloud Run v2 service.
- Prevents a bootstrap trap where a failed first apply (e.g. image not yet in Artifact Registry) taints the resource and blocks destroy-and-recreate on the next apply.

## Context
The Terraform provider defaults `deletion_protection` to `true`. When Cloud Run rejects the initial revision (image 404, image-not-found with `:latest` tag), Terraform marks the resource as tainted; the next apply then tries to replace it and fails with `cannot destroy service without setting deletion_protection=false`. Recovery requires `terraform untaint` plus an in-place image-ref update, which is non-obvious.

The alert-router is a stateless webhook receiver with no persistent state, so removing deletion protection has no safety cost. Matches the current deployed state after today's setup.

## Test plan
- [x] `terraform plan` against staging shows no drift on the service.
- [x] Verified end-to-end: synthetic webhook POST → log-based metric → Cloud Monitoring alert policy → email delivery to configured address.