### PR TITLE
feat: split CI SA, scope WIF to staging environment, add prod skeletons

### DIFF
--- a/.github/workflows/deploy-mlflow-production.yml
+++ b/.github/workflows/deploy-mlflow-production.yml
@@ -1,0 +1,17 @@
+name: CD / Deploy MLflow / Production
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Not yet implemented
+        run: echo "Production infrastructure is not yet provisioned (UP-47)."

--- a/.github/workflows/deploy-platform-jobs-production.yml
+++ b/.github/workflows/deploy-platform-jobs-production.yml
@@ -1,0 +1,17 @@
+name: CD / Deploy Platform Jobs / Production
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Not yet implemented
+        run: echo "Production infrastructure is not yet provisioned (UP-47)."

--- a/.github/workflows/deploy-serving-production.yml
+++ b/.github/workflows/deploy-serving-production.yml
@@ -1,0 +1,17 @@
+name: CD / Deploy Serving / Production
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Not yet implemented
+        run: echo "Production infrastructure is not yet provisioned (UP-47)."

--- a/.github/workflows/gcp-auth-verify.yml
+++ b/.github/workflows/gcp-auth-verify.yml
@@ -34,6 +34,7 @@ jobs:
   verify:
     name: Verify
     runs-on: ubuntu-latest
+    environment: staging
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -53,6 +53,7 @@ jobs:
   build-and-push:
     name: Build And Push
     runs-on: ubuntu-latest
+    environment: staging
     timeout-minutes: 30
     permissions:
       contents: read

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -9,6 +9,7 @@ locals {
   artifact_registry_repository_id = "${local.foundation_name_prefix}-images"
   bucket_location                 = upper(var.region)
   github_repository_full_name     = "${var.github_repository_owner}/${var.github_repository}"
+  tf_state_bucket                 = "fpl-tf-state-jelle"
   workload_identity_pool_id       = "github-actions"
   workload_identity_provider_id   = "github-oidc"
 
@@ -176,6 +177,12 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     google_project_service.required["iamcredentials.googleapis.com"],
     google_project_service.required["sts.googleapis.com"],
   ]
+}
+
+resource "google_storage_bucket_iam_member" "ci_staging_tf_state_admin" {
+  bucket = local.tf_state_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_service_account_iam_member" "ci_staging_workload_identity_user" {

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -71,11 +71,20 @@ resource "google_secret_manager_secret" "foundation" {
   depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
 }
 
-resource "google_service_account" "ci" {
+resource "google_service_account" "ci_staging" {
   project      = data.google_project.current.project_id
-  account_id   = "${local.foundation_name_prefix}-ci"
-  display_name = "ML lifecycle platform CI"
-  description  = "GitHub Actions identity for pushing images and later deploy automation."
+  account_id   = "${local.foundation_name_prefix}-ci-staging"
+  display_name = "ML lifecycle platform CI / staging"
+  description  = "GitHub Actions identity for staging deploys. Bound to environment:staging OIDC subject."
+
+  depends_on = [google_project_service.required["iam.googleapis.com"]]
+}
+
+resource "google_service_account" "ci_prod" {
+  project      = data.google_project.current.project_id
+  account_id   = "${local.foundation_name_prefix}-ci-prod"
+  display_name = "ML lifecycle platform CI / production"
+  description  = "Reserved production CI identity. No WIF binding until UP-47."
 
   depends_on = [google_project_service.required["iam.googleapis.com"]]
 }
@@ -89,18 +98,18 @@ resource "google_service_account" "runtime" {
   depends_on = [google_project_service.required["iam.googleapis.com"]]
 }
 
-resource "google_artifact_registry_repository_iam_member" "ci_writer" {
+resource "google_artifact_registry_repository_iam_member" "ci_staging_writer" {
   project    = google_artifact_registry_repository.images.project
   location   = google_artifact_registry_repository.images.location
   repository = google_artifact_registry_repository.images.name
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${google_service_account.ci.email}"
+  member     = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
-resource "google_project_iam_member" "ci_viewer" {
+resource "google_project_iam_member" "ci_staging_viewer" {
   project = data.google_project.current.project_id
   role    = "roles/viewer"
-  member  = "serviceAccount:${google_service_account.ci.email}"
+  member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_storage_bucket_iam_member" "runtime_bucket_admin" {
@@ -149,6 +158,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     "google.subject"                = "assertion.sub"
     "attribute.actor"               = "assertion.actor"
     "attribute.aud"                 = "assertion.aud"
+    "attribute.environment"         = "assertion.environment"
     "attribute.ref"                 = "assertion.ref"
     "attribute.ref_type"            = "assertion.ref_type"
     "attribute.repository"          = "assertion.repository"
@@ -168,12 +178,11 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   ]
 }
 
-resource "google_service_account_iam_member" "ci_workload_identity_user" {
-  service_account_id = google_service_account.ci.name
+resource "google_service_account_iam_member" "ci_staging_workload_identity_user" {
+  service_account_id = google_service_account.ci_staging.name
   role               = "roles/iam.workloadIdentityUser"
   member = format(
-    "principalSet://iam.googleapis.com/%s/attribute.repository_id/%s",
+    "principalSet://iam.googleapis.com/%s/attribute.environment/staging",
     google_iam_workload_identity_pool.github.name,
-    var.github_repository_id,
   )
 }

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -113,6 +113,20 @@ resource "google_project_iam_member" "ci_staging_viewer" {
   member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
+resource "google_project_iam_member" "ci_staging_scheduler_admin" {
+  project = data.google_project.current.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:${google_service_account.ci_staging.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_staging_foundation_bucket_admin" {
+  for_each = google_storage_bucket.foundation
+
+  bucket = each.value.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.ci_staging.email}"
+}
+
 resource "google_storage_bucket_iam_member" "runtime_bucket_admin" {
   for_each = google_storage_bucket.foundation
 
@@ -181,7 +195,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 
 resource "google_storage_bucket_iam_member" "ci_staging_tf_state_admin" {
   bucket = local.tf_state_bucket
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -169,5 +169,5 @@ resource "google_cloud_run_v2_job_iam_member" "platform_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci.email}"
+  member   = "serviceAccount:${google_service_account.ci_staging.email}"
 }

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -57,14 +57,15 @@ output "foundation_secret_ids" {
 output "foundation_service_accounts" {
   description = "Service account emails for CI and hosted runtime identities."
   value = {
-    ci      = google_service_account.ci.email
-    runtime = google_service_account.runtime.email
+    ci_staging = google_service_account.ci_staging.email
+    ci_prod    = google_service_account.ci_prod.email
+    runtime    = google_service_account.runtime.email
   }
 }
 
 output "ci_service_account_email" {
   description = "CI service account email for GitHub Actions federation."
-  value       = google_service_account.ci.email
+  value       = google_service_account.ci_staging.email
 }
 
 output "runtime_service_account_email" {
@@ -125,7 +126,7 @@ output "mlflow_service" {
     name       = google_cloud_run_v2_service.mlflow["staging"].name
     uri        = google_cloud_run_v2_service.mlflow["staging"].uri
     image      = google_cloud_run_v2_service.mlflow["staging"].template[0].containers[0].image
-    invoker_sa = google_service_account.ci.email
+    invoker_sa = google_service_account.ci_staging.email
   } : null
 }
 
@@ -135,7 +136,7 @@ output "serving_service" {
     name       = google_cloud_run_v2_service.serving["staging"].name
     uri        = google_cloud_run_v2_service.serving["staging"].uri
     image      = google_cloud_run_v2_service.serving["staging"].template[0].containers[0].image
-    invoker_sa = google_service_account.ci.email
+    invoker_sa = google_service_account.ci_staging.email
   } : null
 }
 

--- a/deployments/gcp/terraform/run_mlflow.tf
+++ b/deployments/gcp/terraform/run_mlflow.tf
@@ -6,19 +6,19 @@ locals {
 resource "google_project_iam_member" "ci_run_admin" {
   project = data.google_project.current.project_id
   role    = "roles/run.admin"
-  member  = "serviceAccount:${google_service_account.ci.email}"
+  member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_project_iam_member" "ci_service_usage_admin" {
   project = data.google_project.current.project_id
   role    = "roles/serviceusage.serviceUsageAdmin"
-  member  = "serviceAccount:${google_service_account.ci.email}"
+  member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_service_account_iam_member" "ci_runtime_service_account_user" {
   service_account_id = google_service_account.runtime.name
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${google_service_account.ci.email}"
+  member             = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_cloud_run_v2_service" "mlflow" {
@@ -163,5 +163,5 @@ resource "google_cloud_run_v2_service_iam_member" "mlflow_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci.email}"
+  member   = "serviceAccount:${google_service_account.ci_staging.email}"
 }

--- a/deployments/gcp/terraform/run_serving.tf
+++ b/deployments/gcp/terraform/run_serving.tf
@@ -169,7 +169,7 @@ resource "google_cloud_run_v2_service_iam_member" "serving_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci.email}"
+  member   = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
 resource "google_cloud_run_v2_service_iam_member" "mlflow_runtime_invoker" {

--- a/docs/runbooks/deploy-serving.md
+++ b/docs/runbooks/deploy-serving.md
@@ -162,3 +162,18 @@ After a good deploy you should see:
 - Terraform output `serving_service.uri`
 - Cloud Run service `mlp-serving-staging`
 - authenticated smoke passed for `/health`, `/metadata/model`, `/metadata/schema`, and `/predict`
+
+## Production deploy
+
+Production infrastructure is not yet provisioned (UP-47).
+
+The skeleton workflow `deploy-serving-production.yml` is available and gated behind the `production` GitHub Environment (5-minute wait timer, no required reviewer). Triggering it from `master` will pause for the timer before proceeding.
+
+To trigger the skeleton:
+
+```bash
+gh workflow run deploy-serving-production.yml --ref master
+gh run list --workflow=deploy-serving-production.yml --limit 1
+```
+
+The run will pause at the environment gate. No GCP resources are invoked.

--- a/docs/runbooks/gcp-ci-auth.md
+++ b/docs/runbooks/gcp-ci-auth.md
@@ -17,7 +17,7 @@ What it proves:
 
 ## Required GitHub Actions variables
 
-Set these repository variables from Terraform outputs:
+Set these as `staging` environment variables (not repository variables) from Terraform outputs:
 
 - `GCP_PROJECT_ID`
   - `terraform -chdir=deployments/gcp/terraform output -raw project_id`
@@ -25,6 +25,10 @@ Set these repository variables from Terraform outputs:
   - `terraform -chdir=deployments/gcp/terraform output -raw workload_identity_provider_name`
 - `GCP_CI_SERVICE_ACCOUNT`
   - `terraform -chdir=deployments/gcp/terraform output -raw ci_service_account_email`
+
+These variables are scoped to the `staging` GitHub Environment, not the repository. Any workflow job that needs them must declare `environment: staging`. The WIF subject-claim binding enforces this: `mlp-ci-staging` can only be impersonated when the OIDC token carries `environment=staging`.
+
+`mlp-ci-prod` is reserved as a placeholder service account with no WIF binding until UP-47.
 
 No static service account key is used.
 

--- a/docs/runbooks/github-environments.md
+++ b/docs/runbooks/github-environments.md
@@ -1,0 +1,89 @@
+# GitHub Environments
+
+Last verified: 2026-05-08
+
+This runbook documents the purpose, configuration, and operational procedures for the `staging` and `production` GitHub Environments used in this repository.
+
+## Environments
+
+### staging
+
+- **Protection rule:** none (auto-approve)
+- **Purpose:** gates every hosted-deploy workflow so that GCP Workload Identity Federation can enforce environment-scoped SA impersonation
+- **Who triggers it:** GitHub Actions automatically when a job declares `environment: staging`
+
+### production
+
+- **Protection rule:** 5-minute wait timer (no required reviewer)
+- **Purpose:** skeleton gate for future production deploys (UP-47); no production infrastructure is provisioned yet
+- **Who triggers it:** `workflow_dispatch` only, from `master`
+
+## Variables by scope
+
+| Variable | Scope | Set from |
+|---|---|---|
+| `GCP_PROJECT_ID` | `staging` environment | `terraform output -raw project_id` |
+| `GCP_WIF_PROVIDER` | `staging` environment | `terraform output -raw workload_identity_provider_name` |
+| `GCP_CI_SERVICE_ACCOUNT` | `staging` environment | `terraform output -raw ci_service_account_email` |
+
+These variables were moved from repository scope to `staging` environment scope so the WIF subject-claim binding can enforce that only environment-scoped jobs can resolve them.
+
+## Service accounts and WIF binding
+
+| SA | Account ID | WIF binding |
+|---|---|---|
+| `mlp-ci-staging` | `mlp-ci-staging@<project>.iam.gserviceaccount.com` | `principalSet://.../attribute.environment/staging` |
+| `mlp-ci-prod` | `mlp-ci-prod@<project>.iam.gserviceaccount.com` | none — reserved, UP-47 |
+
+The WIF provider maps `assertion.environment` → `attribute.environment`. A workflow job must declare `environment: staging` for its OIDC token to carry `environment=staging`; without that claim the `mlp-ci-staging` impersonation is denied.
+
+## Adding or rotating variables
+
+To add a variable to the `staging` environment:
+
+```bash
+gh api --method POST \
+  /repos/jellewillekes/ml-lifecycle-platform/environments/staging/variables \
+  -f name=MY_VAR -f value=my_value
+```
+
+To update an existing variable:
+
+```bash
+gh api --method PATCH \
+  /repos/jellewillekes/ml-lifecycle-platform/environments/staging/variables/MY_VAR \
+  -f value=new_value
+```
+
+To list current variables:
+
+```bash
+gh api /repos/jellewillekes/ml-lifecycle-platform/environments/staging/variables \
+  --jq '.variables[].name'
+```
+
+## SA or WIF cutover sequence
+
+If you need to rotate the SA key or rebind the WIF provider:
+
+1. Run `terraform apply` to create the new SA / update the WIF binding.
+2. Immediately update the GitHub environment variable that changed (step above) — do NOT merge any workflow trigger between these two steps or auth will fail.
+3. Run `gh workflow run gcp-auth-verify.yml --ref <branch>` to confirm the new chain.
+4. Merge only after the verify workflow passes.
+
+## Which workflows use `environment: staging`
+
+- `publish-images.yml` — `build-and-push` job
+- `gcp-auth-verify.yml` — `verify` job
+- `deploy-mlflow-staging.yml` — `deploy` job
+- `deploy-platform-jobs-staging.yml` — `deploy` job
+- `deploy-serving-staging.yml` — `deploy` job
+- `run-platform-job-staging.yml` — `run` job
+- `seed-staging-model.yml` — `seed` job
+- `hosted-golden-path-staging.yml` — all deploy jobs
+
+## Which workflows use `environment: production`
+
+- `deploy-serving-production.yml` — `deploy` job (skeleton, UP-47)
+- `deploy-mlflow-production.yml` — `deploy` job (skeleton, UP-47)
+- `deploy-platform-jobs-production.yml` — `deploy` job (skeleton, UP-47)

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Split `mlp-ci` service account into `mlp-ci-staging` (active, WIF-bound) and `mlp-ci-prod` (reserved, UP-47)
- Added `attribute.environment = assertion.environment` to WIF provider attribute mapping
- Scoped WIF IAM binding to `principalSet://.../attribute.environment/staging` so only jobs declaring `environment: staging` can impersonate `mlp-ci-staging`
- Made all previously out-of-band IAM grants explicit in Terraform: `storage.admin` on foundation buckets and TF state bucket, `cloudscheduler.admin` on project
- Moved `GCP_PROJECT_ID`, `GCP_WIF_PROVIDER`, `GCP_CI_SERVICE_ACCOUNT` from repository scope to `staging` environment scope
- Added `environment: staging` to `publish-images.yml` and `gcp-auth-verify.yml` jobs so they resolve environment-scoped variables and satisfy the WIF subject claim
- Added three production skeleton workflows (`deploy-serving-production.yml`, `deploy-mlflow-production.yml`, `deploy-platform-jobs-production.yml`) gated behind the `production` GitHub Environment (5-minute wait timer, no required reviewer)
- Added `docs/runbooks/github-environments.md` covering environment configs, variable rotation, SA/WIF bindings, and cutover sequence
- Updated `docs/runbooks/gcp-ci-auth.md` and `docs/runbooks/deploy-serving.md` to reflect new SA name and environment-scoped variables

## Test plan

- [x] `make check` passes
- [x] `make docs-check` passes
- [x] `Ops / Verify GCP Auth` workflow passes on branch (confirms environment-scoped WIF binding works end-to-end)
- [x] `CD / Deploy MLflow / Staging` passes with digest-pinned image
- [x] `CD / Deploy Platform Jobs / Staging` passes with digest-pinned image
- [x] `CD / Deploy Serving / Staging` passes with smoke checks: `/health`, `/metadata/model`, `/metadata/schema`, `/predict`
- [x] All PR checks pass (Terraform, Lint, Typecheck, Unit Tests, Docker Build, Workflow Lint, CodeQL)

Closes #175