### PR TITLE
fix: grant CI service account BigQuery admin for event plane

### DIFF
--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -121,6 +121,15 @@ resource "google_project_iam_member" "ci_staging_scheduler_admin" {
   member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
+# CI provisions the event-plane dataset and table during deploy, which needs
+# project-level bigquery.datasets.create (dataEditor on the dataset is not
+# enough and cannot exist before the dataset does). Apply with owner creds.
+resource "google_project_iam_member" "ci_staging_bigquery_admin" {
+  project = data.google_project.current.project_id
+  role    = "roles/bigquery.admin"
+  member  = "serviceAccount:${google_service_account.ci_staging.email}"
+}
+
 resource "google_storage_bucket_iam_member" "ci_staging_foundation_bucket_admin" {
   for_each = google_storage_bucket.foundation
 


### PR DESCRIPTION
## Summary

- Grant `mlp-ci-staging` `roles/bigquery.admin` at the project level so the staging deploy can create the `mlp_events` dataset, `prediction_events_v1` table, and their IAM bindings.
- Fixes the failed staging CD: `Error 403: ... does not have bigquery.datasets.create permission` on `google_bigquery_dataset.events`.

## Rollout

This binding must be applied with owner credentials before the deploy CD can succeed — CI cannot grant itself project IAM:

\`\`\`
terraform -chdir=deployments/gcp/terraform apply -target=google_project_iam_member.ci_staging_bigquery_admin
\`\`\`

## Test plan

- [x] \`make terraform-gcp-fmt\` and \`terraform validate\`
- [x] owner-applied the targeted binding
- [ ] staging deploy re-run is green and \`mlp_events.prediction_events_v1\` exists

Refs #203