### PR TITLE
fix: gate production foundation behind manage_production_foundation

### DIFF
--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -82,6 +82,8 @@ resource "google_service_account" "ci_staging" {
 }
 
 resource "google_service_account" "ci_prod" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project      = data.google_project.current.project_id
   account_id   = "${local.foundation_name_prefix}-ci-prod"
   display_name = "ML lifecycle platform CI / production"
@@ -209,41 +211,51 @@ resource "google_service_account_iam_member" "ci_staging_workload_identity_user"
 }
 
 resource "google_artifact_registry_repository_iam_member" "ci_prod_writer" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project    = google_artifact_registry_repository.images.project
   location   = google_artifact_registry_repository.images.location
   repository = google_artifact_registry_repository.images.name
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${google_service_account.ci_prod.email}"
+  member     = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }
 
 resource "google_project_iam_member" "ci_prod_viewer" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project = data.google_project.current.project_id
   role    = "roles/viewer"
-  member  = "serviceAccount:${google_service_account.ci_prod.email}"
+  member  = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }
 
 resource "google_project_iam_member" "ci_prod_scheduler_admin" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project = data.google_project.current.project_id
   role    = "roles/cloudscheduler.admin"
-  member  = "serviceAccount:${google_service_account.ci_prod.email}"
+  member  = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "ci_prod_foundation_bucket_admin" {
-  for_each = google_storage_bucket.foundation
+  for_each = var.manage_production_foundation ? google_storage_bucket.foundation : {}
 
   bucket = each.value.name
   role   = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.ci_prod.email}"
+  member = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "ci_prod_tf_state_admin" {
+  count = var.manage_production_foundation ? 1 : 0
+
   bucket = local.tf_state_bucket
   role   = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.ci_prod.email}"
+  member = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }
 
 resource "google_service_account_iam_member" "ci_prod_workload_identity_user" {
-  service_account_id = google_service_account.ci_prod.name
+  count = var.manage_production_foundation ? 1 : 0
+
+  service_account_id = google_service_account.ci_prod[0].name
   role               = "roles/iam.workloadIdentityUser"
   member = format(
     "principalSet://iam.googleapis.com/%s/attribute.environment/production",

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -173,7 +173,7 @@ resource "google_cloud_run_v2_job_iam_member" "platform_ci_invoker" {
 }
 
 locals {
-  platform_production_jobs_enabled = length(trimspace(var.production_platform_image)) > 0
+  platform_production_jobs_enabled = length(trimspace(var.production_platform_image)) > 0 && var.manage_production_foundation
 
   platform_jobs_production = {
     pipeline = {
@@ -247,8 +247,8 @@ resource "google_cloud_run_v2_job" "platform_production" {
         egress = "PRIVATE_RANGES_ONLY"
 
         network_interfaces {
-          network    = google_compute_network.production.id
-          subnetwork = google_compute_subnetwork.production.id
+          network    = google_compute_network.production[0].id
+          subnetwork = google_compute_subnetwork.production[0].id
         }
       }
 
@@ -344,5 +344,5 @@ resource "google_cloud_run_v2_job_iam_member" "platform_production_ci_invoker" {
   location = each.value.location
   name     = each.value.name
   role     = "roles/run.invoker"
-  member   = "serviceAccount:${google_service_account.ci_prod.email}"
+  member   = "serviceAccount:${google_service_account.ci_prod[0].email}"
 }

--- a/deployments/gcp/terraform/network.tf
+++ b/deployments/gcp/terraform/network.tf
@@ -55,6 +55,8 @@ resource "google_service_networking_connection" "staging_private_services" {
 }
 
 resource "google_compute_network" "production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project                 = data.google_project.current.project_id
   name                    = local.production_network_name
   auto_create_subnetworks = false
@@ -64,10 +66,12 @@ resource "google_compute_network" "production" {
 }
 
 resource "google_compute_subnetwork" "production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project                  = data.google_project.current.project_id
   name                     = local.production_subnetwork_name
   region                   = var.region
-  network                  = google_compute_network.production.id
+  network                  = google_compute_network.production[0].id
   ip_cidr_range            = local.production_subnetwork_cidr
   private_ip_google_access = true
 
@@ -75,20 +79,24 @@ resource "google_compute_subnetwork" "production" {
 }
 
 resource "google_compute_global_address" "production_private_services" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project       = data.google_project.current.project_id
   name          = local.production_private_service_range_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = local.production_private_service_range_prefix_len
-  network       = google_compute_network.production.id
+  network       = google_compute_network.production[0].id
 
   depends_on = [google_project_service.required["compute.googleapis.com"]]
 }
 
 resource "google_service_networking_connection" "production_private_services" {
-  network                 = google_compute_network.production.id
+  count = var.manage_production_foundation ? 1 : 0
+
+  network                 = google_compute_network.production[0].id
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.production_private_services.name]
+  reserved_peering_ranges = [google_compute_global_address.production_private_services[0].name]
 
   depends_on = [
     google_project_service.required["servicenetworking.googleapis.com"],

--- a/deployments/gcp/terraform/outputs.tf
+++ b/deployments/gcp/terraform/outputs.tf
@@ -55,10 +55,10 @@ output "foundation_secret_ids" {
 }
 
 output "foundation_service_accounts" {
-  description = "Service account emails for CI and hosted runtime identities."
+  description = "Service account emails for CI and hosted runtime identities. ci_prod is null until the production foundation is bootstrapped."
   value = {
     ci_staging = google_service_account.ci_staging.email
-    ci_prod    = google_service_account.ci_prod.email
+    ci_prod    = var.manage_production_foundation ? google_service_account.ci_prod[0].email : null
     runtime    = google_service_account.runtime.email
   }
 }
@@ -171,35 +171,35 @@ output "platform_schedules" {
 }
 
 output "production_network" {
-  description = "Production VPC and subnet used by production hosted workloads."
-  value = {
-    network_name    = google_compute_network.production.name
-    network_id      = google_compute_network.production.id
-    subnetwork_name = google_compute_subnetwork.production.name
-    subnetwork_id   = google_compute_subnetwork.production.id
-    subnetwork_cidr = google_compute_subnetwork.production.ip_cidr_range
-    peering_range   = google_compute_global_address.production_private_services.name
-    peering_cidr    = google_compute_global_address.production_private_services.address
-  }
+  description = "Production VPC and subnet used by production hosted workloads. Null until the production foundation is bootstrapped."
+  value = var.manage_production_foundation ? {
+    network_name    = google_compute_network.production[0].name
+    network_id      = google_compute_network.production[0].id
+    subnetwork_name = google_compute_subnetwork.production[0].name
+    subnetwork_id   = google_compute_subnetwork.production[0].id
+    subnetwork_cidr = google_compute_subnetwork.production[0].ip_cidr_range
+    peering_range   = google_compute_global_address.production_private_services[0].name
+    peering_cidr    = google_compute_global_address.production_private_services[0].address
+  } : null
 }
 
 output "mlflow_production_service" {
   description = "Hosted production MLflow service contract. Null until the first production MLflow deploy."
-  value = local.mlflow_production_deploy_enabled ? {
+  value = local.mlflow_production_deploy_enabled && var.manage_production_foundation ? {
     name       = google_cloud_run_v2_service.mlflow["production"].name
     uri        = google_cloud_run_v2_service.mlflow["production"].uri
     image      = google_cloud_run_v2_service.mlflow["production"].template[0].containers[0].image
-    invoker_sa = google_service_account.ci_prod.email
+    invoker_sa = google_service_account.ci_prod[0].email
   } : null
 }
 
 output "serving_production_service" {
   description = "Hosted production serving service contract. Null until the first production serving deploy."
-  value = local.serving_production_deploy_enabled ? {
+  value = local.serving_production_deploy_enabled && var.manage_production_foundation ? {
     name       = google_cloud_run_v2_service.serving["production"].name
     uri        = google_cloud_run_v2_service.serving["production"].uri
     image      = google_cloud_run_v2_service.serving["production"].template[0].containers[0].image
-    invoker_sa = google_service_account.ci_prod.email
+    invoker_sa = google_service_account.ci_prod[0].email
   } : null
 }
 

--- a/deployments/gcp/terraform/run_mlflow.tf
+++ b/deployments/gcp/terraform/run_mlflow.tf
@@ -4,29 +4,29 @@ locals {
 
   mlflow_deploy_map = merge(
     local.mlflow_deploy_enabled ? { staging = var.mlflow_image } : {},
-    local.mlflow_production_deploy_enabled ? { production = var.production_mlflow_image } : {},
+    local.mlflow_production_deploy_enabled && var.manage_production_foundation ? { production = var.production_mlflow_image } : {},
   )
 
-  mlflow_networks = {
-    staging    = google_compute_network.staging
-    production = google_compute_network.production
-  }
-  mlflow_subnetworks = {
-    staging    = google_compute_subnetwork.staging
-    production = google_compute_subnetwork.production
-  }
-  mlflow_sql_instances = {
-    staging    = google_sql_database_instance.mlflow
-    production = google_sql_database_instance.mlflow_production
-  }
-  mlflow_secret_refs = {
-    staging    = google_secret_manager_secret.mlflow
-    production = google_secret_manager_secret.mlflow_production
-  }
-  mlflow_ci_sas = {
-    staging    = google_service_account.ci_staging
-    production = google_service_account.ci_prod
-  }
+  mlflow_networks = merge(
+    { staging = google_compute_network.staging },
+    var.manage_production_foundation ? { production = google_compute_network.production[0] } : {},
+  )
+  mlflow_subnetworks = merge(
+    { staging = google_compute_subnetwork.staging },
+    var.manage_production_foundation ? { production = google_compute_subnetwork.production[0] } : {},
+  )
+  mlflow_sql_instances = merge(
+    { staging = google_sql_database_instance.mlflow },
+    var.manage_production_foundation ? { production = google_sql_database_instance.mlflow_production[0] } : {},
+  )
+  mlflow_secret_refs = merge(
+    { staging = google_secret_manager_secret.mlflow },
+    var.manage_production_foundation ? { production = google_secret_manager_secret.mlflow_production } : {},
+  )
+  mlflow_ci_sas = merge(
+    { staging = google_service_account.ci_staging },
+    var.manage_production_foundation ? { production = google_service_account.ci_prod[0] } : {},
+  )
 }
 
 resource "google_project_iam_member" "ci_run_admin" {

--- a/deployments/gcp/terraform/run_serving.tf
+++ b/deployments/gcp/terraform/run_serving.tf
@@ -5,7 +5,7 @@ locals {
 
   serving_deploy_map = merge(
     local.serving_deploy_enabled ? { staging = var.serving_image } : {},
-    local.serving_production_deploy_enabled ? { production = var.production_serving_image } : {},
+    local.serving_production_deploy_enabled && var.manage_production_foundation ? { production = var.production_serving_image } : {},
   )
 }
 

--- a/deployments/gcp/terraform/secrets_mlflow.tf
+++ b/deployments/gcp/terraform/secrets_mlflow.tf
@@ -48,21 +48,21 @@ resource "google_secret_manager_secret_iam_member" "runtime_mlflow_secret_access
 }
 
 locals {
-  mlflow_secret_ids_production = {
+  mlflow_secret_ids_production = var.manage_production_foundation ? {
     db_user                  = "${local.foundation_name_prefix}-mlflow-db-user-production"
     db_password              = "${local.foundation_name_prefix}-mlflow-db-password-production"
     db_name                  = "${local.foundation_name_prefix}-mlflow-db-name-production"
     instance_connection_name = "${local.foundation_name_prefix}-mlflow-instance-connection-name-production"
     artifact_root            = "${local.foundation_name_prefix}-mlflow-artifact-root-production"
-  }
+  } : {}
 
-  mlflow_secret_values_production = {
-    db_user                  = google_sql_user.mlflow_production.name
-    db_password              = random_password.mlflow_db_password_production.result
-    db_name                  = google_sql_database.mlflow_production.name
-    instance_connection_name = google_sql_database_instance.mlflow_production.connection_name
+  mlflow_secret_values_production = var.manage_production_foundation ? {
+    db_user                  = google_sql_user.mlflow_production[0].name
+    db_password              = random_password.mlflow_db_password_production[0].result
+    db_name                  = google_sql_database.mlflow_production[0].name
+    instance_connection_name = google_sql_database_instance.mlflow_production[0].connection_name
     artifact_root            = local.mlflow_artifact_root_production
-  }
+  } : {}
 }
 
 resource "google_secret_manager_secret" "mlflow_production" {

--- a/deployments/gcp/terraform/sql.tf
+++ b/deployments/gcp/terraform/sql.tf
@@ -75,6 +75,8 @@ resource "google_project_iam_member" "runtime_cloudsql_client" {
 }
 
 resource "random_password" "mlflow_db_password_production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   length           = 32
   special          = false
   min_lower        = 1
@@ -84,6 +86,8 @@ resource "random_password" "mlflow_db_password_production" {
 }
 
 resource "google_sql_database_instance" "mlflow_production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project             = data.google_project.current.project_id
   name                = local.mlflow_sql_instance_name_production
   region              = var.region
@@ -104,7 +108,7 @@ resource "google_sql_database_instance" "mlflow_production" {
 
     ip_configuration {
       ipv4_enabled                                  = false
-      private_network                               = google_compute_network.production.id
+      private_network                               = google_compute_network.production[0].id
       enable_private_path_for_google_cloud_services = true
     }
   }
@@ -116,14 +120,18 @@ resource "google_sql_database_instance" "mlflow_production" {
 }
 
 resource "google_sql_database" "mlflow_production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project  = data.google_project.current.project_id
   name     = local.mlflow_database_name
-  instance = google_sql_database_instance.mlflow_production.name
+  instance = google_sql_database_instance.mlflow_production[0].name
 }
 
 resource "google_sql_user" "mlflow_production" {
+  count = var.manage_production_foundation ? 1 : 0
+
   project  = data.google_project.current.project_id
   name     = local.mlflow_database_user
-  instance = google_sql_database_instance.mlflow_production.name
-  password = random_password.mlflow_db_password_production.result
+  instance = google_sql_database_instance.mlflow_production[0].name
+  password = random_password.mlflow_db_password_production[0].result
 }

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -134,3 +134,9 @@ variable "production_platform_image" {
   type        = string
   default     = ""
 }
+
+variable "manage_production_foundation" {
+  description = "Manage production foundation resources (CI service account, VPC, Cloud SQL, Secret Manager secrets, production Cloud Run services, jobs, schedulers) from this Terraform root. Default false so the staging CD service account, which lacks production IAM, can apply cleanly. Set true only for owner-credentialed bootstrap or for the production CD identity once it has the required IAM."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Add `manage_production_foundation` variable (bool, default `false`) so the staging CD service account does not try to manage production-only resources it lacks IAM for.
- Gate all production-only resources behind it: `ci_prod` service account + IAM, production VPC and peering, production Cloud SQL, production Secret Manager secrets, `platform_production` Cloud Run job + scheduler, and the production keys in the shared `mlflow_*` maps.
- Gate the `production_network`, `mlflow_production_service`, `serving_production_service`, and `foundation_service_accounts.ci_prod` outputs so they return `null` when the foundation is not managed from this apply.

## Context

Master CD failed on `a161833` (PR #227) at `Terraform apply hosted MLflow staging`. The staging CI service account `mlp-ci-staging@…` hit `403` on `setIamPolicy`, `compute.networks.create`, `iam.serviceAccounts.setIamPolicy`, and `secretmanager.secrets.create` while trying to manage production resources. Failed run: https://github.com/jellewillekes/ml-lifecycle-platform/actions/runs/25557644065/job/75021201199

This change keeps the CI service-account boundary established in PR #226 intact and unblocks staging CD. Production CD remains a separate problem: the production CI service account also lacks the foundation permissions, so the production foundation has to be bootstrapped out-of-band with owner credentials, and the production CD workflows will need a follow-up to pass `TF_VAR_manage_production_foundation=true` once that is in place.

## Test plan

- [x] `terraform fmt -check`
- [x] `terraform validate`
- [x] `make check`
- [ ] `make e2e-clean`
- [ ] Verify master CD goes green on the next push

Refs #175