### PR TITLE
feat: add release-linked drift baselines

### DIFF
--- a/docs/reference/release-contract.md
+++ b/docs/reference/release-contract.md
@@ -138,6 +138,27 @@ It is not the same as:
 - "which image is deployed?"
 - "which model alias is live?"
 
+## Drift baseline
+
+Every promotion computes a `DriftBaseline` from the model's training split
+(`repro/inputs/train.csv` on the source run) and attaches it to release
+evidence. The `release_manifest.json` carries a `baseline_ref` pointing at the
+`drift_baseline.json` artifact under the same release-evidence root.
+
+The baseline is the statistical fingerprint of the data the model was trained
+on, so a production release can be compared against live traffic later:
+
+- per column: `count`, `null_rate`, `mean`, `std`, `min`, `max`, plus a quantile
+  grid (p0…p100 by 5)
+- the quantile grid lets batch drift (UP-32) reconstruct a step-CDF for a KS
+  test; `mean`/`std` drive a cheaper mean/std delta
+- **stat-test choice for v1: KS + mean/std delta** per feature
+- a missing or unreadable training split degrades to no baseline rather than
+  failing the promotion
+
+Inspect it with `mlp registry show-baseline --model-version <v>` (or `--alias`).
+A Pandera schema validates the per-column summary table before it is written.
+
 ## Event-plane contracts
 
 The event plane is the durable record of what the platform predicted and what

--- a/src/ml_lifecycle_platform/cli/main.py
+++ b/src/ml_lifecycle_platform/cli/main.py
@@ -274,6 +274,28 @@ def _handle_registry_reproduce(
     return _run(command, _command_env(profile, env_overrides))
 
 
+def _handle_registry_show_baseline(
+    args: argparse.Namespace, profile: RuntimeProfile
+) -> int:
+    env_overrides: dict[str, str] = {}
+    if args.model_name:
+        env_overrides["MODEL_NAME"] = args.model_name
+
+    command = _python_module_cmd(
+        "ml_lifecycle_platform.registry.show_baseline",
+        "--format",
+        args.format,
+    )
+    if args.model_name:
+        command.extend(["--model-name", args.model_name])
+    if args.model_version:
+        command.extend(["--model-version", args.model_version])
+    elif args.alias:
+        command.extend(["--alias", args.alias])
+
+    return _run(command, _command_env(profile, env_overrides))
+
+
 def _handle_serve_api(args: argparse.Namespace, profile: RuntimeProfile) -> int:
     env_overrides: dict[str, str] = {}
     if args.model_name:
@@ -414,6 +436,19 @@ def _build_parser() -> argparse.ArgumentParser:
         "--format", choices=["json", "text"], default="json"
     )
     registry_reproduce.set_defaults(handler=_handle_registry_reproduce)
+    registry_show_baseline = registry_sub.add_parser(
+        "show-baseline", help="Show the drift baseline for a model version"
+    )
+    registry_show_baseline.add_argument("--model-name")
+    baseline_selector = registry_show_baseline.add_mutually_exclusive_group(
+        required=True
+    )
+    baseline_selector.add_argument("--model-version")
+    baseline_selector.add_argument("--alias")
+    registry_show_baseline.add_argument(
+        "--format", choices=["json", "text"], default="json"
+    )
+    registry_show_baseline.set_defaults(handler=_handle_registry_show_baseline)
 
     serve = subparsers.add_parser("serve", help="Serving commands")
     serve_sub = serve.add_subparsers(dest="serve_command", required=True)

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -11,6 +11,7 @@ FEATURE_STATS_SCHEMA_VERSION = "feature_stats/v1"
 REPRO_CONTRACT_SCHEMA_VERSION = "repro_contract/v1"
 MODEL_SPEC_SCHEMA_VERSION = "model_spec/v1"
 RELEASE_REPORT_SCHEMA_VERSION = "release_reports/v1"
+DRIFT_BASELINE_SCHEMA_VERSION = "drift_baseline/v1"
 RUNTIME_EVENT_SCHEMA_VERSION = "runtime_event/v1"
 
 # Event-plane contracts use a bare-major envelope version (not the name/vN
@@ -83,6 +84,7 @@ ART_PROMOTION_DECISION_JSON = "promotion_decision.json"
 ART_RELEASE_MANIFEST_JSON = "release_manifest.json"
 ART_ROLLBACK_TARGET_JSON = "rollback_target.json"
 ART_MODEL_CARD_MD = "model_card.md"
+ART_DRIFT_BASELINE_JSON = "drift_baseline.json"
 
 # Artifact paths inside MLflow
 MLFLOW_ARTIFACT_PATH_REPORTS = "reports"

--- a/src/ml_lifecycle_platform/contracts/drift_baseline.py
+++ b/src/ml_lifecycle_platform/contracts/drift_baseline.py
@@ -1,0 +1,161 @@
+"""Schema-versioned ``DriftBaseline`` artifact — the statistical fingerprint of
+the data a model was trained on, computed at promotion and attached to release
+evidence (UP-31). Batch drift (UP-32) compares live event windows against it.
+
+Per column it stores summary stats (count, null-rate, mean, std, min, max) and
+a quantile grid. The quantiles let the drift job reconstruct a step-CDF for a
+KS comparison; mean/std drive a cheaper mean/std delta. A Pandera schema
+validates the summary table.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.errors import SchemaError, SchemaErrors
+
+from ml_lifecycle_platform.common.constants import DRIFT_BASELINE_SCHEMA_VERSION
+
+# p0, p5, ..., p100 — enough to reconstruct a step-CDF for a KS comparison.
+DEFAULT_QUANTILE_GRID: tuple[float, ...] = tuple(round(i / 20, 2) for i in range(21))
+
+_SUMMARY_KEYS = ("count", "null_rate", "mean", "std", "min", "max")
+
+
+@dataclass(frozen=True)
+class ColumnStats:
+    count: int
+    null_rate: float
+    mean: float
+    std: float
+    min: float
+    max: float
+    quantiles: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "count": self.count,
+            "null_rate": self.null_rate,
+            "mean": self.mean,
+            "std": self.std,
+            "min": self.min,
+            "max": self.max,
+            "quantiles": dict(self.quantiles),
+        }
+
+    @staticmethod
+    def from_dict(payload: Mapping[str, Any]) -> ColumnStats:
+        return ColumnStats(
+            count=int(payload["count"]),
+            null_rate=float(payload["null_rate"]),
+            mean=float(payload["mean"]),
+            std=float(payload["std"]),
+            min=float(payload["min"]),
+            max=float(payload["max"]),
+            quantiles={str(k): float(v) for k, v in payload["quantiles"].items()},
+        )
+
+
+@dataclass(frozen=True)
+class DriftBaseline:
+    model_name: str
+    model_version: str
+    source_run_id: str
+    created_at: str
+    columns: dict[str, ColumnStats]
+    quantile_grid: tuple[float, ...] = DEFAULT_QUANTILE_GRID
+    schema_version: str = DRIFT_BASELINE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_name": self.model_name,
+            "model_version": self.model_version,
+            "source_run_id": self.source_run_id,
+            "created_at": self.created_at,
+            "quantile_grid": list(self.quantile_grid),
+            "columns": {name: stats.to_dict() for name, stats in self.columns.items()},
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    def to_table(self) -> pd.DataFrame:
+        """Flatten the per-column summary stats into a validatable table."""
+        rows = [
+            {"column": name, **{key: getattr(stats, key) for key in _SUMMARY_KEYS}}
+            for name, stats in self.columns.items()
+        ]
+        return pd.DataFrame(rows, columns=["column", *_SUMMARY_KEYS])
+
+    @staticmethod
+    def from_dict(payload: Mapping[str, Any]) -> DriftBaseline:
+        schema_version = str(payload.get("schema_version", ""))
+        if schema_version != DRIFT_BASELINE_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported DriftBaseline schema_version={schema_version!r} "
+                f"(expected {DRIFT_BASELINE_SCHEMA_VERSION!r})"
+            )
+        raw_columns = payload.get("columns")
+        if not isinstance(raw_columns, dict):
+            raise TypeError("DriftBaseline.columns must be a dict")
+        grid = payload.get("quantile_grid", list(DEFAULT_QUANTILE_GRID))
+        return DriftBaseline(
+            model_name=str(payload["model_name"]),
+            model_version=str(payload["model_version"]),
+            source_run_id=str(payload["source_run_id"]),
+            created_at=str(payload["created_at"]),
+            columns={
+                str(name): ColumnStats.from_dict(stats)
+                for name, stats in raw_columns.items()
+            },
+            quantile_grid=tuple(float(q) for q in grid),
+        )
+
+    @staticmethod
+    def from_json(payload: str) -> DriftBaseline:
+        return DriftBaseline.from_dict(json.loads(payload))
+
+
+class DriftBaselineValidationError(ValueError):
+    pass
+
+
+def drift_baseline_table_schema() -> pa.DataFrameSchema:
+    """Pandera schema for the per-column summary table."""
+    return pa.DataFrameSchema(
+        columns={
+            "column": pa.Column(str, required=True, nullable=False, unique=True),
+            "count": pa.Column(int, pa.Check.ge(0), required=True, nullable=False),
+            "null_rate": pa.Column(
+                float, pa.Check.in_range(0.0, 1.0), required=True, nullable=False
+            ),
+            "mean": pa.Column(float, required=True, nullable=False),
+            "std": pa.Column(float, pa.Check.ge(0.0), required=True, nullable=False),
+            "min": pa.Column(float, required=True, nullable=False),
+            "max": pa.Column(float, required=True, nullable=False),
+        },
+        strict=False,
+        coerce=False,
+    )
+
+
+def validate_drift_baseline(baseline: DriftBaseline) -> DriftBaseline:
+    """Validate the baseline's summary table; raise on a schema violation."""
+    try:
+        drift_baseline_table_schema().validate(baseline.to_table(), lazy=True)
+    except (SchemaError, SchemaErrors) as error:
+        raise DriftBaselineValidationError(
+            f"drift baseline failed contract validation: {error}"
+        ) from error
+    return baseline
+
+
+def quantile_keys(grid: Sequence[float]) -> list[str]:
+    """Stable string keys for a quantile grid (matches ``ColumnStats.quantiles``)."""
+    return [f"{q:.2f}" for q in grid]

--- a/src/ml_lifecycle_platform/contracts/release_reports.py
+++ b/src/ml_lifecycle_platform/contracts/release_reports.py
@@ -9,12 +9,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ml_lifecycle_platform.common.constants import (
+    ART_DRIFT_BASELINE_JSON,
     ART_MODEL_CARD_MD,
     ART_PROMOTION_DECISION_JSON,
     ART_RELEASE_MANIFEST_JSON,
     ART_ROLLBACK_TARGET_JSON,
     RELEASE_REPORT_SCHEMA_VERSION,
 )
+from ml_lifecycle_platform.contracts.drift_baseline import DriftBaseline
 from ml_lifecycle_platform.policy.policy_engine import PolicyDecision
 
 
@@ -120,6 +122,7 @@ class ReleaseManifest:
     policy_outcome: PolicyOutcome
     result: OperationResult
     metrics: dict[str, float] = field(default_factory=dict)
+    baseline_ref: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -137,6 +140,7 @@ class ReleaseManifest:
             "policy_outcome": self.policy_outcome.to_dict(),
             "result": self.result.to_dict(),
             "metrics": dict(self.metrics),
+            "baseline_ref": self.baseline_ref,
         }
 
     @classmethod
@@ -167,6 +171,7 @@ class ReleaseManifest:
             policy_outcome=_parse_policy_outcome(policy),
             result=_parse_operation_result(result),
             metrics={str(key): float(value) for key, value in metrics.items()},
+            baseline_ref=_optional_str(raw.get("baseline_ref")),
         )
 
 
@@ -205,9 +210,10 @@ class ReleaseReportBundle:
     manifest: ReleaseManifest
     rollback_target: RollbackTargetReport
     model_card: str
+    drift_baseline: DriftBaseline | None = None
 
     def file_contents(self) -> dict[str, bytes]:
-        return {
+        contents = {
             ART_PROMOTION_DECISION_JSON: json.dumps(
                 self.decision.to_dict(), indent=2, sort_keys=True
             ).encode("utf-8"),
@@ -219,6 +225,11 @@ class ReleaseReportBundle:
             ).encode("utf-8"),
             ART_MODEL_CARD_MD: self.model_card.encode("utf-8"),
         }
+        if self.drift_baseline is not None:
+            contents[ART_DRIFT_BASELINE_JSON] = self.drift_baseline.to_json().encode(
+                "utf-8"
+            )
+        return contents
 
 
 def render_model_card(bundle: ReleaseReportBundle) -> str:

--- a/src/ml_lifecycle_platform/registry/drift_baseline.py
+++ b/src/ml_lifecycle_platform/registry/drift_baseline.py
@@ -1,0 +1,114 @@
+"""Compute a ``DriftBaseline`` from a model's training split at promotion time
+(UP-31). The split is the ``repro/inputs/train.csv`` artifact already logged by
+the training run; a missing or unreadable split degrades to no baseline rather
+than failing the promotion."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+
+import pandas as pd
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+
+from ml_lifecycle_platform.common.constants import (
+    MLFLOW_ARTIFACT_PATH_REPRO,
+    TRAIN_CSV,
+)
+from ml_lifecycle_platform.contracts.drift_baseline import (
+    DEFAULT_QUANTILE_GRID,
+    ColumnStats,
+    DriftBaseline,
+    quantile_keys,
+    validate_drift_baseline,
+)
+
+logger = logging.getLogger(__name__)
+
+TRAIN_SPLIT_ARTIFACT = f"{MLFLOW_ARTIFACT_PATH_REPRO}/inputs/{TRAIN_CSV}"
+
+
+def compute_drift_baseline(
+    df: pd.DataFrame,
+    *,
+    model_name: str,
+    model_version: str,
+    source_run_id: str,
+    created_at: str,
+    quantile_grid: tuple[float, ...] = DEFAULT_QUANTILE_GRID,
+) -> DriftBaseline:
+    """Per-column summary stats + quantile grid over the training split.
+
+    Non-numeric or all-null columns are skipped (drift compares numeric
+    feature distributions). The label column is included like any other column;
+    the drift job only compares columns that also appear in live events.
+    """
+    keys = quantile_keys(quantile_grid)
+    columns: dict[str, ColumnStats] = {}
+    for name in df.columns:
+        series = pd.to_numeric(df[name], errors="coerce")
+        total = int(len(series))
+        non_null = series.dropna()
+        if total == 0 or non_null.empty:
+            continue
+        quantile_values = non_null.quantile(list(quantile_grid))
+        columns[str(name)] = ColumnStats(
+            count=total,
+            null_rate=float(series.isna().mean()),
+            mean=float(non_null.mean()),
+            std=float(non_null.std(ddof=0)),
+            min=float(non_null.min()),
+            max=float(non_null.max()),
+            quantiles={
+                key: float(quantile_values.iloc[index])
+                for index, key in enumerate(keys)
+            },
+        )
+    baseline = DriftBaseline(
+        model_name=model_name,
+        model_version=model_version,
+        source_run_id=source_run_id,
+        created_at=created_at,
+        columns=columns,
+        quantile_grid=tuple(quantile_grid),
+    )
+    return validate_drift_baseline(baseline)
+
+
+def baseline_from_source_run(
+    client: MlflowClient,
+    *,
+    source_run_id: str,
+    model_name: str,
+    model_version: str,
+    created_at: str,
+) -> DriftBaseline | None:
+    """Download the training split from the source run and compute a baseline.
+
+    Returns ``None`` (with a warning) if the split is unavailable — a missing
+    baseline must never break a promotion.
+    """
+    try:
+        with tempfile.TemporaryDirectory(prefix="drift-baseline-") as tmpdir:
+            local = client.download_artifacts(
+                run_id=source_run_id,
+                path=TRAIN_SPLIT_ARTIFACT,
+                dst_path=tmpdir,
+            )
+            df = pd.read_csv(local)
+        return compute_drift_baseline(
+            df,
+            model_name=model_name,
+            model_version=model_version,
+            source_run_id=source_run_id,
+            created_at=created_at,
+        )
+    except (MlflowException, OSError, ValueError) as exc:
+        logger.warning(
+            "Could not compute drift baseline for %s v%s: %s",
+            model_name,
+            model_version,
+            exc,
+        )
+        return None

--- a/src/ml_lifecycle_platform/registry/promote.py
+++ b/src/ml_lifecycle_platform/registry/promote.py
@@ -20,6 +20,7 @@ from ml_lifecycle_platform.common.constants import (
     ALIAS_CANDIDATE,
     ALIAS_CHAMPION,
     ALIAS_PROD,
+    ART_DRIFT_BASELINE_JSON,
     RELEASE_STATUS_PREVIOUS_PROD,
     TAG_CONFIG_HASH,
     TAG_DATASET_FINGERPRINT,
@@ -45,8 +46,12 @@ from ml_lifecycle_platform.policy.policy_engine import (
     PolicyDecision,
     evaluate_promotion_policy,
 )
+from ml_lifecycle_platform.registry.drift_baseline import baseline_from_source_run
 from ml_lifecycle_platform.registry.metrics import record_release
-from ml_lifecycle_platform.registry.release_evidence import emit_release_evidence
+from ml_lifecycle_platform.registry.release_evidence import (
+    artifact_root,
+    emit_release_evidence,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +262,18 @@ def _build_promotion_bundle(
             "to_alias": str(decision.context.get("to_alias", "")),
         },
     )
+    drift_baseline = baseline_from_source_run(
+        client,
+        source_run_id=source_run_id,
+        model_name=model_name,
+        model_version=candidate_version,
+        created_at=generated_at,
+    )
+    baseline_ref = (
+        f"{artifact_root(operation='promote', model_name=model_name, model_version=candidate_version)}/{ART_DRIFT_BASELINE_JSON}"
+        if drift_baseline is not None
+        else None
+    )
     manifest = ReleaseManifest(
         generated_at=generated_at,
         operation="promote",
@@ -272,6 +289,7 @@ def _build_promotion_bundle(
         policy_outcome=policy_outcome,
         result=result,
         metrics=_source_run_metrics(client, source_run_id),
+        baseline_ref=baseline_ref,
     )
     bundle = ReleaseReportBundle(
         decision=PromotionDecisionReport(
@@ -308,6 +326,7 @@ def _build_promotion_bundle(
         manifest=bundle.manifest,
         rollback_target=bundle.rollback_target,
         model_card=render_model_card(bundle),
+        drift_baseline=drift_baseline,
     )
 
 

--- a/src/ml_lifecycle_platform/registry/show_baseline.py
+++ b/src/ml_lifecycle_platform/registry/show_baseline.py
@@ -1,0 +1,104 @@
+"""CLI: print the ``DriftBaseline`` attached to a model version's release
+evidence (UP-31). Resolves the version (or alias), finds the release-evidence
+root tagged on the version, and downloads ``drift_baseline.json``."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+
+from ml_lifecycle_platform.common.constants import (
+    ART_DRIFT_BASELINE_JSON,
+    TAG_RELEASE_REPORTS_PATH,
+    TAG_SOURCE_RUN_ID,
+)
+from ml_lifecycle_platform.contracts.drift_baseline import DriftBaseline
+from ml_lifecycle_platform.runtime.bootstrap import (
+    configure_mlflow,
+    get_runtime_context,
+)
+from ml_lifecycle_platform.runtime.mlflow import client as mlflow_client
+
+_SUMMARY_HEADER = (
+    f"{'column':<24} {'count':>8} {'null_rate':>10} {'mean':>12} {'std':>12}"
+)
+
+
+def _resolve_version(
+    client: MlflowClient,
+    model_name: str,
+    *,
+    version: str | None,
+    alias: str | None,
+) -> str:
+    if version:
+        return version
+    model_version = client.get_model_version_by_alias(model_name, str(alias))
+    return str(model_version.version)
+
+
+def load_baseline(
+    client: MlflowClient, *, model_name: str, version: str
+) -> DriftBaseline:
+    model_version = client.get_model_version(model_name, version)
+    tags = model_version.tags or {}
+    root = str(tags.get(TAG_RELEASE_REPORTS_PATH, "")).strip()
+    source_run_id = str(tags.get(TAG_SOURCE_RUN_ID, "")).strip()
+    if not root or not source_run_id:
+        raise SystemExit(f"No release evidence found for {model_name} v{version}.")
+    baseline_path = f"{root}/{ART_DRIFT_BASELINE_JSON}"
+    with tempfile.TemporaryDirectory(prefix="show-baseline-") as tmpdir:
+        try:
+            local = client.download_artifacts(
+                run_id=source_run_id, path=baseline_path, dst_path=tmpdir
+            )
+        except MlflowException as exc:
+            raise SystemExit(
+                f"No drift baseline at {baseline_path} for {model_name} v{version}: {exc}"
+            ) from exc
+        return DriftBaseline.from_json(Path(local).read_text(encoding="utf-8"))
+
+
+def render_text(baseline: DriftBaseline) -> str:
+    lines = [
+        f"DriftBaseline {baseline.model_name} v{baseline.model_version}",
+        f"  source_run_id: {baseline.source_run_id}",
+        f"  created_at:    {baseline.created_at}",
+        f"  columns:       {len(baseline.columns)}",
+        "",
+        _SUMMARY_HEADER,
+    ]
+    for name, stats in sorted(baseline.columns.items()):
+        lines.append(
+            f"{name:<24} {stats.count:>8} {stats.null_rate:>10.4f} "
+            f"{stats.mean:>12.4f} {stats.std:>12.4f}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="show-baseline")
+    parser.add_argument("--model-name")
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--model-version")
+    selector.add_argument("--alias")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    args = parser.parse_args(argv)
+
+    runtime = get_runtime_context()
+    configure_mlflow(runtime)
+    client = mlflow_client()
+    model_name = args.model_name or runtime.model_name
+    version = _resolve_version(
+        client, model_name, version=args.model_version, alias=args.alias
+    )
+    baseline = load_baseline(client, model_name=model_name, version=version)
+    print(baseline.to_json() if args.format == "json" else render_text(baseline))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_drift_baseline.py
+++ b/tests/unit/test_drift_baseline.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ml_lifecycle_platform.contracts.drift_baseline import (
+    ColumnStats,
+    DriftBaseline,
+    DriftBaselineValidationError,
+    validate_drift_baseline,
+)
+from ml_lifecycle_platform.registry.drift_baseline import compute_drift_baseline
+
+pytestmark = pytest.mark.unit
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "f1": [0.0, 1.0, 2.0, 3.0, 4.0],
+            "f2": [10.0, 10.0, 10.0, 10.0, 10.0],
+            "label": [0, 1, 0, 1, 1],
+        }
+    )
+
+
+def _baseline() -> DriftBaseline:
+    return compute_drift_baseline(
+        _frame(),
+        model_name="m",
+        model_version="1",
+        source_run_id="run-1",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+def test_compute_baseline_stats() -> None:
+    baseline = _baseline()
+    assert set(baseline.columns) == {"f1", "f2", "label"}
+    f1 = baseline.columns["f1"]
+    assert f1.count == 5
+    assert f1.null_rate == 0.0
+    assert f1.mean == pytest.approx(2.0)
+    assert f1.min == 0.0
+    assert f1.max == 4.0
+    assert f1.quantiles["0.50"] == pytest.approx(2.0)
+    # constant column has zero population std
+    assert baseline.columns["f2"].std == 0.0
+
+
+def test_baseline_round_trips() -> None:
+    baseline = _baseline()
+    assert DriftBaseline.from_dict(baseline.to_dict()) == baseline
+
+
+def test_unknown_schema_version_rejected() -> None:
+    payload = _baseline().to_dict()
+    payload["schema_version"] = "drift_baseline/v2"
+    with pytest.raises(ValueError, match="schema_version"):
+        DriftBaseline.from_dict(payload)
+
+
+def test_skips_non_numeric_columns() -> None:
+    df = pd.DataFrame({"f1": [1.0, 2.0], "name": ["a", "b"]})
+    baseline = compute_drift_baseline(
+        df, model_name="m", model_version="1", source_run_id="r", created_at="t"
+    )
+    assert "name" not in baseline.columns
+    assert "f1" in baseline.columns
+
+
+def test_validation_rejects_bad_null_rate() -> None:
+    bad = DriftBaseline(
+        model_name="m",
+        model_version="1",
+        source_run_id="r",
+        created_at="t",
+        columns={
+            "f1": ColumnStats(
+                count=5,
+                null_rate=1.5,
+                mean=0.0,
+                std=0.0,
+                min=0.0,
+                max=0.0,
+                quantiles={},
+            )
+        },
+    )
+    with pytest.raises(DriftBaselineValidationError):
+        validate_drift_baseline(bad)


### PR DESCRIPTION
## Summary

- Add the `DriftBaseline` contract: per-column `count`, `null_rate`, `mean`, `std`, `min`, `max` plus a p0…p100-by-5 quantile grid, with a Pandera schema over the summary table.
- Compute it at promotion from the candidate's `repro/inputs/train.csv` and write `drift_baseline.json` into the existing release-evidence path; add `baseline_ref` to `release_manifest.json`.
- A missing/unreadable training split degrades to no baseline rather than failing the promotion.
- Add `mlp registry show-baseline --model-version|--alias`.
- Document the KS + mean/std v1 stat-test choice in `docs/reference/release-contract.md`.

## Test plan

- [x] `make check` (230 unit tests incl. 5 new, mypy, lint)
- [x] `make docs-check`
- [x] `make e2e-clean` — required; promotion now computes the baseline, so e2e confirms `drift_baseline.json` is written
- [ ] `mlp registry show-baseline` against the promoted local model

Closes #206