### PR TITLE
feat: add multi-model spec-driven orchestration

### DIFF
--- a/docs/runbooks/local-bootstrap.md
+++ b/docs/runbooks/local-bootstrap.md
@@ -135,6 +135,20 @@ Starter CSV location:
 
 - [`examples/csv/local_csv_binary_classifier.csv`](../../examples/csv/local_csv_binary_classifier.csv)
 
+## Train multiple models
+
+The pipeline is spec-driven, so one command trains every spec in `configs/models/`:
+
+```bash
+uv run mlp --env local pipeline run --all
+uv run mlp --env local pipeline run --model binance_btc_1m
+```
+
+Each model is isolated in its own MLflow experiment (keyed on `model_name`), and
+`--all` continues past a single model's failure, then exits non-zero listing the
+models that failed. Serving stays one model per container; each instance exposes
+`/predict/<model_name>` and rejects any other name with a 404.
+
 ## Tear down
 
 ```bash

--- a/src/ml_lifecycle_platform/cli/main.py
+++ b/src/ml_lifecycle_platform/cli/main.py
@@ -196,16 +196,26 @@ def _handle_infra_build(args: argparse.Namespace, profile: RuntimeProfile) -> in
     return _run(_compose_cmd(profile, *command), _command_env(profile))
 
 
+def _pipeline_orchestrate_args(args: argparse.Namespace) -> list[str]:
+    if args.all:
+        return ["--all"]
+    if args.model:
+        return ["--model", args.model]
+    return []
+
+
 def _handle_pipeline_run(args: argparse.Namespace, profile: RuntimeProfile) -> int:
     env_overrides: dict[str, str] = {}
     if args.model_spec:
         env_overrides["MLP_MODEL_SPEC_PATH"] = args.model_spec
     env = _command_env(profile, env_overrides)
     _run(_compose_cmd(profile, "build", *SVC_IMAGES), env)
-    return _run(
-        _compose_cmd(profile, "run", "--rm", "--use-aliases", "pipeline"),
-        env,
-    )
+    command = _compose_cmd(profile, "run", "--rm", "--use-aliases", "pipeline")
+    orchestrate_args = _pipeline_orchestrate_args(args)
+    if orchestrate_args:
+        command += ["python", "-m", "ml_lifecycle_platform.pipeline.orchestrate"]
+        command += orchestrate_args
+    return _run(command, env)
 
 
 def _handle_registry_promote(args: argparse.Namespace, profile: RuntimeProfile) -> int:
@@ -373,6 +383,13 @@ def _build_parser() -> argparse.ArgumentParser:
     pipeline_sub = pipeline.add_subparsers(dest="pipeline_command", required=True)
     pipeline_run = pipeline_sub.add_parser("run", help="Run the local pipeline")
     pipeline_run.add_argument("--model-spec")
+    pipeline_selector = pipeline_run.add_mutually_exclusive_group()
+    pipeline_selector.add_argument("--model", help="Train one model by its model_name")
+    pipeline_selector.add_argument(
+        "--all",
+        action="store_true",
+        help="Train every spec in configs/models/",
+    )
     pipeline_run.set_defaults(handler=_handle_pipeline_run)
 
     registry = subparsers.add_parser("registry", help="Registry commands")

--- a/src/ml_lifecycle_platform/core/model_specs.py
+++ b/src/ml_lifecycle_platform/core/model_specs.py
@@ -588,3 +588,21 @@ def load_model_spec(path: str | Path) -> ModelSpec:
     spec_path = resolve_model_spec_path(path)
     payload = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
     return model_spec_from_dict(payload, spec_path=spec_path)
+
+
+def discover_model_specs(models_dir: str | Path = "configs/models") -> list[ModelSpec]:
+    """Load every ``*.yaml`` spec under ``models_dir``, sorted by file name."""
+    base = Path(models_dir)
+    if not base.is_absolute():
+        base = (REPO_ROOT / base).resolve()
+    return [load_model_spec(path) for path in sorted(base.glob("*.yaml"))]
+
+
+def resolve_spec_by_model_name(model_name: str) -> ModelSpec:
+    """Return the discovered spec whose ``model_name`` matches, else raise."""
+    for spec in discover_model_specs():
+        if spec.model_name == model_name:
+            return spec
+    raise ValueError(
+        f"No model spec with model_name={model_name!r} under configs/models/."
+    )

--- a/src/ml_lifecycle_platform/pipeline/orchestrate.py
+++ b/src/ml_lifecycle_platform/pipeline/orchestrate.py
@@ -1,7 +1,15 @@
 """Drive the local pipeline end-to-end by running ingest, featurize, train,
-evaluate, and register as child MLflow runs under a single parent run."""
+evaluate, and register as child MLflow runs under a single parent run.
+
+Without flags it trains the model selected by the active profile/env (the
+hosted jobs rely on this). ``--model <name>`` trains one discovered spec and
+``--all`` trains every spec in ``configs/models/``; both isolate each model in
+its own MLflow experiment and continue past a single model's failure."""
 
 from __future__ import annotations
+
+import argparse
+import os
 
 import mlflow
 import pandas as pd
@@ -12,10 +20,16 @@ from ml_lifecycle_platform.common.constants import (
     TAG_STEP,
 )
 from ml_lifecycle_platform.common.jobs import start_job
+from ml_lifecycle_platform.core.model_spec_types import ModelSpec
+from ml_lifecycle_platform.core.model_specs import (
+    discover_model_specs,
+    resolve_spec_by_model_name,
+)
 from ml_lifecycle_platform.runtime.mlflow import ensure_experiment
 from ml_lifecycle_platform.runtime.bootstrap import (
     configure_mlflow,
     get_runtime_context,
+    reset_runtime_context,
 )
 
 STEP_MODULES = {
@@ -57,32 +71,94 @@ def _latest_train_run_id(experiment_id: str) -> str:
     return str(runs.iloc[0]["run_id"])
 
 
-def main() -> None:
+def _run_one_model() -> None:
+    """Run the full pipeline for the model the active runtime points at.
+
+    Each model runs its complete ingest-through-register sequence before the
+    next one starts, so the shared artifacts dir is consumed before reuse.
+    """
+    runtime = get_runtime_context()
+    configure_mlflow(runtime)
+    ensure_experiment(runtime.experiment_name)
+    mlflow.set_experiment(runtime.experiment_name)
+    art_dir = runtime.artifacts_dir
+    art_dir.mkdir(parents=True, exist_ok=True)
+
+    _run_step("ingest")
+    _run_step("validate_data")
+    _run_step("featurize")
+    _run_step("train")
+
+    exp = mlflow.get_experiment_by_name(runtime.experiment_name)
+    assert exp is not None
+
+    train_run_id = _latest_train_run_id(exp.experiment_id)
+    (art_dir / ART_TRAIN_RUN_ID).write_text(str(train_run_id), encoding="utf-8")
+    print(f"[orchestrate] Captured {ART_TRAIN_RUN_ID}={train_run_id}")
+
+    _run_step("evaluate")
+    _run_step("validate_model")
+    _run_step("register")
+
+
+def _select_model(spec: ModelSpec) -> None:
+    """Point the runtime (and the step subprocesses) at one model spec.
+
+    The experiment is keyed on ``model_name`` so each model gets its own clean
+    run history and the train-run lookup stays scoped to that model.
+    """
+    os.environ["MLP_MODEL_SPEC_PATH"] = str(spec.spec_path)
+    os.environ["MODEL_NAME"] = spec.model_name
+    os.environ["EXPERIMENT_NAME"] = spec.model_name
+    reset_runtime_context()
+
+
+def _resolve_specs(args: argparse.Namespace) -> list[ModelSpec] | None:
+    """Return the specs to train, or ``None`` for the profile-selected model."""
+    if args.all:
+        specs = discover_model_specs()
+        if not specs:
+            raise SystemExit("No model specs found under configs/models/.")
+        return specs
+    if args.model:
+        return [resolve_spec_by_model_name(args.model)]
+    return None
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="orchestrate")
+    selector = parser.add_mutually_exclusive_group()
+    selector.add_argument("--model", help="Train one model by its model_name")
+    selector.add_argument(
+        "--all",
+        action="store_true",
+        help="Train every spec in configs/models/",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    specs = _resolve_specs(args)
     runtime = get_runtime_context()
     with start_job("pipeline", level=runtime.log_level):
-        configure_mlflow(runtime)
-        ensure_experiment(runtime.experiment_name)
-        mlflow.set_experiment(runtime.experiment_name)
-        art_dir = runtime.artifacts_dir
-        art_dir.mkdir(parents=True, exist_ok=True)
+        if specs is None:
+            _run_one_model()
+            print("[orchestrate] Pipeline complete.")
+            return
 
-        _run_step("ingest")
-        _run_step("validate_data")
-        _run_step("featurize")
-        _run_step("train")
-
-        exp = mlflow.get_experiment_by_name(runtime.experiment_name)
-        assert exp is not None
-
-        train_run_id = _latest_train_run_id(exp.experiment_id)
-        (art_dir / ART_TRAIN_RUN_ID).write_text(str(train_run_id), encoding="utf-8")
-        print(f"[orchestrate] Captured {ART_TRAIN_RUN_ID}={train_run_id}")
-
-        _run_step("evaluate")
-        _run_step("validate_model")
-        _run_step("register")
-
-        print("[orchestrate] Pipeline complete.")
+        failures: list[str] = []
+        for spec in specs:
+            print(f"[orchestrate] === model {spec.model_name} ===")
+            _select_model(spec)
+            try:
+                _run_one_model()
+            except Exception as error:  # isolate one model's failure
+                print(f"[orchestrate] model {spec.model_name} FAILED: {error}")
+                failures.append(spec.model_name)
+        if failures:
+            raise SystemExit("Pipeline failed for: " + ", ".join(failures))
+        print(f"[orchestrate] Pipeline complete for {len(specs)} model(s).")
 
 
 if __name__ == "__main__":

--- a/src/ml_lifecycle_platform/serving/app.py
+++ b/src/ml_lifecycle_platform/serving/app.py
@@ -204,6 +204,23 @@ def _feature_contract(settings: Settings) -> FeatureContractSpec:
     return _load_feature_contract(settings.model_name, settings.model_spec_path)
 
 
+def _require_served_model(model_name: str) -> None:
+    """404 unless ``model_name`` is the one this instance serves.
+
+    Per-model isolation: each container serves exactly one model, so the
+    self-describing ``/predict/<model_name>`` route rejects every other name.
+    """
+    settings = get_settings()
+    if model_name != settings.model_name:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"model {model_name!r} is not served by this instance "
+                f"(serving {settings.model_name!r})"
+            ),
+        )
+
+
 def _registry_resolves_prod_alias(settings: Settings) -> tuple[bool, str | None]:
     """Return whether the prod alias resolves."""
     if settings.unit_testing:
@@ -337,6 +354,18 @@ def metadata_schema() -> SchemaMetadataResponse:
             for feature in contract.features
         ],
     )
+
+
+@app.get("/metadata/model/{model_name}", response_model=ModelMetadataResponse)
+def metadata_model_for(model_name: str) -> ModelMetadataResponse:
+    _require_served_model(model_name)
+    return metadata_model()
+
+
+@app.get("/metadata/schema/{model_name}", response_model=SchemaMetadataResponse)
+def metadata_schema_for(model_name: str) -> SchemaMetadataResponse:
+    _require_served_model(model_name)
+    return metadata_schema()
 
 
 @app.post("/predict", response_model=PredictResponse)
@@ -474,3 +503,16 @@ async def predict(
             chosen=chosen_label,
             latency_s=latency_s,
         )
+
+
+@app.post("/predict/{model_name}", response_model=PredictResponse)
+async def predict_model(
+    model_name: str,
+    request: Request,
+    payload: PredictRequest,
+    response: Response,
+    mode: Mode = Query(default="prod", description="prod|candidate|shadow|canary"),
+) -> PredictResponse:
+    """Self-describing predict route; delegates once the model name matches."""
+    _require_served_model(model_name)
+    return await predict(request, payload, response, mode)

--- a/tests/unit/serving/tests/test_multi_model_routes.py
+++ b/tests/unit/serving/tests/test_multi_model_routes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_row() -> dict[str, float]:
+    return {
+        "mean_radius": 17.99,
+        "mean_texture": 10.38,
+        "mean_perimeter": 122.8,
+        "mean_area": 1001.0,
+        "mean_smoothness": 0.1184,
+    }
+
+
+def test_predict_path_param_matches_served_model(client: TestClient) -> None:
+    r = client.post("/predict/local_csv_binary_clf", json={"rows": [_valid_row()]})
+    assert r.status_code == 200, r.text
+    assert r.json()["n"] == 1
+
+
+def test_predict_path_param_unknown_model_404(client: TestClient) -> None:
+    r = client.post("/predict/not_this_model", json={"rows": [_valid_row()]})
+    assert r.status_code == 404, r.text
+
+
+def test_predict_alias_route_still_works(client: TestClient) -> None:
+    r = client.post("/predict", json={"rows": [_valid_row()]})
+    assert r.status_code == 200, r.text
+
+
+def test_metadata_model_path_param_ok(client: TestClient) -> None:
+    r = client.get("/metadata/model/local_csv_binary_clf")
+    assert r.status_code == 200, r.text
+    assert r.json()["model_name"] == "local_csv_binary_clf"
+
+
+def test_metadata_model_path_param_unknown_404(client: TestClient) -> None:
+    r = client.get("/metadata/model/nope")
+    assert r.status_code == 404, r.text
+
+
+def test_metadata_schema_path_param_ok(client: TestClient) -> None:
+    r = client.get("/metadata/schema/local_csv_binary_clf")
+    assert r.status_code == 200, r.text
+    assert r.json()["model_name"] == "local_csv_binary_clf"

--- a/tests/unit/test_orchestrate_multi_model.py
+++ b/tests/unit/test_orchestrate_multi_model.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from ml_lifecycle_platform.core.model_specs import (
+    discover_model_specs,
+    resolve_spec_by_model_name,
+)
+from ml_lifecycle_platform.pipeline import orchestrate
+from ml_lifecycle_platform.runtime.bootstrap import reset_runtime_context
+
+pytestmark = pytest.mark.unit
+
+_MODEL_ENV_KEYS = ("MLP_MODEL_SPEC_PATH", "MODEL_NAME", "EXPERIMENT_NAME")
+
+
+@pytest.fixture(autouse=True)
+def _restore_runtime() -> Iterator[None]:
+    original = {key: os.environ.get(key) for key in _MODEL_ENV_KEYS}
+    try:
+        yield
+    finally:
+        for key, value in original.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        reset_runtime_context()
+
+
+def _discovered_names() -> set[str]:
+    return {spec.model_name for spec in discover_model_specs()}
+
+
+def test_discover_finds_all_specs() -> None:
+    assert {
+        "binance_btc_1m",
+        "breast_cancer_clf",
+        "local_csv_binary_clf",
+    } <= _discovered_names()
+
+
+def test_resolve_by_model_name_hits_and_misses() -> None:
+    assert resolve_spec_by_model_name("binance_btc_1m").model_name == "binance_btc_1m"
+    with pytest.raises(ValueError, match="No model spec"):
+        resolve_spec_by_model_name("does_not_exist")
+
+
+def test_all_runs_every_model_with_isolated_experiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, str]] = []
+
+    def _fake_run_one_model() -> None:
+        seen.append((os.environ["MODEL_NAME"], os.environ["EXPERIMENT_NAME"]))
+
+    monkeypatch.setattr(orchestrate, "_run_one_model", _fake_run_one_model)
+    orchestrate.main(["--all"])
+
+    assert {name for name, _ in seen} == _discovered_names()
+    # experiment is keyed on model name, so each model gets a clean history
+    assert all(name == experiment for name, experiment in seen)
+
+
+def test_failure_is_isolated_and_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempted: list[str] = []
+
+    def _fake_run_one_model() -> None:
+        name = os.environ["MODEL_NAME"]
+        attempted.append(name)
+        if name == "binance_btc_1m":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(orchestrate, "_run_one_model", _fake_run_one_model)
+    with pytest.raises(SystemExit, match="binance_btc_1m"):
+        orchestrate.main(["--all"])
+
+    # every model is attempted despite one failing
+    assert set(attempted) == _discovered_names()
+
+
+def test_model_flag_runs_single_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def _fake_run_one_model() -> None:
+        seen.append(os.environ["MODEL_NAME"])
+
+    monkeypatch.setattr(orchestrate, "_run_one_model", _fake_run_one_model)
+    orchestrate.main(["--model", "binance_btc_1m"])
+
+    assert seen == ["binance_btc_1m"]
+
+
+def test_no_flags_runs_profile_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def _fake_run_one_model() -> None:
+        calls.append(1)
+
+    monkeypatch.setattr(orchestrate, "_run_one_model", _fake_run_one_model)
+    orchestrate.main([])
+
+    assert calls == [1]

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "ml-lifecycle-platform"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Orchestrator gains `--model <name>` and `--all`: `--all` trains every spec in `configs/models/`, each isolated in its own MLflow experiment (keyed on `model_name`) with a clean run history.
- `--all` runs each model's full ingest→register sequence and continues past a single model's failure, then exits non-zero listing the failed models.
- No flags keeps the current profile-selected behaviour, so the hosted per-model jobs are unchanged.
- Add `discover_model_specs()` / `resolve_spec_by_model_name()` spec helpers.
- CLI `mlp pipeline run --model/--all` forwards the selection into the container.
- Serving exposes `/predict/<model_name>`, `/metadata/model/<name>`, `/metadata/schema/<name>`, each 404ing unless the name matches the container's model; `/predict` stays as a back-compat alias. One model per container — no dynamic registry (per the issue's non-goals).

## Test plan

- [x] `make check` (format, lint, mypy, 209 unit tests incl. 12 new)
- [x] `make docs-check`
- [x] `make e2e-clean` (required — touches pipeline + serving)

Closes #202