### PR TITLE
feat: production environment infrastructure (VPC, SQL, secrets, Cloud Run, workflows)

### DIFF
--- a/.github/workflows/deploy-mlflow-production.yml
+++ b/.github/workflows/deploy-mlflow-production.yml
@@ -1,17 +1,288 @@
 name: CD / Deploy MLflow / Production
 
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      mlflow_image:
+        description: Digest-pinned Artifact Registry ref for the production MLflow image to deploy.
+        required: true
+        type: string
+    outputs:
+      mlflow_image:
+        description: Deployed production MLflow image pinned by digest.
+        value: ${{ jobs.deploy.outputs.mlflow_image }}
+      service_url:
+        description: Hosted production MLflow service URL after deploy.
+        value: ${{ jobs.deploy.outputs.service_url }}
+  workflow_dispatch:
+    inputs:
+      mlflow_image:
+        description: Digest-pinned Artifact Registry ref for the production MLflow image to deploy.
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+concurrency:
+  group: production-mlflow-deploy
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+  GCP_CI_SERVICE_ACCOUNT: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
+  GCP_REGION: europe-west1
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment: production
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      mlflow_image: ${{ steps.service.outputs.service_image }}
+      service_url: ${{ steps.service.outputs.service_url }}
+
     steps:
-      - name: Not yet implemented
-        run: echo "Production infrastructure is not yet provisioned (UP-47)."
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate required GitHub Actions secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions secret(s): %s\n' "${missing[*]}"
+            echo "Set them in the production GitHub Environment:"
+            echo "  GCP_PROJECT_ID <- terraform output project_id"
+            echo "  GCP_WIF_PROVIDER <- terraform output workload_identity_provider_name"
+            echo "  GCP_CI_SERVICE_ACCOUNT <- mlp-ci-prod@<project>.iam.gserviceaccount.com"
+            exit 1
+          fi
+
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_MLFLOW_IMAGE: ${{ inputs.mlflow_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mlflow_image="${INPUT_MLFLOW_IMAGE}"
+          if [[ -z "${mlflow_image}" ]]; then
+            echo "Provide mlflow_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${mlflow_image}" != *@sha256:* ]]; then
+            echo "mlflow_image must be pinned by digest, for example .../mlflow@sha256:..."
+            exit 1
+          fi
+          if [[ "${mlflow_image%@*}" == *:* ]]; then
+            echo "mlflow_image must be a pure digest ref without a tag, for example .../mlflow@sha256:..."
+            exit 1
+          fi
+
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          version: ">= 363.0.0"
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Verify MLflow image exists in Artifact Registry
+        env:
+          MLFLOW_IMAGE: ${{ steps.context.outputs.mlflow_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="$(
+            gcloud artifacts docker images describe "${MLFLOW_IMAGE}" \
+              --format='value(image_summary.digest)'
+          )"
+          if [[ -z "${digest}" ]]; then
+            echo "Failed to resolve MLflow image digest from Artifact Registry."
+            exit 1
+          fi
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: 1.5.7
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11.7"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Sync (locked)
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv sync --frozen --group dev
+
+      - name: Terraform init
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/retry_terraform_gcp_init.sh
+
+      - id: staging_mlflow
+        name: Resolve current staging MLflow image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json mlflow_service > "${MLFLOW_SERVICE_JSON}"
+          mlflow_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(value["image"] if value else "")
+          ' "${MLFLOW_SERVICE_JSON}")"
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: staging_serving
+        name: Resolve current staging serving image
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-serving-staging" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --allow-missing
+
+      - id: staging_platform
+        name: Resolve current staging platform image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_jobs > "${PLATFORM_JOBS_JSON}"
+          platform_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(next(iter(value.values()))["image"] if value else "")
+          ' "${PLATFORM_JOBS_JSON}")"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: prod_serving
+        name: Resolve current production serving image
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-serving-production" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --allow-missing
+
+      - id: prod_platform
+        name: Resolve current production platform image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs-production.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_production_jobs > "${PLATFORM_JOBS_JSON}"
+          platform_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(next(iter(value.values()))["image"] if value else "")
+          ' "${PLATFORM_JOBS_JSON}")"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Terraform apply hosted MLflow production
+        env:
+          TF_VAR_mlflow_image: ${{ steps.staging_mlflow.outputs.mlflow_image }}
+          TF_VAR_serving_image: ${{ steps.staging_serving.outputs.service_image }}
+          TF_VAR_platform_image: ${{ steps.staging_platform.outputs.platform_image }}
+          TF_VAR_production_mlflow_image: ${{ steps.context.outputs.mlflow_image }}
+          TF_VAR_production_serving_image: ${{ steps.prod_serving.outputs.service_image }}
+          TF_VAR_production_platform_image: ${{ steps.prod_platform.outputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          terraform -chdir=deployments/gcp/terraform apply -auto-approve -input=false
+
+      - id: service
+        name: Resolve hosted MLflow production service contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-mlflow-production" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Mint identity token for Cloud Run
+        id: token
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: false
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ steps.service.outputs.service_url }}
+          id_token_include_email: true
+
+      - name: Verify hosted MLflow production
+        env:
+          MLFLOW_TRACKING_TOKEN: ${{ steps.token.outputs.id_token }}
+          TRACKING_URI: ${{ steps.service.outputs.service_url }}
+          EXPERIMENT_NAME: mlflow-production-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/verify_mlflow_staging.py \
+            --tracking-uri "${TRACKING_URI}" \
+            --experiment-name "${EXPERIMENT_NAME}"
+
+      - name: Write workflow summary
+        env:
+          MLFLOW_IMAGE: ${{ steps.service.outputs.service_image }}
+          SERVICE_URL: ${{ steps.service.outputs.service_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Hosted MLflow production"
+            echo
+            echo "- Image: \`${MLFLOW_IMAGE}\`"
+            echo "- Service URL: \`${SERVICE_URL}\`"
+            echo "- Verification: metadata write + artifact write passed"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-platform-jobs-production.yml
+++ b/.github/workflows/deploy-platform-jobs-production.yml
@@ -1,17 +1,254 @@
 name: CD / Deploy Platform Jobs / Production
 
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the production platform image to deploy.
+        required: true
+        type: string
+    outputs:
+      platform_image:
+        description: Deployed production platform image pinned by digest.
+        value: ${{ jobs.deploy.outputs.platform_image }}
+      job_names:
+        description: Comma-separated deployed production Cloud Run Job names.
+        value: ${{ jobs.deploy.outputs.job_names }}
+  workflow_dispatch:
+    inputs:
+      platform_image:
+        description: Digest-pinned Artifact Registry ref for the production platform image to deploy.
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+concurrency:
+  group: production-platform-jobs-deploy
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+  GCP_CI_SERVICE_ACCOUNT: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
+  GCP_REGION: europe-west1
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment: production
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      platform_image: ${{ steps.context.outputs.platform_image }}
+      job_names: ${{ steps.jobs.outputs.job_names }}
+
     steps:
-      - name: Not yet implemented
-        run: echo "Production infrastructure is not yet provisioned (UP-47)."
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate required GitHub Actions secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions secret(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_PLATFORM_IMAGE: ${{ inputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          platform_image="${INPUT_PLATFORM_IMAGE}"
+          if [[ -z "${platform_image}" ]]; then
+            echo "Provide platform_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${platform_image}" != *@sha256:* ]]; then
+            echo "platform_image must be pinned by digest, for example .../platform@sha256:..."
+            exit 1
+          fi
+          if [[ "${platform_image%@*}" == *:* ]]; then
+            echo "platform_image must be a pure digest ref without a tag, for example .../platform@sha256:..."
+            exit 1
+          fi
+
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          version: ">= 363.0.0"
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Verify platform image exists in Artifact Registry
+        env:
+          PLATFORM_IMAGE: ${{ steps.context.outputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="$(
+            gcloud artifacts docker images describe "${PLATFORM_IMAGE}" \
+              --format='value(image_summary.digest)'
+          )"
+          if [[ -z "${digest}" ]]; then
+            echo "Failed to resolve platform image digest from Artifact Registry."
+            exit 1
+          fi
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: 1.5.7
+
+      - name: Terraform init
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/retry_terraform_gcp_init.sh
+
+      - id: staging_mlflow
+        name: Resolve current staging MLflow image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json mlflow_service > "${MLFLOW_SERVICE_JSON}"
+          mlflow_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(value["image"] if value else "")
+          ' "${MLFLOW_SERVICE_JSON}")"
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: staging_serving
+        name: Resolve current staging serving image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export SERVING_SERVICE_JSON="${RUNNER_TEMP}/serving-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json serving_service > "${SERVING_SERVICE_JSON}"
+          serving_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(value["image"] if value else "")
+          ' "${SERVING_SERVICE_JSON}")"
+          echo "serving_image=${serving_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: staging_platform
+        name: Resolve current staging platform image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_jobs > "${PLATFORM_JOBS_JSON}"
+          platform_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(next(iter(value.values()))["image"] if value else "")
+          ' "${PLATFORM_JOBS_JSON}")"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: prod_mlflow
+        name: Resolve current production MLflow image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-production-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json mlflow_production_service > "${MLFLOW_SERVICE_JSON}"
+          mlflow_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          if not value:
+              raise SystemExit("mlflow_production_service output is null; deploy production MLflow before production platform jobs.")
+          print(value["image"])
+          ' "${MLFLOW_SERVICE_JSON}")"
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: prod_serving
+        name: Resolve current production serving image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export SERVING_SERVICE_JSON="${RUNNER_TEMP}/serving-production-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json serving_production_service > "${SERVING_SERVICE_JSON}"
+          serving_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          if not value:
+              raise SystemExit("serving_production_service output is null; deploy production serving before production platform jobs.")
+          print(value["image"])
+          ' "${SERVING_SERVICE_JSON}")"
+          echo "serving_image=${serving_image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Terraform apply hosted platform jobs production
+        env:
+          TF_VAR_mlflow_image: ${{ steps.staging_mlflow.outputs.mlflow_image }}
+          TF_VAR_serving_image: ${{ steps.staging_serving.outputs.serving_image }}
+          TF_VAR_platform_image: ${{ steps.staging_platform.outputs.platform_image }}
+          TF_VAR_production_mlflow_image: ${{ steps.prod_mlflow.outputs.mlflow_image }}
+          TF_VAR_production_serving_image: ${{ steps.prod_serving.outputs.serving_image }}
+          TF_VAR_production_platform_image: ${{ steps.context.outputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          terraform -chdir=deployments/gcp/terraform apply -auto-approve -input=false
+
+      - id: jobs
+        name: Resolve deployed production platform jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs-production.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_production_jobs > "${PLATFORM_JOBS_JSON}"
+          python3 - "${PLATFORM_JOBS_JSON}" "${GITHUB_OUTPUT}" <<'PY'
+          import json
+          import sys
+
+          jobs = json.load(open(sys.argv[1], encoding="utf-8"))
+          if not jobs:
+            raise SystemExit("platform_production_jobs output is null after apply.")
+          names = ",".join(sorted(job["name"] for job in jobs.values()))
+          with open(sys.argv[2], "a", encoding="utf-8") as handle:
+            handle.write(f"job_names={names}\n")
+          PY
+
+      - name: Write workflow summary
+        env:
+          PLATFORM_IMAGE: ${{ steps.context.outputs.platform_image }}
+          JOB_NAMES: ${{ steps.jobs.outputs.job_names }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Hosted platform jobs production"
+            echo
+            echo "- Platform image: \`${PLATFORM_IMAGE}\`"
+            echo "- Jobs: \`${JOB_NAMES}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-serving-production.yml
+++ b/.github/workflows/deploy-serving-production.yml
@@ -1,17 +1,360 @@
 name: CD / Deploy Serving / Production
 
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      serving_image:
+        description: Digest-pinned Artifact Registry ref for the production serving image to deploy.
+        required: true
+        type: string
+    outputs:
+      serving_image:
+        description: Deployed production serving image pinned by digest.
+        value: ${{ jobs.deploy.outputs.serving_image }}
+      service_url:
+        description: Hosted production serving service URL after deploy.
+        value: ${{ jobs.deploy.outputs.service_url }}
+  workflow_dispatch:
+    inputs:
+      serving_image:
+        description: Digest-pinned Artifact Registry ref for the production serving image to deploy.
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+concurrency:
+  group: production-serving-deploy
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+  GCP_CI_SERVICE_ACCOUNT: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
+  GCP_REGION: europe-west1
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment: production
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      serving_image: ${{ steps.service.outputs.service_image }}
+      service_url: ${{ steps.service.outputs.service_url }}
+
     steps:
-      - name: Not yet implemented
-        run: echo "Production infrastructure is not yet provisioned (UP-47)."
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate required GitHub Actions secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for var_name in GCP_PROJECT_ID GCP_WIF_PROVIDER GCP_CI_SERVICE_ACCOUNT; do
+            if [[ -z "${!var_name:-}" ]]; then
+              missing+=("${var_name}")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions secret(s): %s\n' "${missing[*]}"
+            echo "Set them in the production GitHub Environment:"
+            echo "  GCP_PROJECT_ID <- terraform output project_id"
+            echo "  GCP_WIF_PROVIDER <- terraform output workload_identity_provider_name"
+            echo "  GCP_CI_SERVICE_ACCOUNT <- mlp-ci-prod@<project>.iam.gserviceaccount.com"
+            exit 1
+          fi
+
+      - id: context
+        name: Validate deploy image input
+        env:
+          INPUT_SERVING_IMAGE: ${{ inputs.serving_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          serving_image="${INPUT_SERVING_IMAGE}"
+          if [[ -z "${serving_image}" ]]; then
+            echo "Provide serving_image as a digest-pinned Artifact Registry ref."
+            exit 1
+          fi
+          if [[ "${serving_image}" != *@sha256:* ]]; then
+            echo "serving_image must be pinned by digest, for example .../serving@sha256:..."
+            exit 1
+          fi
+          if [[ "${serving_image%@*}" == *:* ]]; then
+            echo "serving_image must be a pure digest ref without a tag, for example .../serving@sha256:..."
+            exit 1
+          fi
+
+          echo "serving_image=${serving_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        with:
+          version: ">= 363.0.0"
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Verify serving image exists in Artifact Registry
+        env:
+          SERVING_IMAGE: ${{ steps.context.outputs.serving_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="$(
+            gcloud artifacts docker images describe "${SERVING_IMAGE}" \
+              --format='value(image_summary.digest)'
+          )"
+          if [[ -z "${digest}" ]]; then
+            echo "Failed to resolve serving image digest from Artifact Registry."
+            exit 1
+          fi
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: 1.5.7
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11.7"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
+
+      - name: Sync (locked)
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv sync --frozen --group dev
+
+      - name: Terraform init
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/retry_terraform_gcp_init.sh
+
+      - name: Clear stale production serving taint
+        shell: bash
+        run: |
+          set -euo pipefail
+          err_file="${RUNNER_TEMP}/terraform-untaint-serving.err"
+          if terraform -chdir=deployments/gcp/terraform untaint 'google_cloud_run_v2_service.serving["production"]' 2>"${err_file}"; then
+            echo "Cleared stale taint from production serving service."
+          elif grep -q "Resource instance is not tainted" "${err_file}"; then
+            echo "Production serving service is not tainted. Continuing."
+          else
+            cat "${err_file}" >&2
+            exit 1
+          fi
+
+      - id: staging_mlflow
+        name: Resolve current staging MLflow image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json mlflow_service > "${MLFLOW_SERVICE_JSON}"
+          mlflow_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(value["image"] if value else "")
+          ' "${MLFLOW_SERVICE_JSON}")"
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: staging_serving
+        name: Resolve current staging serving image
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-serving-staging" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --allow-missing
+
+      - id: staging_platform
+        name: Resolve current staging platform image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_jobs > "${PLATFORM_JOBS_JSON}"
+          platform_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(next(iter(value.values()))["image"] if value else "")
+          ' "${PLATFORM_JOBS_JSON}")"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - id: prod_mlflow
+        name: Resolve current production MLflow service
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MLFLOW_SERVICE_JSON="${RUNNER_TEMP}/mlflow-production-service.json"
+          terraform -chdir=deployments/gcp/terraform output -json mlflow_production_service > "${MLFLOW_SERVICE_JSON}"
+          mlflow_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          if not value:
+              raise SystemExit("mlflow_production_service output is null; deploy production MLflow before production serving.")
+          print(value["image"])
+          ' "${MLFLOW_SERVICE_JSON}")"
+          mlflow_url="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(value["uri"] if value else "")
+          ' "${MLFLOW_SERVICE_JSON}")"
+          echo "mlflow_image=${mlflow_image}" >> "${GITHUB_OUTPUT}"
+          echo "mlflow_url=${mlflow_url}" >> "${GITHUB_OUTPUT}"
+
+      - id: prod_platform
+        name: Resolve current production platform image
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PLATFORM_JOBS_JSON="${RUNNER_TEMP}/platform-jobs-production.json"
+          terraform -chdir=deployments/gcp/terraform output -json platform_production_jobs > "${PLATFORM_JOBS_JSON}"
+          platform_image="$(python3 -c '
+          import json, sys
+          value = json.load(open(sys.argv[1], encoding="utf-8"))
+          print(next(iter(value.values()))["image"] if value else "")
+          ' "${PLATFORM_JOBS_JSON}")"
+          echo "platform_image=${platform_image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Mint identity token for production MLflow
+        id: mlflow_token
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: false
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ steps.prod_mlflow.outputs.mlflow_url }}
+          id_token_include_email: true
+
+      - name: Verify production MLflow prod alias exists
+        env:
+          MLFLOW_TRACKING_TOKEN: ${{ steps.mlflow_token.outputs.id_token }}
+          MLFLOW_TRACKING_URI: ${{ steps.prod_mlflow.outputs.mlflow_url }}
+          MLFLOW_REGISTRY_URI: ${{ steps.prod_mlflow.outputs.mlflow_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/verify_hosted_model_alias.py \
+            --tracking-uri "${MLFLOW_TRACKING_URI}" \
+            --model-name "breast_cancer_clf" \
+            --alias "prod"
+
+      - id: apply
+        name: Terraform apply hosted serving production
+        continue-on-error: true
+        env:
+          TF_VAR_mlflow_image: ${{ steps.staging_mlflow.outputs.mlflow_image }}
+          TF_VAR_serving_image: ${{ steps.staging_serving.outputs.service_image }}
+          TF_VAR_platform_image: ${{ steps.staging_platform.outputs.platform_image }}
+          TF_VAR_production_mlflow_image: ${{ steps.prod_mlflow.outputs.mlflow_image }}
+          TF_VAR_production_serving_image: ${{ steps.context.outputs.serving_image }}
+          TF_VAR_production_platform_image: ${{ steps.prod_platform.outputs.platform_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          terraform -chdir=deployments/gcp/terraform apply -auto-approve -input=false
+
+      - name: Dump Cloud Run service diagnostics
+        if: steps.apply.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          service_name="mlp-serving-production"
+
+          if ! gcloud run services describe "${service_name}" \
+            --region "${GCP_REGION}" \
+            --project "${GCP_PROJECT_ID}" \
+            --format='yaml(metadata.name,status.latestCreatedRevisionName,status.latestReadyRevisionName,status.url,status.conditions,spec.template.containers[0].image)'; then
+            echo "Cloud Run service ${service_name} is not readable yet."
+          fi
+
+      - name: Fail when Terraform apply fails
+        if: steps.apply.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Production serving deploy failed during terraform apply. See the Cloud Run diagnostics above."
+          exit 1
+
+      - id: service
+        name: Resolve hosted serving production service contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/resolve_cloud_run_service_contract.py \
+            --project-id "${GCP_PROJECT_ID}" \
+            --region "${GCP_REGION}" \
+            --service-name "mlp-serving-production" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Mint identity token for production serving
+        id: token
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: false
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_CI_SERVICE_ACCOUNT }}
+          token_format: id_token
+          id_token_audience: ${{ steps.service.outputs.service_url }}
+          id_token_include_email: true
+
+      - name: Verify hosted serving production
+        env:
+          SERVE_URL: ${{ steps.service.outputs.service_url }}
+          SERVE_BEARER_TOKEN: ${{ steps.token.outputs.id_token }}
+          MODEL_NAME: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python -m ml_lifecycle_platform.serving.smoke_test
+
+      - name: Write workflow summary
+        env:
+          SERVING_IMAGE: ${{ steps.service.outputs.service_image }}
+          SERVICE_URL: ${{ steps.service.outputs.service_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Hosted serving production"
+            echo
+            echo "- Image: \`${SERVING_IMAGE}\`"
+            echo "- Service URL: \`${SERVICE_URL}\`"
+            echo "- Verification: authenticated smoke passed"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -207,3 +207,46 @@ resource "google_service_account_iam_member" "ci_staging_workload_identity_user"
     google_iam_workload_identity_pool.github.name,
   )
 }
+
+resource "google_artifact_registry_repository_iam_member" "ci_prod_writer" {
+  project    = google_artifact_registry_repository.images.project
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.ci_prod.email}"
+}
+
+resource "google_project_iam_member" "ci_prod_viewer" {
+  project = data.google_project.current.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.ci_prod.email}"
+}
+
+resource "google_project_iam_member" "ci_prod_scheduler_admin" {
+  project = data.google_project.current.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:${google_service_account.ci_prod.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_prod_foundation_bucket_admin" {
+  for_each = google_storage_bucket.foundation
+
+  bucket = each.value.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.ci_prod.email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_prod_tf_state_admin" {
+  bucket = local.tf_state_bucket
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.ci_prod.email}"
+}
+
+resource "google_service_account_iam_member" "ci_prod_workload_identity_user" {
+  service_account_id = google_service_account.ci_prod.name
+  role               = "roles/iam.workloadIdentityUser"
+  member = format(
+    "principalSet://iam.googleapis.com/%s/attribute.environment/production",
+    google_iam_workload_identity_pool.github.name,
+  )
+}

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -171,3 +171,178 @@ resource "google_cloud_run_v2_job_iam_member" "platform_ci_invoker" {
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.ci_staging.email}"
 }
+
+locals {
+  platform_production_jobs_enabled = length(trimspace(var.production_platform_image)) > 0
+
+  platform_jobs_production = {
+    pipeline = {
+      name                 = "${local.foundation_name_prefix}-pipeline-production"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.pipeline.orchestrate"]
+      timeout              = "1800s"
+      mutates_model_state  = true
+      safe_validation_args = []
+    }
+    promote = {
+      name                 = "${local.foundation_name_prefix}-promote-production"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.registry.promote", "--model-name", "breast_cancer_clf", "--format", "json"]
+      timeout              = "900s"
+      mutates_model_state  = true
+      safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+    }
+    rollback = {
+      name                 = "${local.foundation_name_prefix}-rollback-production"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.registry.rollback", "--model-name", "breast_cancer_clf"]
+      timeout              = "900s"
+      mutates_model_state  = true
+      safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+    }
+    reproduce = {
+      name                 = "${local.foundation_name_prefix}-reproduce-production"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.registry.reproduce", "--model-name", "breast_cancer_clf", "--alias", "prod", "--format", "json"]
+      timeout              = "1800s"
+      mutates_model_state  = false
+      safe_validation_args = []
+    }
+    maintenance = {
+      name                 = "${local.foundation_name_prefix}-maintenance-production"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.jobs.maintenance", "--format", "json"]
+      timeout              = "600s"
+      mutates_model_state  = false
+      safe_validation_args = []
+    }
+  }
+}
+
+resource "google_cloud_run_v2_job" "platform_production" {
+  for_each = local.platform_production_jobs_enabled ? local.platform_jobs_production : {}
+
+  project  = data.google_project.current.project_id
+  name     = each.value.name
+  location = var.region
+
+  labels = merge(
+    local.common_labels,
+    {
+      purpose = "platform_job"
+      job     = each.key
+    },
+  )
+
+  template {
+    parallelism = 1
+    task_count  = 1
+
+    template {
+      service_account = google_service_account.runtime.email
+      timeout         = each.value.timeout
+      max_retries     = 0
+
+      vpc_access {
+        egress = "PRIVATE_RANGES_ONLY"
+
+        network_interfaces {
+          network    = google_compute_network.production.id
+          subnetwork = google_compute_subnetwork.production.id
+        }
+      }
+
+      containers {
+        image   = var.production_platform_image
+        command = each.value.command
+        args    = each.value.args
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1Gi"
+          }
+        }
+
+        env {
+          name  = "MLP_ENV"
+          value = "production"
+        }
+
+        env {
+          name  = "MLFLOW_TRACKING_URI"
+          value = google_cloud_run_v2_service.mlflow["production"].uri
+        }
+
+        env {
+          name  = "MLFLOW_REGISTRY_URI"
+          value = google_cloud_run_v2_service.mlflow["production"].uri
+        }
+
+        env {
+          name  = "MLFLOW_CLOUD_RUN_AUDIENCE"
+          value = google_cloud_run_v2_service.mlflow["production"].uri
+        }
+
+        env {
+          name  = "MODEL_NAME"
+          value = "breast_cancer_clf"
+        }
+
+        env {
+          name  = "MLP_MODEL_SPEC_PATH"
+          value = "configs/models/breast_cancer_demo.yaml"
+        }
+
+        env {
+          name  = "LOG_LEVEL"
+          value = "INFO"
+        }
+
+        env {
+          name  = "GOOGLE_CLOUD_PROJECT"
+          value = data.google_project.current.project_id
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+            value = "http://${var.otlp_collector_endpoint}"
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+            value = "grpc"
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.otlp_enabled ? [1] : []
+          content {
+            name  = "OTEL_EXPORTER_OTLP_INSECURE"
+            value = "true"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.required["run.googleapis.com"],
+    google_cloud_run_v2_service.mlflow,
+  ]
+}
+
+resource "google_cloud_run_v2_job_iam_member" "platform_production_ci_invoker" {
+  for_each = google_cloud_run_v2_job.platform_production
+
+  project  = each.value.project
+  location = each.value.location
+  name     = each.value.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.ci_prod.email}"
+}

--- a/deployments/gcp/terraform/moved.tf
+++ b/deployments/gcp/terraform/moved.tf
@@ -1,0 +1,14 @@
+moved {
+  from = google_project_iam_member.ci_run_admin
+  to   = google_project_iam_member.ci_run_admin["staging"]
+}
+
+moved {
+  from = google_project_iam_member.ci_service_usage_admin
+  to   = google_project_iam_member.ci_service_usage_admin["staging"]
+}
+
+moved {
+  from = google_service_account_iam_member.ci_runtime_service_account_user
+  to   = google_service_account_iam_member.ci_runtime_service_account_user["staging"]
+}

--- a/deployments/gcp/terraform/network.tf
+++ b/deployments/gcp/terraform/network.tf
@@ -4,6 +4,12 @@ locals {
   staging_subnetwork_cidr                  = "10.42.0.0/24"
   staging_private_service_range_name       = "${local.foundation_name_prefix}-staging-private-services"
   staging_private_service_range_prefix_len = 16
+
+  production_network_name                     = "${local.foundation_name_prefix}-production-vpc"
+  production_subnetwork_name                  = "${local.foundation_name_prefix}-production-subnet"
+  production_subnetwork_cidr                  = "10.43.0.0/24"
+  production_private_service_range_name       = "${local.foundation_name_prefix}-production-private-services"
+  production_private_service_range_prefix_len = 16
 }
 
 resource "google_compute_network" "staging" {
@@ -45,5 +51,47 @@ resource "google_service_networking_connection" "staging_private_services" {
   depends_on = [
     google_project_service.required["servicenetworking.googleapis.com"],
     google_compute_global_address.staging_private_services,
+  ]
+}
+
+resource "google_compute_network" "production" {
+  project                 = data.google_project.current.project_id
+  name                    = local.production_network_name
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_compute_subnetwork" "production" {
+  project                  = data.google_project.current.project_id
+  name                     = local.production_subnetwork_name
+  region                   = var.region
+  network                  = google_compute_network.production.id
+  ip_cidr_range            = local.production_subnetwork_cidr
+  private_ip_google_access = true
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_compute_global_address" "production_private_services" {
+  project       = data.google_project.current.project_id
+  name          = local.production_private_service_range_name
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = local.production_private_service_range_prefix_len
+  network       = google_compute_network.production.id
+
+  depends_on = [google_project_service.required["compute.googleapis.com"]]
+}
+
+resource "google_service_networking_connection" "production_private_services" {
+  network                 = google_compute_network.production.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.production_private_services.name]
+
+  depends_on = [
+    google_project_service.required["servicenetworking.googleapis.com"],
+    google_compute_global_address.production_private_services,
   ]
 }

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -169,3 +169,66 @@ output "platform_schedules" {
     }
   } : null
 }
+
+output "production_network" {
+  description = "Production VPC and subnet used by production hosted workloads."
+  value = {
+    network_name    = google_compute_network.production.name
+    network_id      = google_compute_network.production.id
+    subnetwork_name = google_compute_subnetwork.production.name
+    subnetwork_id   = google_compute_subnetwork.production.id
+    subnetwork_cidr = google_compute_subnetwork.production.ip_cidr_range
+    peering_range   = google_compute_global_address.production_private_services.name
+    peering_cidr    = google_compute_global_address.production_private_services.address
+  }
+}
+
+output "mlflow_production_service" {
+  description = "Hosted production MLflow service contract. Null until the first production MLflow deploy."
+  value = local.mlflow_production_deploy_enabled ? {
+    name       = google_cloud_run_v2_service.mlflow["production"].name
+    uri        = google_cloud_run_v2_service.mlflow["production"].uri
+    image      = google_cloud_run_v2_service.mlflow["production"].template[0].containers[0].image
+    invoker_sa = google_service_account.ci_prod.email
+  } : null
+}
+
+output "serving_production_service" {
+  description = "Hosted production serving service contract. Null until the first production serving deploy."
+  value = local.serving_production_deploy_enabled ? {
+    name       = google_cloud_run_v2_service.serving["production"].name
+    uri        = google_cloud_run_v2_service.serving["production"].uri
+    image      = google_cloud_run_v2_service.serving["production"].template[0].containers[0].image
+    invoker_sa = google_service_account.ci_prod.email
+  } : null
+}
+
+output "platform_production_jobs" {
+  description = "Hosted production Cloud Run job contracts. Null until the first production platform image deploy."
+  value = local.platform_production_jobs_enabled ? {
+    for key, job in google_cloud_run_v2_job.platform_production :
+    key => {
+      name                 = job.name
+      image                = job.template[0].template[0].containers[0].image
+      command              = local.platform_jobs_production[key].command
+      args                 = local.platform_jobs_production[key].args
+      mutates_model_state  = local.platform_jobs_production[key].mutates_model_state
+      safe_validation_args = local.platform_jobs_production[key].safe_validation_args
+    }
+  } : null
+}
+
+output "platform_production_schedules" {
+  description = "Hosted production Cloud Scheduler contracts. Null until the first production platform image deploy."
+  value = local.platform_production_jobs_enabled ? {
+    for key, job in google_cloud_scheduler_job.platform_production :
+    key => {
+      name       = job.name
+      region     = job.region
+      schedule   = job.schedule
+      time_zone  = job.time_zone
+      paused     = job.paused
+      target_job = google_cloud_run_v2_job.platform_production[key].name
+    }
+  } : null
+}

--- a/deployments/gcp/terraform/run_mlflow.tf
+++ b/deployments/gcp/terraform/run_mlflow.tf
@@ -1,36 +1,68 @@
 locals {
-  mlflow_service_name   = "${local.foundation_name_prefix}-mlflow-staging"
-  mlflow_deploy_enabled = length(trimspace(var.mlflow_image)) > 0
+  mlflow_deploy_enabled            = length(trimspace(var.mlflow_image)) > 0
+  mlflow_production_deploy_enabled = length(trimspace(var.production_mlflow_image)) > 0
+
+  mlflow_deploy_map = merge(
+    local.mlflow_deploy_enabled ? { staging = var.mlflow_image } : {},
+    local.mlflow_production_deploy_enabled ? { production = var.production_mlflow_image } : {},
+  )
+
+  mlflow_networks = {
+    staging    = google_compute_network.staging
+    production = google_compute_network.production
+  }
+  mlflow_subnetworks = {
+    staging    = google_compute_subnetwork.staging
+    production = google_compute_subnetwork.production
+  }
+  mlflow_sql_instances = {
+    staging    = google_sql_database_instance.mlflow
+    production = google_sql_database_instance.mlflow_production
+  }
+  mlflow_secret_refs = {
+    staging    = google_secret_manager_secret.mlflow
+    production = google_secret_manager_secret.mlflow_production
+  }
+  mlflow_ci_sas = {
+    staging    = google_service_account.ci_staging
+    production = google_service_account.ci_prod
+  }
 }
 
 resource "google_project_iam_member" "ci_run_admin" {
+  for_each = local.mlflow_ci_sas
+
   project = data.google_project.current.project_id
   role    = "roles/run.admin"
-  member  = "serviceAccount:${google_service_account.ci_staging.email}"
+  member  = "serviceAccount:${each.value.email}"
 }
 
 resource "google_project_iam_member" "ci_service_usage_admin" {
+  for_each = local.mlflow_ci_sas
+
   project = data.google_project.current.project_id
   role    = "roles/serviceusage.serviceUsageAdmin"
-  member  = "serviceAccount:${google_service_account.ci_staging.email}"
+  member  = "serviceAccount:${each.value.email}"
 }
 
 resource "google_service_account_iam_member" "ci_runtime_service_account_user" {
+  for_each = local.mlflow_ci_sas
+
   service_account_id = google_service_account.runtime.name
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${google_service_account.ci_staging.email}"
+  member             = "serviceAccount:${each.value.email}"
 }
 
 resource "google_cloud_run_v2_service" "mlflow" {
-  for_each = local.mlflow_deploy_enabled ? { staging = var.mlflow_image } : {}
+  for_each = local.mlflow_deploy_map
 
   project             = data.google_project.current.project_id
-  name                = local.mlflow_service_name
+  name                = "${local.foundation_name_prefix}-mlflow-${each.key}"
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
   deletion_protection = true
 
-  labels = merge(local.common_labels, { purpose = "mlflow_staging" })
+  labels = merge(local.common_labels, { purpose = "mlflow_${each.key}" })
 
   template {
     service_account                  = google_service_account.runtime.email
@@ -46,8 +78,8 @@ resource "google_cloud_run_v2_service" "mlflow" {
       egress = "PRIVATE_RANGES_ONLY"
 
       network_interfaces {
-        network    = google_compute_network.staging.id
-        subnetwork = google_compute_subnetwork.staging.id
+        network    = local.mlflow_networks[each.key].id
+        subnetwork = local.mlflow_subnetworks[each.key].id
       }
     }
 
@@ -77,7 +109,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
 
       env {
         name  = "DB_HOST"
-        value = google_sql_database_instance.mlflow.private_ip_address
+        value = local.mlflow_sql_instances[each.key].private_ip_address
       }
 
       env {
@@ -89,7 +121,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
         name = "DB_NAME"
         value_source {
           secret_key_ref {
-            secret  = google_secret_manager_secret.mlflow["db_name"].secret_id
+            secret  = local.mlflow_secret_refs[each.key]["db_name"].secret_id
             version = "latest"
           }
         }
@@ -99,7 +131,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
         name = "DB_USER"
         value_source {
           secret_key_ref {
-            secret  = google_secret_manager_secret.mlflow["db_user"].secret_id
+            secret  = local.mlflow_secret_refs[each.key]["db_user"].secret_id
             version = "latest"
           }
         }
@@ -109,7 +141,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
         name = "DB_PASSWORD"
         value_source {
           secret_key_ref {
-            secret  = google_secret_manager_secret.mlflow["db_password"].secret_id
+            secret  = local.mlflow_secret_refs[each.key]["db_password"].secret_id
             version = "latest"
           }
         }
@@ -119,7 +151,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
         name = "ARTIFACTS_DESTINATION"
         value_source {
           secret_key_ref {
-            secret  = google_secret_manager_secret.mlflow["artifact_root"].secret_id
+            secret  = local.mlflow_secret_refs[each.key]["artifact_root"].secret_id
             version = "latest"
           }
         }
@@ -152,6 +184,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
   depends_on = [
     google_project_service.required["run.googleapis.com"],
     google_secret_manager_secret_iam_member.runtime_mlflow_secret_accessor,
+    google_secret_manager_secret_iam_member.runtime_mlflow_production_secret_accessor,
     google_project_iam_member.runtime_cloudsql_client,
   ]
 }
@@ -163,5 +196,5 @@ resource "google_cloud_run_v2_service_iam_member" "mlflow_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci_staging.email}"
+  member   = "serviceAccount:${local.mlflow_ci_sas[each.key].email}"
 }

--- a/deployments/gcp/terraform/run_serving.tf
+++ b/deployments/gcp/terraform/run_serving.tf
@@ -1,19 +1,24 @@
 locals {
-  serving_service_name   = "${local.foundation_name_prefix}-serving-staging"
-  serving_deploy_enabled = length(trimspace(var.serving_image)) > 0
-  otlp_enabled           = length(trimspace(var.otlp_collector_endpoint)) > 0
+  serving_deploy_enabled            = length(trimspace(var.serving_image)) > 0
+  serving_production_deploy_enabled = length(trimspace(var.production_serving_image)) > 0
+  otlp_enabled                      = length(trimspace(var.otlp_collector_endpoint)) > 0
+
+  serving_deploy_map = merge(
+    local.serving_deploy_enabled ? { staging = var.serving_image } : {},
+    local.serving_production_deploy_enabled ? { production = var.production_serving_image } : {},
+  )
 }
 
 resource "google_cloud_run_v2_service" "serving" {
-  for_each = local.serving_deploy_enabled ? { staging = var.serving_image } : {}
+  for_each = local.serving_deploy_map
 
   project             = data.google_project.current.project_id
-  name                = local.serving_service_name
+  name                = "${local.foundation_name_prefix}-serving-${each.key}"
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
   deletion_protection = true
 
-  labels = merge(local.common_labels, { purpose = "serving_staging" })
+  labels = merge(local.common_labels, { purpose = "serving_${each.key}" })
 
   template {
     service_account                  = google_service_account.runtime.email
@@ -29,8 +34,8 @@ resource "google_cloud_run_v2_service" "serving" {
       egress = "PRIVATE_RANGES_ONLY"
 
       network_interfaces {
-        network    = google_compute_network.staging.id
-        subnetwork = google_compute_subnetwork.staging.id
+        network    = local.mlflow_networks[each.key].id
+        subnetwork = local.mlflow_subnetworks[each.key].id
       }
     }
 
@@ -50,22 +55,22 @@ resource "google_cloud_run_v2_service" "serving" {
 
       env {
         name  = "MLP_ENV"
-        value = "staging"
+        value = each.key
       }
 
       env {
         name  = "MLFLOW_TRACKING_URI"
-        value = google_cloud_run_v2_service.mlflow["staging"].uri
+        value = google_cloud_run_v2_service.mlflow[each.key].uri
       }
 
       env {
         name  = "MLFLOW_REGISTRY_URI"
-        value = google_cloud_run_v2_service.mlflow["staging"].uri
+        value = google_cloud_run_v2_service.mlflow[each.key].uri
       }
 
       env {
         name  = "MLFLOW_CLOUD_RUN_AUDIENCE"
-        value = google_cloud_run_v2_service.mlflow["staging"].uri
+        value = google_cloud_run_v2_service.mlflow[each.key].uri
       }
 
       env {
@@ -169,7 +174,7 @@ resource "google_cloud_run_v2_service_iam_member" "serving_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci_staging.email}"
+  member   = "serviceAccount:${local.mlflow_ci_sas[each.key].email}"
 }
 
 resource "google_cloud_run_v2_service_iam_member" "mlflow_runtime_invoker" {

--- a/deployments/gcp/terraform/scheduler_platform.tf
+++ b/deployments/gcp/terraform/scheduler_platform.tf
@@ -71,3 +71,77 @@ resource "google_cloud_run_v2_job_iam_member" "platform_scheduler_invoker" {
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.runtime.email}"
 }
+
+locals {
+  platform_schedules_production = {
+    maintenance = {
+      name             = "${local.foundation_name_prefix}-maintenance-production-schedule"
+      description      = "Conservative daily hosted maintenance cadence for production."
+      schedule         = "17 3 * * *"
+      paused           = false
+      attempt_deadline = "180s"
+      retry_count      = 0
+    }
+    pipeline = {
+      name             = "${local.foundation_name_prefix}-pipeline-production-schedule"
+      description      = "Optional weekly hosted candidate-generation cadence for production. Paused by default."
+      schedule         = "17 4 * * 1"
+      paused           = true
+      attempt_deadline = "180s"
+      retry_count      = 0
+    }
+  }
+}
+
+resource "google_cloud_scheduler_job" "platform_production" {
+  for_each = local.platform_production_jobs_enabled ? local.platform_schedules_production : {}
+
+  project          = data.google_project.current.project_id
+  region           = var.region
+  name             = each.value.name
+  description      = each.value.description
+  schedule         = each.value.schedule
+  time_zone        = "UTC"
+  paused           = each.value.paused
+  attempt_deadline = each.value.attempt_deadline
+
+  retry_config {
+    retry_count = each.value.retry_count
+  }
+
+  http_target {
+    http_method = "POST"
+    uri = format(
+      "https://%s-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/%s/jobs/%s:run",
+      google_cloud_run_v2_job.platform_production[each.key].location,
+      data.google_project.current.number,
+      google_cloud_run_v2_job.platform_production[each.key].name,
+    )
+
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    body = base64encode(jsonencode({}))
+
+    oauth_token {
+      service_account_email = google_service_account.runtime.email
+      scope                 = "https://www.googleapis.com/auth/cloud-platform"
+    }
+  }
+
+  depends_on = [
+    google_project_service.required["cloudscheduler.googleapis.com"],
+    google_cloud_run_v2_job.platform_production,
+  ]
+}
+
+resource "google_cloud_run_v2_job_iam_member" "platform_production_scheduler_invoker" {
+  for_each = google_cloud_scheduler_job.platform_production
+
+  project  = google_cloud_run_v2_job.platform_production[each.key].project
+  location = google_cloud_run_v2_job.platform_production[each.key].location
+  name     = google_cloud_run_v2_job.platform_production[each.key].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/deployments/gcp/terraform/secrets_mlflow.tf
+++ b/deployments/gcp/terraform/secrets_mlflow.tf
@@ -46,3 +46,52 @@ resource "google_secret_manager_secret_iam_member" "runtime_mlflow_secret_access
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.runtime.email}"
 }
+
+locals {
+  mlflow_secret_ids_production = {
+    db_user                  = "${local.foundation_name_prefix}-mlflow-db-user-production"
+    db_password              = "${local.foundation_name_prefix}-mlflow-db-password-production"
+    db_name                  = "${local.foundation_name_prefix}-mlflow-db-name-production"
+    instance_connection_name = "${local.foundation_name_prefix}-mlflow-instance-connection-name-production"
+    artifact_root            = "${local.foundation_name_prefix}-mlflow-artifact-root-production"
+  }
+
+  mlflow_secret_values_production = {
+    db_user                  = google_sql_user.mlflow_production.name
+    db_password              = random_password.mlflow_db_password_production.result
+    db_name                  = google_sql_database.mlflow_production.name
+    instance_connection_name = google_sql_database_instance.mlflow_production.connection_name
+    artifact_root            = local.mlflow_artifact_root_production
+  }
+}
+
+resource "google_secret_manager_secret" "mlflow_production" {
+  for_each = local.mlflow_secret_ids_production
+
+  project   = data.google_project.current.project_id
+  secret_id = each.value
+
+  labels = merge(local.common_labels, { purpose = "mlflow_production_${each.key}" })
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required["secretmanager.googleapis.com"]]
+}
+
+resource "google_secret_manager_secret_version" "mlflow_production" {
+  for_each = local.mlflow_secret_values_production
+
+  secret      = google_secret_manager_secret.mlflow_production[each.key].id
+  secret_data = each.value
+}
+
+resource "google_secret_manager_secret_iam_member" "runtime_mlflow_production_secret_accessor" {
+  for_each = google_secret_manager_secret.mlflow_production
+
+  project   = each.value.project
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/deployments/gcp/terraform/sql.tf
+++ b/deployments/gcp/terraform/sql.tf
@@ -7,6 +7,11 @@ locals {
     "%s/mlflow/",
     google_storage_bucket.foundation["artifacts"].url,
   )
+  mlflow_sql_instance_name_production = "${local.foundation_name_prefix}-mlflow-production"
+  mlflow_artifact_root_production = format(
+    "%s/mlflow-production/",
+    google_storage_bucket.foundation["artifacts"].url,
+  )
 }
 
 resource "random_password" "mlflow_db_password" {
@@ -67,4 +72,58 @@ resource "google_project_iam_member" "runtime_cloudsql_client" {
   project = data.google_project.current.project_id
   role    = "roles/cloudsql.client"
   member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "random_password" "mlflow_db_password_production" {
+  length           = 32
+  special          = false
+  min_lower        = 1
+  min_numeric      = 1
+  min_upper        = 1
+  override_special = ""
+}
+
+resource "google_sql_database_instance" "mlflow_production" {
+  project             = data.google_project.current.project_id
+  name                = local.mlflow_sql_instance_name_production
+  region              = var.region
+  database_version    = "POSTGRES_16"
+  deletion_protection = true
+
+  settings {
+    edition           = "ENTERPRISE"
+    tier              = local.mlflow_sql_tier
+    availability_type = "ZONAL"
+    disk_autoresize   = true
+    disk_size         = 20
+    disk_type         = "PD_SSD"
+
+    backup_configuration {
+      enabled = true
+    }
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.production.id
+      enable_private_path_for_google_cloud_services = true
+    }
+  }
+
+  depends_on = [
+    google_project_service.required["sqladmin.googleapis.com"],
+    google_service_networking_connection.production_private_services,
+  ]
+}
+
+resource "google_sql_database" "mlflow_production" {
+  project  = data.google_project.current.project_id
+  name     = local.mlflow_database_name
+  instance = google_sql_database_instance.mlflow_production.name
+}
+
+resource "google_sql_user" "mlflow_production" {
+  project  = data.google_project.current.project_id
+  name     = local.mlflow_database_user
+  instance = google_sql_database_instance.mlflow_production.name
+  password = random_password.mlflow_db_password_production.result
 }

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -116,3 +116,21 @@ variable "otlp_collector_endpoint" {
   type        = string
   default     = ""
 }
+
+variable "production_mlflow_image" {
+  description = "Hosted production MLflow container image ref. Leave empty until the first production MLflow deploy."
+  type        = string
+  default     = ""
+}
+
+variable "production_serving_image" {
+  description = "Hosted production serving container image ref. Leave empty until the first production serving deploy."
+  type        = string
+  default     = ""
+}
+
+variable "production_platform_image" {
+  description = "Hosted production platform jobs container image ref. Leave empty until the first production platform-jobs deploy."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Extends Terraform to manage staging **and** production in one state file; no staging resources are modified or renamed
- Adds `mlp-ci-prod` IAM grants (artifact registry, viewer, scheduler admin, bucket admin, TF state) and WIF binding scoped to `attribute.environment/production`
- Adds production VPC (`10.43.0.0/24`), Cloud SQL instance, and Secret Manager secrets for MLflow runtime config
- Parameterises `run_mlflow.tf` and `run_serving.tf` with `for_each` deploy maps keyed by environment; naming template `mlp-mlflow-${each.key}` keeps staging GCP names identical
- Adds production Cloud Run jobs (`pipeline`, `promote`, `rollback`, `reproduce`, `maintenance`) and Cloud Scheduler triggers
- Adds three `moved {}` blocks for IAM members transitioning from bare → `for_each["staging"]`
- Adds `production_mlflow_image`, `production_serving_image`, `production_platform_image` Terraform variables (default `""` = disabled)
- Rewrites three production deploy workflows with `environment: production`, GitHub Environment secrets, `if: github.ref == 'refs/heads/master'` guard, and ordered smoke tests

## Test plan

- [x] `make check` — 140 passed, 0 failures
- [ ] `terraform plan` — verify 0 changes to staging, correct new production additions
- [ ] Set GitHub production environment secrets (`GCP_PROJECT_ID`, `GCP_WIF_PROVIDER`, `GCP_CI_SERVICE_ACCOUNT`)
- [ ] `terraform apply` after merge — creates production network, SQL, secrets, IAM
- [ ] Run production deploy workflows in order: MLflow → Platform Jobs → Serving
- [ ] Verify production MLflow UI accessible and prod alias resolves

Closes #175