### PR TITLE
feat: add event-plane prediction and label contracts

### DIFF
--- a/docs/reference/release-contract.md
+++ b/docs/reference/release-contract.md
@@ -138,6 +138,63 @@ It is not the same as:
 - "which image is deployed?"
 - "which model alias is live?"
 
+## Event-plane contracts
+
+The event plane is the durable record of what the platform predicted and what
+actually happened. Drift, replay, and feedback all read from it. Two row-level
+Pydantic contracts define it; both carry ns-precision timestamps.
+
+These use a **bare-major envelope version** (`schema_version: "1"`), not the
+`name/vN` scheme the artifact contracts above use. The event plane is consumed
+by streaming and batch readers (BigQuery, DuckDB) where registry-style
+versioning does not apply.
+
+### Schema evolution
+
+- additive, optional fields → no version bump
+- any breaking change (rename, type change, new required field) → bump the
+  major (`"1"` → `"2"`)
+- a reader refuses an unknown major rather than guessing
+
+### PredictionEvent
+
+`contracts/prediction_event.py` — one prediction, with latency attribution.
+
+| Field | Type | Stability |
+| --- | --- | --- |
+| `schema_version` | `Literal["1"]` | stable; bumped only on a breaking change |
+| `event_id` | `UUID` | stable; the sink idempotency key |
+| `corr_id` | `str` | stable; join key to the labels table |
+| `event_time_ns` | `int` (ns, INT64) | stable |
+| `ingest_time_ns` | `int` (ns, INT64) | stable |
+| `model_ref` | `ModelRef` | stable; carries its own `model_ref/v1` version |
+| `features` | `dict[str, JsonValue]` | may columnar-break at tick volume (UP-29a) |
+| `prediction` | `JsonValue` | stable |
+| `latency_ns` | `int` (ns, INT64) | stable |
+| `envelope` | `EventEnvelope` | stable: `service`, `env`, `run_id`, `git_sha` |
+
+### LabelEvent and the labels table
+
+`contracts/label_event.py` — a delayed realized label plus the Pandera schema
+for the batch `labels` table that feedback capture (UP-34) joins against
+prediction events.
+
+- **join key**: `corr_id` (prediction events ⋈ labels); required and non-null
+  on both sides
+- **freshness SLO**: a label is expected within its source's natural lag; a
+  join is considered complete once that window has elapsed
+- **late-arrival policy**: labels arriving after the window are still ingested
+  and recompute the affected realized-performance rows; they never mutate the
+  original prediction event
+
+Realized-label sources for the three M4c models:
+
+| Model | Realized label | Lag |
+| --- | --- | --- |
+| Binance BTC 1m | next-bar return sign at bar close | ~1 bar |
+| Coinbase BTC 1m | next-bar return sign at bar close | ~1 bar |
+| Open-Meteo temp 1h | ERA5 realized temperature | ~2 days |
+
 ## What deploy workflows should consume
 
 Today and going forward:

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -13,6 +13,11 @@ MODEL_SPEC_SCHEMA_VERSION = "model_spec/v1"
 RELEASE_REPORT_SCHEMA_VERSION = "release_reports/v1"
 RUNTIME_EVENT_SCHEMA_VERSION = "runtime_event/v1"
 
+# Event-plane contracts use a bare-major envelope version (not the name/vN
+# scheme above): streaming/batch readers refuse an unknown major.
+PREDICTION_EVENT_SCHEMA_VERSION = "1"
+LABEL_EVENT_SCHEMA_VERSION = "1"
+
 # MLflow tag keys
 TAG_STEP = "step"
 TAG_MODEL_NAME = "model_name"

--- a/src/ml_lifecycle_platform/contracts/label_event.py
+++ b/src/ml_lifecycle_platform/contracts/label_event.py
@@ -1,0 +1,96 @@
+"""Pydantic + Pandera contracts for delayed realized labels.
+
+The row-level ``LabelEvent`` mirrors ``PredictionEvent``'s envelope
+conventions; ``labels_table_schema`` validates the batch ``labels`` table that
+feedback capture (UP-34) joins against prediction events on ``corr_id``.
+Contract-only: no ingestion job here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.errors import SchemaError, SchemaErrors
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+
+from ml_lifecycle_platform.common.constants import LABEL_EVENT_SCHEMA_VERSION
+
+# ns-since-epoch must fit a signed 64-bit column (BigQuery INT64, Parquet).
+_INT64_MAX = 2**63 - 1
+
+
+class LabelEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["1"] = "1"
+    event_id: UUID = Field(default_factory=uuid4)
+    corr_id: str
+    label_time_ns: int
+    label: JsonValue
+    source: str
+
+    @field_validator("corr_id", "source")
+    @classmethod
+    def _validate_non_empty(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must be a non-empty string")
+        return stripped
+
+    @field_validator("label_time_ns")
+    @classmethod
+    def _validate_ns(cls, value: int) -> int:
+        if value < 0 or value > _INT64_MAX:
+            raise ValueError(f"ns value out of signed 64-bit range: {value}")
+        return value
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> LabelEvent:
+        schema_version = str(payload.get("schema_version", ""))
+        if schema_version != LABEL_EVENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported LabelEvent schema_version={schema_version!r} "
+                f"(expected {LABEL_EVENT_SCHEMA_VERSION!r})"
+            )
+        return cls.model_validate(dict(payload))
+
+
+class LabelsTableValidationError(ValueError):
+    pass
+
+
+def labels_table_schema() -> pa.DataFrameSchema:
+    """Pandera schema for the batch ``labels`` table.
+
+    ``corr_id`` is the join key against prediction events. Every key column is
+    required and non-null, so a missing column or a bad join key fails loudly
+    before the feedback join (UP-34) runs.
+    """
+    return pa.DataFrameSchema(
+        columns={
+            "corr_id": pa.Column(str, required=True, nullable=False),
+            "event_id": pa.Column(str, required=True, nullable=False),
+            "label_time_ns": pa.Column(int, required=True, nullable=False),
+            "label": pa.Column(required=True, nullable=False),
+            "source": pa.Column(str, required=True, nullable=False),
+            "schema_version": pa.Column(str, required=True, nullable=False),
+        },
+        strict=False,
+        coerce=False,
+    )
+
+
+def validate_labels_table(df: pd.DataFrame) -> pd.DataFrame:
+    try:
+        return labels_table_schema().validate(df, lazy=True)
+    except (SchemaError, SchemaErrors) as error:
+        raise LabelsTableValidationError(
+            f"labels table failed contract validation: {error}"
+        ) from error

--- a/src/ml_lifecycle_platform/contracts/prediction_event.py
+++ b/src/ml_lifecycle_platform/contracts/prediction_event.py
@@ -1,0 +1,80 @@
+"""Pydantic contract for a single prediction emitted onto the event plane.
+
+The envelope carries ns-precision timestamps and latency attribution so the
+cold event sink (UP-29a), drift (UP-32), replay (UP-30), and feedback (UP-34)
+all read one stable schema. Contract-only: nothing emits this yet.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+
+from ml_lifecycle_platform.common.constants import PREDICTION_EVENT_SCHEMA_VERSION
+from ml_lifecycle_platform.contracts.model_ref import ModelRef
+
+# ns-since-epoch must fit a signed 64-bit column (BigQuery INT64, Parquet).
+_INT64_MAX = 2**63 - 1
+
+
+class EventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    service: str
+    env: Literal["local", "staging", "prod"]
+    run_id: str | None = None
+    git_sha: str | None = None
+
+
+class PredictionEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["1"] = "1"
+    event_id: UUID = Field(default_factory=uuid4)
+    corr_id: str
+    event_time_ns: int
+    ingest_time_ns: int
+    model_ref: ModelRef
+    features: dict[str, JsonValue]
+    prediction: JsonValue
+    latency_ns: int
+    envelope: EventEnvelope
+
+    @field_validator("corr_id")
+    @classmethod
+    def _validate_corr_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must be a non-empty string")
+        return stripped
+
+    @field_validator("event_time_ns", "ingest_time_ns", "latency_ns")
+    @classmethod
+    def _validate_ns(cls, value: int) -> int:
+        if value < 0 or value > _INT64_MAX:
+            raise ValueError(f"ns value out of signed 64-bit range: {value}")
+        return value
+
+    @property
+    def idempotency_key(self) -> str:
+        """Stable dedup key for the sink; survives serialisation round-trips."""
+        return str(self.event_id)
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> PredictionEvent:
+        schema_version = str(payload.get("schema_version", ""))
+        if schema_version != PREDICTION_EVENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported PredictionEvent schema_version={schema_version!r} "
+                f"(expected {PREDICTION_EVENT_SCHEMA_VERSION!r})"
+            )
+        data = dict(payload)
+        if "model_ref" in data:
+            data["model_ref"] = ModelRef.from_dict(data["model_ref"])
+        return cls.model_validate(data)

--- a/tests/unit/test_label_event.py
+++ b/tests/unit/test_label_event.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from ml_lifecycle_platform.contracts.label_event import (
+    LabelEvent,
+    LabelsTableValidationError,
+    validate_labels_table,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _label_event() -> LabelEvent:
+    return LabelEvent(
+        corr_id="req-1",
+        label_time_ns=1_700_000_000_000_000_000,
+        label=1,
+        source="binance_bar_close",
+    )
+
+
+def _labels_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "corr_id": ["req-1", "req-2"],
+            "event_id": ["evt-1", "evt-2"],
+            "label_time_ns": [
+                1_700_000_000_000_000_000,
+                1_700_000_000_000_000_001,
+            ],
+            "label": [1, 0],
+            "source": ["binance_bar_close", "binance_bar_close"],
+            "schema_version": ["1", "1"],
+        }
+    )
+
+
+def test_label_event_round_trips() -> None:
+    event = _label_event()
+    assert LabelEvent.from_dict(event.to_dict()) == event
+
+
+def test_label_event_rejects_empty_corr_id() -> None:
+    with pytest.raises(ValidationError):
+        LabelEvent(
+            corr_id="   ",
+            label_time_ns=1,
+            label=1,
+            source="binance_bar_close",
+        )
+
+
+def test_label_event_unknown_schema_version_refused() -> None:
+    payload = _label_event().to_dict()
+    payload["schema_version"] = "2"
+    with pytest.raises(ValueError, match="schema_version"):
+        LabelEvent.from_dict(payload)
+
+
+def test_labels_table_accepts_valid_frame() -> None:
+    assert len(validate_labels_table(_labels_df())) == 2
+
+
+def test_labels_table_rejects_null_join_key() -> None:
+    df = _labels_df()
+    df.loc[0, "corr_id"] = None
+    with pytest.raises(LabelsTableValidationError):
+        validate_labels_table(df)
+
+
+def test_labels_table_rejects_missing_column() -> None:
+    df = _labels_df().drop(columns=["label_time_ns"])
+    with pytest.raises(LabelsTableValidationError):
+        validate_labels_table(df)

--- a/tests/unit/test_prediction_event.py
+++ b/tests/unit/test_prediction_event.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import JsonValue, ValidationError
+
+from ml_lifecycle_platform.contracts.model_ref import ModelRef
+from ml_lifecycle_platform.contracts.prediction_event import (
+    EventEnvelope,
+    PredictionEvent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _event(
+    *,
+    corr_id: str = "req-1",
+    event_time_ns: int = 1_700_000_000_000_000_000,
+    ingest_time_ns: int = 1_700_000_000_000_000_100,
+    prediction: JsonValue = 1,
+    latency_ns: int = 4_200,
+) -> PredictionEvent:
+    return PredictionEvent(
+        corr_id=corr_id,
+        event_time_ns=event_time_ns,
+        ingest_time_ns=ingest_time_ns,
+        model_ref=ModelRef(model_name="binance_btc_1m", alias="prod"),
+        features={"ret_1": 0.5, "vol": 12.0},
+        prediction=prediction,
+        latency_ns=latency_ns,
+        envelope=EventEnvelope(service="serving", env="local"),
+    )
+
+
+def test_round_trips_through_dict() -> None:
+    event = _event()
+    restored = PredictionEvent.from_dict(event.to_dict())
+    assert restored == event
+    assert restored.model_ref == event.model_ref
+
+
+def test_forbids_unknown_fields() -> None:
+    payload = _event().to_dict()
+    payload["unexpected"] = "nope"
+    with pytest.raises(ValidationError):
+        PredictionEvent.from_dict(payload)
+
+
+def test_missing_required_field_rejected() -> None:
+    payload = _event().to_dict()
+    del payload["model_ref"]
+    with pytest.raises(ValidationError):
+        PredictionEvent.from_dict(payload)
+
+
+def test_empty_corr_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _event(corr_id="   ")
+
+
+def test_unknown_schema_version_refused() -> None:
+    payload = _event().to_dict()
+    payload["schema_version"] = "2"
+    with pytest.raises(ValueError, match="schema_version"):
+        PredictionEvent.from_dict(payload)
+
+
+def test_ns_overflow_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _event(event_time_ns=2**63)
+
+
+def test_idempotency_key_survives_round_trip() -> None:
+    event = _event()
+    restored = PredictionEvent.from_dict(event.to_dict())
+    assert restored.idempotency_key == event.idempotency_key
+    assert restored.event_id == event.event_id


### PR DESCRIPTION
## Summary

- Add `PredictionEvent` + `EventEnvelope` (`contracts/prediction_event.py`): ns-precision int64 timestamps, latency attribution, `model_ref`, `to_dict`/`from_dict` with a schema-version guard, and an `idempotency_key` for the sink.
- Add `LabelEvent` + the Pandera `labels` table schema (`contracts/label_event.py`) for delayed realized labels, joined on `corr_id`.
- Document the event plane in `docs/reference/release-contract.md`: bare-major envelope versioning + schema-evolution rule, per-field `PredictionEvent` stability table, labels join key / freshness SLO / late-arrival policy, and the three M4c realized-label sources.
- Contract-only — no sink, emitter, or ingestion job (those land in UP-29a / UP-34).

## Test plan

- [x] `make check` (format, lint, mypy on src + tests, 197 unit tests)
- [x] `make docs-check`
- [ ] `make e2e-clean` — not required; contract-only, touches none of pipeline/registry/serving/infra

Closes #198
Closes #205