### PR TITLE
feat: add hosted staging Binance pipeline job

### DIFF
--- a/.github/workflows/run-platform-job-staging.yml
+++ b/.github/workflows/run-platform-job-staging.yml
@@ -23,6 +23,7 @@ on:
           - promote
           - rollback
           - pipeline
+          - pipeline-binance
       execution_mode:
         description: Safe execution mode for the selected job.
         required: true
@@ -102,7 +103,7 @@ jobs:
           job_args_csv=""
 
           case "${JOB_NAME_INPUT}:${EXECUTION_MODE_INPUT}" in
-            maintenance:default|reproduce:default|pipeline:default)
+            maintenance:default|reproduce:default|pipeline:default|pipeline-binance:default)
               ;;
             promote:default)
               job_args_csv="-m,ml_lifecycle_platform.registry.promote,--model-name,breast_cancer_clf,--format,json"
@@ -116,7 +117,7 @@ jobs:
             rollback:dry_run)
               job_args_csv="-m,ml_lifecycle_platform.registry.rollback,--model-name,breast_cancer_clf,--dry-run,--format,json"
               ;;
-            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run)
+            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run|pipeline-binance:dry_run)
               echo "execution_mode=dry_run is not supported for job ${JOB_NAME_INPUT}."
               exit 1
               ;;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,7 +363,7 @@ The current pipeline ingests synthetic data. Real data from day one makes every 
 #### Acceptance criteria
 
 - `make e2e-clean` trains `binance_btc_1m` end-to-end locally on real data
-- staging Cloud Run Job ingests Binance klines and produces a registered model
+- staging Cloud Run Job ingests Binance klines and produces a registered model — wired via the `mlp-pipeline-binance-staging` job (run with the `pipeline-binance` workflow choice)
 - UP-49/UP-50 gates exercised on real data
 - `data-sources.md` runbook takes a contributor from "I have an API in mind" to a merged new-source PR
 

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -1,5 +1,16 @@
 locals {
   platform_jobs_enabled = length(trimspace(var.platform_image)) > 0
+
+  # Model identity is injected per job via env vars (MLP_ENV plus the
+  # MODEL_NAME / MLP_MODEL_SPEC_PATH / EXPERIMENT_NAME runtime overrides), so a
+  # single platform image can drive several model pipelines. The breast-cancer
+  # demo is the default identity; the binance pipeline overrides it.
+  staging_demo_model_env = {
+    MLP_ENV             = "staging"
+    MODEL_NAME          = "breast_cancer_clf"
+    MLP_MODEL_SPEC_PATH = "configs/models/breast_cancer_demo.yaml"
+  }
+
   platform_jobs = {
     pipeline = {
       name                 = "${local.foundation_name_prefix}-pipeline-staging"
@@ -8,6 +19,21 @@ locals {
       timeout              = "1800s"
       mutates_model_state  = true
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
+    }
+    pipeline_binance = {
+      name                 = "${local.foundation_name_prefix}-pipeline-binance-staging"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.pipeline.orchestrate"]
+      timeout              = "1800s"
+      mutates_model_state  = true
+      safe_validation_args = []
+      model_env = {
+        MLP_ENV             = "staging"
+        EXPERIMENT_NAME     = "binance-btc-1m"
+        MODEL_NAME          = "binance_btc_1m"
+        MLP_MODEL_SPEC_PATH = "configs/models/binance_btc_1m.yaml"
+      }
     }
     promote = {
       name                 = "${local.foundation_name_prefix}-promote-staging"
@@ -16,6 +42,7 @@ locals {
       timeout              = "900s"
       mutates_model_state  = true
       safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+      model_env            = local.staging_demo_model_env
     }
     rollback = {
       name                 = "${local.foundation_name_prefix}-rollback-staging"
@@ -24,6 +51,7 @@ locals {
       timeout              = "900s"
       mutates_model_state  = true
       safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+      model_env            = local.staging_demo_model_env
     }
     reproduce = {
       name                 = "${local.foundation_name_prefix}-reproduce-staging"
@@ -32,6 +60,7 @@ locals {
       timeout              = "1800s"
       mutates_model_state  = false
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
     }
     maintenance = {
       name                 = "${local.foundation_name_prefix}-maintenance-staging"
@@ -40,6 +69,7 @@ locals {
       timeout              = "600s"
       mutates_model_state  = false
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
     }
   }
 }
@@ -89,9 +119,12 @@ resource "google_cloud_run_v2_job" "platform" {
           }
         }
 
-        env {
-          name  = "MLP_ENV"
-          value = "staging"
+        dynamic "env" {
+          for_each = each.value.model_env
+          content {
+            name  = env.key
+            value = env.value
+          }
         }
 
         env {
@@ -107,16 +140,6 @@ resource "google_cloud_run_v2_job" "platform" {
         env {
           name  = "MLFLOW_CLOUD_RUN_AUDIENCE"
           value = google_cloud_run_v2_service.mlflow["staging"].uri
-        }
-
-        env {
-          name  = "MODEL_NAME"
-          value = "breast_cancer_clf"
-        }
-
-        env {
-          name  = "MLP_MODEL_SPEC_PATH"
-          value = "configs/models/breast_cancer_demo.yaml"
         }
 
         env {

--- a/docs/runbooks/data-sources.md
+++ b/docs/runbooks/data-sources.md
@@ -38,6 +38,34 @@ make e2e-binance          # = make e2e-clean MLP_ENV_NAME=local_binance
 served model name aligned with the spec — register reads the spec's model name,
 but promote and serve read the profile, so they must agree.)
 
+## Run on hosted staging
+
+The same adapter runs unchanged on GCP — it is plain public HTTPS, which is why
+the `backends/common` location is deliberate. Model identity is injected per job
+via env (`MLP_ENV` plus the `MODEL_NAME` / `MLP_MODEL_SPEC_PATH` /
+`EXPERIMENT_NAME` overrides), so one platform image drives both the demo and the
+Binance pipelines side by side.
+
+- **Job** — `mlp-pipeline-binance-staging`, defined in
+  [`jobs_platform.tf`](../../deployments/gcp/terraform/jobs_platform.tf) next to
+  the demo jobs. `terraform apply` (the *Deploy Platform Jobs / Staging*
+  workflow) creates it; there is no allow-list to update.
+- **Run it** — dispatch *Run Platform Job / Staging* with
+  `job_name: pipeline-binance`. It executes the job, running
+  `ingest → … → register` against hosted MLflow.
+- **Egress** — the job uses `egress = "PRIVATE_RANGES_ONLY"`, which routes only
+  RFC-1918 traffic through the VPC; public `data-api.binance.vision` egresses
+  directly, so no Cloud NAT is needed.
+- **Confirm the model** — a gated run registers `binance_btc_1m` and points its
+  `candidate` alias at the new version. Check the MLflow registry, or run
+  `scripts/verify_hosted_model_alias.py --tracking-uri <mlflow-url> --model-name
+  binance_btc_1m --alias candidate`. The POC gate (`roc_auc >= 0.50`) is a low
+  mechanics bar by design — 1-minute direction is near-random, so on a thin
+  slice a run can miss the gate and skip registration; just re-run.
+
+Hosting a *new* source is the same small pattern: add a `model_env` entry to
+`platform_jobs` and a `job_name` choice to the staging platform-job workflow.
+
 ## Add a new source in 5 steps
 
 Worked example: a second exchange, Coinbase, that produces the same OHLCV shape.


### PR DESCRIPTION
## Summary
- Add `mlp-pipeline-binance-staging` Cloud Run Job that runs ingest→register for the `binance_btc_1m` model on hosted staging, beside the breast-cancer demo.
- Inject model identity per job via env, rendered from a `model_env` map, so a single platform image drives multiple model pipelines (no new profile file; `environment` stays `staging`).
- Add a `pipeline-binance` choice to *Run Platform Job / Staging* to execute the job on demand.
- Document hosted runs and the `PRIVATE_RANGES_ONLY` egress story in `docs/runbooks/data-sources.md`; annotate the UP-51 staging acceptance criterion.

## Test plan
- [x] `make check` (159 passed; ruff + mypy clean)
- [x] `make docs-check`
- [x] `terraform fmt -check -recursive` and `terraform validate`
- [ ] Hosted: deploy via *Deploy Platform Jobs / Staging*, then dispatch *Run Platform Job / Staging* with `job_name: pipeline-binance`; confirm a `binance_btc_1m@candidate` version in hosted MLflow (operator-run; needs GCP)

Closes #236
Refs #201