### PR TITLE
feat: add LightGBM trainer and use it for binance model

### DIFF
--- a/.github/workflows/run-platform-job-staging.yml
+++ b/.github/workflows/run-platform-job-staging.yml
@@ -23,6 +23,7 @@ on:
           - promote
           - rollback
           - pipeline
+          - pipeline-binance
       execution_mode:
         description: Safe execution mode for the selected job.
         required: true
@@ -102,7 +103,7 @@ jobs:
           job_args_csv=""
 
           case "${JOB_NAME_INPUT}:${EXECUTION_MODE_INPUT}" in
-            maintenance:default|reproduce:default|pipeline:default)
+            maintenance:default|reproduce:default|pipeline:default|pipeline-binance:default)
               ;;
             promote:default)
               job_args_csv="-m,ml_lifecycle_platform.registry.promote,--model-name,breast_cancer_clf,--format,json"
@@ -116,7 +117,7 @@ jobs:
             rollback:dry_run)
               job_args_csv="-m,ml_lifecycle_platform.registry.rollback,--model-name,breast_cancer_clf,--dry-run,--format,json"
               ;;
-            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run)
+            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run|pipeline-binance:dry_run)
               echo "execution_mode=dry_run is not supported for job ${JOB_NAME_INPUT}."
               exit 1
               ;;

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 # Base: git for registry URIs, curl for healthchecks, uv for locked installs.
+# libgomp1 is the OpenMP runtime LightGBM's native lib loads at import time;
+# the slim base omits it, so train and serve would crash without it.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git curl \
+  && apt-get install -y --no-install-recommends git curl libgomp1 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.5 /uv /uvx /bin/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,7 +363,7 @@ The current pipeline ingests synthetic data. Real data from day one makes every 
 #### Acceptance criteria
 
 - `make e2e-clean` trains `binance_btc_1m` end-to-end locally on real data
-- staging Cloud Run Job ingests Binance klines and produces a registered model
+- staging Cloud Run Job ingests Binance klines and produces a registered model — wired via the `mlp-pipeline-binance-staging` job (run with the `pipeline-binance` workflow choice)
 - UP-49/UP-50 gates exercised on real data
 - `data-sources.md` runbook takes a contributor from "I have an API in mind" to a merged new-source PR
 

--- a/configs/models/binance_btc_1m.yaml
+++ b/configs/models/binance_btc_1m.yaml
@@ -15,9 +15,12 @@ split:
 preprocessor:
   kind: standard_scaler
 trainer:
-  kind: logistic_regression
-  max_iter: 2000
-  solver: lbfgs
+  kind: lightgbm
+  n_estimators: 200
+  learning_rate: 0.05
+  num_leaves: 15
+  max_depth: 4
+  min_child_samples: 20
   class_weight: balanced
   random_state: 42
 evaluation:

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -1,5 +1,16 @@
 locals {
   platform_jobs_enabled = length(trimspace(var.platform_image)) > 0
+
+  # Model identity is injected per job via env vars (MLP_ENV plus the
+  # MODEL_NAME / MLP_MODEL_SPEC_PATH / EXPERIMENT_NAME runtime overrides), so a
+  # single platform image can drive several model pipelines. The breast-cancer
+  # demo is the default identity; the binance pipeline overrides it.
+  staging_demo_model_env = {
+    MLP_ENV             = "staging"
+    MODEL_NAME          = "breast_cancer_clf"
+    MLP_MODEL_SPEC_PATH = "configs/models/breast_cancer_demo.yaml"
+  }
+
   platform_jobs = {
     pipeline = {
       name                 = "${local.foundation_name_prefix}-pipeline-staging"
@@ -8,6 +19,21 @@ locals {
       timeout              = "1800s"
       mutates_model_state  = true
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
+    }
+    pipeline_binance = {
+      name                 = "${local.foundation_name_prefix}-pipeline-binance-staging"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.pipeline.orchestrate"]
+      timeout              = "1800s"
+      mutates_model_state  = true
+      safe_validation_args = []
+      model_env = {
+        MLP_ENV             = "staging"
+        EXPERIMENT_NAME     = "binance-btc-1m"
+        MODEL_NAME          = "binance_btc_1m"
+        MLP_MODEL_SPEC_PATH = "configs/models/binance_btc_1m.yaml"
+      }
     }
     promote = {
       name                 = "${local.foundation_name_prefix}-promote-staging"
@@ -16,6 +42,7 @@ locals {
       timeout              = "900s"
       mutates_model_state  = true
       safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+      model_env            = local.staging_demo_model_env
     }
     rollback = {
       name                 = "${local.foundation_name_prefix}-rollback-staging"
@@ -24,6 +51,7 @@ locals {
       timeout              = "900s"
       mutates_model_state  = true
       safe_validation_args = ["--model-name", "breast_cancer_clf", "--dry-run", "--format", "json"]
+      model_env            = local.staging_demo_model_env
     }
     reproduce = {
       name                 = "${local.foundation_name_prefix}-reproduce-staging"
@@ -32,6 +60,7 @@ locals {
       timeout              = "1800s"
       mutates_model_state  = false
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
     }
     maintenance = {
       name                 = "${local.foundation_name_prefix}-maintenance-staging"
@@ -40,6 +69,7 @@ locals {
       timeout              = "600s"
       mutates_model_state  = false
       safe_validation_args = []
+      model_env            = local.staging_demo_model_env
     }
   }
 }
@@ -89,9 +119,12 @@ resource "google_cloud_run_v2_job" "platform" {
           }
         }
 
-        env {
-          name  = "MLP_ENV"
-          value = "staging"
+        dynamic "env" {
+          for_each = each.value.model_env
+          content {
+            name  = env.key
+            value = env.value
+          }
         }
 
         env {
@@ -107,16 +140,6 @@ resource "google_cloud_run_v2_job" "platform" {
         env {
           name  = "MLFLOW_CLOUD_RUN_AUDIENCE"
           value = google_cloud_run_v2_service.mlflow["staging"].uri
-        }
-
-        env {
-          name  = "MODEL_NAME"
-          value = "breast_cancer_clf"
-        }
-
-        env {
-          name  = "MLP_MODEL_SPEC_PATH"
-          value = "configs/models/breast_cancer_demo.yaml"
         }
 
         env {

--- a/docs/runbooks/data-sources.md
+++ b/docs/runbooks/data-sources.md
@@ -38,6 +38,34 @@ make e2e-binance          # = make e2e-clean MLP_ENV_NAME=local_binance
 served model name aligned with the spec — register reads the spec's model name,
 but promote and serve read the profile, so they must agree.)
 
+## Run on hosted staging
+
+The same adapter runs unchanged on GCP — it is plain public HTTPS, which is why
+the `backends/common` location is deliberate. Model identity is injected per job
+via env (`MLP_ENV` plus the `MODEL_NAME` / `MLP_MODEL_SPEC_PATH` /
+`EXPERIMENT_NAME` overrides), so one platform image drives both the demo and the
+Binance pipelines side by side.
+
+- **Job** — `mlp-pipeline-binance-staging`, defined in
+  [`jobs_platform.tf`](../../deployments/gcp/terraform/jobs_platform.tf) next to
+  the demo jobs. `terraform apply` (the *Deploy Platform Jobs / Staging*
+  workflow) creates it; there is no allow-list to update.
+- **Run it** — dispatch *Run Platform Job / Staging* with
+  `job_name: pipeline-binance`. It executes the job, running
+  `ingest → … → register` against hosted MLflow.
+- **Egress** — the job uses `egress = "PRIVATE_RANGES_ONLY"`, which routes only
+  RFC-1918 traffic through the VPC; public `data-api.binance.vision` egresses
+  directly, so no Cloud NAT is needed.
+- **Confirm the model** — a gated run registers `binance_btc_1m` and points its
+  `candidate` alias at the new version. Check the MLflow registry, or run
+  `scripts/verify_hosted_model_alias.py --tracking-uri <mlflow-url> --model-name
+  binance_btc_1m --alias candidate`. The POC gate (`roc_auc >= 0.50`) is a low
+  mechanics bar by design — 1-minute direction is near-random, so on a thin
+  slice a run can miss the gate and skip registration; just re-run.
+
+Hosting a *new* source is the same small pattern: add a `model_env` entry to
+`platform_jobs` and a `job_name` choice to the staging platform-job workflow.
+
 ## Add a new source in 5 steps
 
 Worked example: a second exchange, Coinbase, that produces the same OHLCV shape.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.128.0",
     "google-auth>=2.48.0",
     "joblib>=1.5.3",
+    "lightgbm>=4.5,<5.0",
     "matplotlib>=3.10.8",
     "mlflow>=2.13,<3.0",
     "numpy>=2.4.1",

--- a/src/ml_lifecycle_platform/core/model_spec_types.py
+++ b/src/ml_lifecycle_platform/core/model_spec_types.py
@@ -18,7 +18,7 @@ from ml_lifecycle_platform.common.constants import (
 SUPPORTED_TASK = "binary_classifier"
 SUPPORTED_SOURCE_KINDS = {"sklearn_demo", "csv", "binance"}
 SUPPORTED_SPLIT_METHODS = {"random", "chronological"}
-SUPPORTED_TRAINER_KIND = "logistic_regression"
+SUPPORTED_TRAINER_KINDS = {"logistic_regression", "lightgbm"}
 SUPPORTED_PREPROCESSOR_KIND = "standard_scaler"
 SUPPORTED_METRICS = {"accuracy", "f1", "roc_auc"}
 SUPPORTED_FEATURE_TYPES = {"float", "int", "bool", "string"}
@@ -119,6 +119,33 @@ class LogisticRegressionTrainerSpec:
             "class_weight": self.class_weight,
             "random_state": self.random_state,
         }
+
+
+@dataclass(frozen=True)
+class LightGBMTrainerSpec:
+    kind: str
+    n_estimators: int
+    learning_rate: float
+    num_leaves: int
+    max_depth: int
+    min_child_samples: int
+    class_weight: str
+    random_state: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "n_estimators": self.n_estimators,
+            "learning_rate": self.learning_rate,
+            "num_leaves": self.num_leaves,
+            "max_depth": self.max_depth,
+            "min_child_samples": self.min_child_samples,
+            "class_weight": self.class_weight,
+            "random_state": self.random_state,
+        }
+
+
+TrainerSpec = LogisticRegressionTrainerSpec | LightGBMTrainerSpec
 
 
 @dataclass(frozen=True)
@@ -223,7 +250,7 @@ class ModelSpec:
     source: SklearnDemoSourceSpec | CsvSourceSpec | BinanceSourceSpec
     split: SplitSpec
     preprocessor: PreprocessorSpec
-    trainer: LogisticRegressionTrainerSpec
+    trainer: TrainerSpec
     evaluation: EvaluationSpec
     feature_contract: FeatureContractSpec
     policy: PolicySpec

--- a/src/ml_lifecycle_platform/core/model_specs.py
+++ b/src/ml_lifecycle_platform/core/model_specs.py
@@ -16,6 +16,7 @@ from ml_lifecycle_platform.core.model_spec_types import (
     EvaluationSpec,
     FeatureContractSpec,
     FeatureFieldSpec,
+    LightGBMTrainerSpec,
     LogisticRegressionTrainerSpec,
     MetricThresholdSpec,
     ModelSpec,
@@ -30,7 +31,8 @@ from ml_lifecycle_platform.core.model_spec_types import (
     SUPPORTED_SOURCE_KINDS,
     SUPPORTED_SPLIT_METHODS,
     SUPPORTED_TASK,
-    SUPPORTED_TRAINER_KIND,
+    SUPPORTED_TRAINER_KINDS,
+    TrainerSpec,
     default_feature_contract_spec,
     default_policy_spec,
 )
@@ -153,16 +155,45 @@ def _parse_preprocessor(payload: Any, *, context: str) -> PreprocessorSpec:
     return PreprocessorSpec(kind=kind)
 
 
-def _parse_trainer(payload: Any, *, context: str) -> LogisticRegressionTrainerSpec:
+def _parse_trainer(payload: Any, *, context: str) -> TrainerSpec:
     raw = _require_mapping(payload, context=context)
+    kind = _require_str(raw, "kind", context=context)
+    if kind not in SUPPORTED_TRAINER_KINDS:
+        raise ValueError(
+            f"{context}.kind must be one of {sorted(SUPPORTED_TRAINER_KINDS)}."
+        )
+
+    if kind == "lightgbm":
+        _reject_extra_keys(
+            raw,
+            allowed={
+                "kind",
+                "n_estimators",
+                "learning_rate",
+                "num_leaves",
+                "max_depth",
+                "min_child_samples",
+                "class_weight",
+                "random_state",
+            },
+            context=context,
+        )
+        return LightGBMTrainerSpec(
+            kind=kind,
+            n_estimators=_require_int(raw, "n_estimators", context=context),
+            learning_rate=_require_float(raw, "learning_rate", context=context),
+            num_leaves=_require_int(raw, "num_leaves", context=context),
+            max_depth=_require_int(raw, "max_depth", context=context),
+            min_child_samples=_require_int(raw, "min_child_samples", context=context),
+            class_weight=_require_str(raw, "class_weight", context=context),
+            random_state=_require_int(raw, "random_state", context=context),
+        )
+
     _reject_extra_keys(
         raw,
         allowed={"kind", "max_iter", "solver", "class_weight", "random_state"},
         context=context,
     )
-    kind = _require_str(raw, "kind", context=context)
-    if kind != SUPPORTED_TRAINER_KIND:
-        raise ValueError(f"{context}.kind must be {SUPPORTED_TRAINER_KIND!r}.")
     return LogisticRegressionTrainerSpec(
         kind=kind,
         max_iter=_require_int(raw, "max_iter", context=context),

--- a/src/ml_lifecycle_platform/pipeline/train.py
+++ b/src/ml_lifecycle_platform/pipeline/train.py
@@ -51,7 +51,10 @@ from ml_lifecycle_platform.contracts.dataset_fingerprint import (
     write_fingerprint_json,
 )
 from ml_lifecycle_platform.contracts.repro_contract import ReproContract
-from ml_lifecycle_platform.core.model_spec_types import ModelSpec
+from ml_lifecycle_platform.core.model_spec_types import (
+    LightGBMTrainerSpec,
+    ModelSpec,
+)
 from ml_lifecycle_platform.core.model_specs import load_model_spec
 from ml_lifecycle_platform.runtime.bootstrap import (
     configure_mlflow,
@@ -112,7 +115,18 @@ def config_hash_for_spec(spec: ModelSpec | Mapping[str, Any]) -> str:
     return sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":")))
 
 
-def trainer_params_for_spec(spec: ModelSpec) -> dict[str, str | int]:
+def trainer_params_for_spec(spec: ModelSpec) -> dict[str, str | int | float]:
+    if isinstance(spec.trainer, LightGBMTrainerSpec):
+        return {
+            "model_type": "lightgbm",
+            "n_estimators": spec.trainer.n_estimators,
+            "learning_rate": spec.trainer.learning_rate,
+            "num_leaves": spec.trainer.num_leaves,
+            "max_depth": spec.trainer.max_depth,
+            "min_child_samples": spec.trainer.min_child_samples,
+            "class_weight": spec.trainer.class_weight,
+            "random_state": spec.trainer.random_state,
+        }
     return {
         "model_type": "logreg",
         "max_iter": spec.trainer.max_iter,
@@ -120,6 +134,36 @@ def trainer_params_for_spec(spec: ModelSpec) -> dict[str, str | int]:
         "class_weight": spec.trainer.class_weight,
         "random_state": spec.trainer.random_state,
     }
+
+
+def build_estimator(spec: ModelSpec) -> BaseEstimator:
+    if isinstance(spec.trainer, LightGBMTrainerSpec):
+        # Imported lazily: the native OpenMP dependency (libgomp) is only
+        # needed when a spec actually selects the lightgbm trainer, so the
+        # logreg path and `make check` never pay for it.
+        from lightgbm import LGBMClassifier
+
+        return LGBMClassifier(
+            n_estimators=spec.trainer.n_estimators,
+            learning_rate=spec.trainer.learning_rate,
+            num_leaves=spec.trainer.num_leaves,
+            max_depth=spec.trainer.max_depth,
+            min_child_samples=spec.trainer.min_child_samples,
+            class_weight=spec.trainer.class_weight,
+            random_state=spec.trainer.random_state,
+            # Single-threaded + deterministic so the reproduce step can replay
+            # the probe predictions bit-for-bit.
+            n_jobs=1,
+            deterministic=True,
+            force_col_wise=True,
+            verbose=-1,
+        )
+    return LogisticRegression(
+        max_iter=spec.trainer.max_iter,
+        solver=spec.trainer.solver,
+        class_weight=spec.trainer.class_weight,
+        random_state=spec.trainer.random_state,
+    )
 
 
 def load_training_inputs(
@@ -156,19 +200,13 @@ def train_from_inputs(
     inputs: TrainingInputs,
     spec: ModelSpec,
 ) -> TrainingResult:
-    params = trainer_params_for_spec(spec)
     X_train = inputs.train_df.drop(columns=[spec.label_column])
     y_train = inputs.train_df[spec.label_column].astype(int)
 
     X_test = inputs.test_df.drop(columns=[spec.label_column])
     y_test = inputs.test_df[spec.label_column].astype(int)
 
-    clf = LogisticRegression(
-        max_iter=int(params["max_iter"]),
-        solver=str(params["solver"]),
-        class_weight=str(params["class_weight"]),
-        random_state=int(params["random_state"]),
-    )
+    clf = build_estimator(spec)
     pipeline = Pipeline(steps=[("pre", inputs.preprocessor), ("clf", clf)])
     pipeline.fit(X_train, y_train)
 

--- a/tests/unit/test_model_specs.py
+++ b/tests/unit/test_model_specs.py
@@ -8,7 +8,10 @@ from ml_lifecycle_platform.common.constants import (
     MODEL_SPEC_SCHEMA_VERSION,
     TAG_CONFIG_HASH,
 )
-from ml_lifecycle_platform.core.model_spec_types import default_policy_spec
+from ml_lifecycle_platform.core.model_spec_types import (
+    LightGBMTrainerSpec,
+    default_policy_spec,
+)
 from ml_lifecycle_platform.core.model_specs import load_model_spec, model_spec_from_dict
 
 pytestmark = pytest.mark.unit
@@ -46,6 +49,72 @@ def test_load_binance_model_spec() -> None:
     assert spec.split.stratify is False
     feature_names = {feature.name for feature in spec.feature_contract.features}
     assert "ret_1" in feature_names and "rsi_14" in feature_names
+
+
+def test_binance_spec_uses_lightgbm_trainer() -> None:
+    spec = load_model_spec("configs/models/binance_btc_1m.yaml")
+
+    assert isinstance(spec.trainer, LightGBMTrainerSpec)
+    assert spec.trainer.kind == "lightgbm"
+    assert spec.trainer.n_estimators == 200
+    assert spec.trainer.num_leaves == 15
+    assert spec.trainer.class_weight == "balanced"
+
+
+def test_lightgbm_trainer_rejects_unsupported_fields() -> None:
+    payload = {
+        "schema_version": "model_spec/v1",
+        "model_name": "bad_lgbm",
+        "task": "binary_classifier",
+        "label_column": "target",
+        "source": {"kind": "sklearn_demo", "dataset_name": "breast_cancer"},
+        "split": {"test_size": 0.2, "random_state": 42, "stratify": True},
+        "preprocessor": {"kind": "standard_scaler"},
+        "trainer": {
+            "kind": "lightgbm",
+            "n_estimators": 100,
+            "learning_rate": 0.1,
+            "num_leaves": 31,
+            "max_depth": -1,
+            "min_child_samples": 20,
+            "class_weight": "balanced",
+            "random_state": 42,
+            "max_iter": 2000,
+        },
+        "evaluation": {
+            "metrics": ["accuracy", "f1", "roc_auc"],
+            "gate": {"metric": "roc_auc", "threshold": 0.5},
+        },
+    }
+
+    with pytest.raises(ValueError, match="unsupported fields"):
+        model_spec_from_dict(
+            payload,
+            spec_path=Path("configs/models/binance_btc_1m.yaml"),
+        )
+
+
+def test_trainer_rejects_unknown_kind() -> None:
+    payload = {
+        "schema_version": "model_spec/v1",
+        "model_name": "bad_kind",
+        "task": "binary_classifier",
+        "label_column": "target",
+        "source": {"kind": "sklearn_demo", "dataset_name": "breast_cancer"},
+        "split": {"test_size": 0.2, "random_state": 42, "stratify": True},
+        "preprocessor": {"kind": "standard_scaler"},
+        "trainer": {"kind": "xgboost", "random_state": 42},
+        "evaluation": {
+            "metrics": ["accuracy", "f1", "roc_auc"],
+            "gate": {"metric": "roc_auc", "threshold": 0.5},
+        },
+    }
+
+    with pytest.raises(ValueError, match="kind must be one of"):
+        model_spec_from_dict(
+            payload,
+            spec_path=Path("configs/models/breast_cancer_demo.yaml"),
+        )
 
 
 def test_chronological_split_rejects_stratify() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1177,6 +1177,23 @@ wheels = [
 ]
 
 [[package]]
+name = "lightgbm"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/0b/a2e9f5c5da7ef047cc60cef37f86185088845e8433e54d2e7ed439cce8a3/lightgbm-4.6.0.tar.gz", hash = "sha256:cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe", size = 1703705, upload-time = "2025-02-15T04:03:03.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/75/cffc9962cca296bc5536896b7e65b4a7cdeb8db208e71b9c0133c08f8f7e/lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed", size = 2010151, upload-time = "2025-02-15T04:02:50.961Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/550ee378512b78847930f5d74228ca1fdba2a7fbdeaac9aeccc085b0e257/lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad", size = 1592172, upload-time = "2025-02-15T04:02:53.937Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
+    { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,6 +1361,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-auth" },
     { name = "joblib" },
+    { name = "lightgbm" },
     { name = "matplotlib" },
     { name = "mlflow" },
     { name = "numpy" },
@@ -1381,6 +1399,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-auth", specifier = ">=2.48.0" },
     { name = "joblib", specifier = ">=1.5.3" },
+    { name = "lightgbm", specifier = ">=4.5,<5.0" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "mlflow", specifier = ">=2.13,<3.0" },
     { name = "numpy", specifier = ">=2.4.1" },


### PR DESCRIPTION
## Summary
- Add `lightgbm` as a second `trainer.kind` alongside `logistic_regression`: new `LightGBMTrainerSpec`, a parser branch with its own allowed-field set, and an estimator branch in `train.py`.
- Point `configs/models/binance_btc_1m.yaml` at the lightgbm trainer (`n_estimators=200`, `learning_rate=0.05`, `num_leaves=15`, `max_depth=4`, `min_child_samples=20`, `class_weight=balanced`). The demo and CSV models stay on `logistic_regression`.
- Build the estimator single-threaded and deterministic (`n_jobs=1`, `deterministic=True`, `force_col_wise=True`, fixed seed) so the reproduce step replays probe predictions bit-for-bit.
- Keep `standard_scaler` in the pipeline (a per-feature monotonic transform is a no-op for tree splits) and keep `mlflow.sklearn.log_model` on the whole Pipeline, so serving and smoke are unchanged.
- Import `lightgbm` lazily so the logreg path and `make check` never load the native lib; add `lightgbm>=4.5,<5.0` and `libgomp1` (OpenMP runtime) to the platform/serving image so the native lib loads at import.

## Test plan
- [x] `make check` (162 passed; ruff + mypy clean)
- [x] `make e2e-clean` and `make e2e-binance` (Docker; operator-run) — proves lightgbm train→register→serve→smoke and the deterministic reproduce replay, and validates `libgomp1` in the image
- [x] Local non-Docker runs on macOS need a one-time `brew install libomp` (Linux/Docker is covered by `libgomp1`)

Closes #237