### PR TITLE
feat: add batch drift MVP against windowed events

### DIFF
--- a/.github/workflows/run-platform-job-staging.yml
+++ b/.github/workflows/run-platform-job-staging.yml
@@ -24,6 +24,7 @@ on:
           - rollback
           - pipeline
           - pipeline-binance
+          - drift
       execution_mode:
         description: Safe execution mode for the selected job.
         required: true
@@ -103,7 +104,7 @@ jobs:
           job_args_csv=""
 
           case "${JOB_NAME_INPUT}:${EXECUTION_MODE_INPUT}" in
-            maintenance:default|reproduce:default|pipeline:default|pipeline-binance:default)
+            maintenance:default|reproduce:default|pipeline:default|pipeline-binance:default|drift:default)
               ;;
             promote:default)
               job_args_csv="-m,ml_lifecycle_platform.registry.promote,--model-name,breast_cancer_clf,--format,json"
@@ -117,7 +118,7 @@ jobs:
             rollback:dry_run)
               job_args_csv="-m,ml_lifecycle_platform.registry.rollback,--model-name,breast_cancer_clf,--dry-run,--format,json"
               ;;
-            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run|pipeline-binance:dry_run)
+            maintenance:dry_run|reproduce:dry_run|pipeline:dry_run|pipeline-binance:dry_run|drift:dry_run)
               echo "execution_mode=dry_run is not supported for job ${JOB_NAME_INPUT}."
               exit 1
               ;;

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ help:
 	@echo "  make reset             down + no-cache rebuild"
 	@echo "  make run-pipeline      train+eval+register (candidate)"
 	@echo "  make reproduce         rebuild a registered model from the source training run"
+	@echo "  make drift             batch drift over recent prediction events (MODEL=<name>)"
 	@echo "  make policy-check      dry-run promotion gate check (fails if blocked)"
 	@echo "  make promote           candidate -> prod"
 	@echo "  make promote-dry-run   show dry-run JSON (no side effects)"
@@ -206,6 +207,24 @@ reproduce:
 		--model-name "$$model_name" \
 		"$${selector[@]}" \
 		--report-path "$$report_path"
+
+drift:
+	@set -euo pipefail; \
+	if [[ -n "$${MODEL:-}" ]]; then \
+		args=(--model "$${MODEL}"); \
+	else \
+		args=(--all); \
+	fi; \
+	if [[ -n "$${WINDOW_HOURS:-}" ]]; then \
+		args+=(--window-hours "$${WINDOW_HOURS}"); \
+	fi; \
+	if [[ -n "$${THRESHOLD:-}" ]]; then \
+		args+=(--threshold "$${THRESHOLD}"); \
+	fi; \
+	MLP_ENV="$(MLP_ENV_NAME)" \
+	MLP_EVENT_SINK="$${MLP_EVENT_SINK:-jsonl}" \
+	MLP_EVENT_JSONL_PATH="$${MLP_EVENT_JSONL_PATH:-artifacts/prediction-events.jsonl}" \
+	$(PY) -m ml_lifecycle_platform.jobs.drift "$${args[@]}"
 
 policy-check:
 	@$(MLP) registry promote --dry-run --format json

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -130,6 +130,15 @@ resource "google_project_iam_member" "ci_staging_bigquery_admin" {
   member  = "serviceAccount:${google_service_account.ci_staging.email}"
 }
 
+# The drift job (running as runtime) reads the event plane via a BigQuery query
+# job, which needs project-level jobs.create. Table-level dataEditor (granted in
+# events.tf) already covers reading the rows. Apply with owner credentials.
+resource "google_project_iam_member" "runtime_bigquery_job_user" {
+  project = data.google_project.current.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
 resource "google_storage_bucket_iam_member" "ci_staging_foundation_bucket_admin" {
   for_each = google_storage_bucket.foundation
 

--- a/deployments/gcp/terraform/jobs_platform.tf
+++ b/deployments/gcp/terraform/jobs_platform.tf
@@ -71,6 +71,18 @@ locals {
       safe_validation_args = []
       model_env            = local.staging_demo_model_env
     }
+    drift = {
+      name                 = "${local.foundation_name_prefix}-drift-staging"
+      command              = ["python"]
+      args                 = ["-m", "ml_lifecycle_platform.jobs.drift", "--all"]
+      timeout              = "900s"
+      mutates_model_state  = false
+      safe_validation_args = []
+      model_env = merge(local.staging_demo_model_env, {
+        MLP_EVENT_SINK     = "bigquery"
+        MLP_EVENT_BQ_TABLE = "${google_bigquery_table.prediction_events.project}.${google_bigquery_table.prediction_events.dataset_id}.${google_bigquery_table.prediction_events.table_id}"
+      })
+    }
   }
 }
 

--- a/deployments/gcp/terraform/scheduler_platform.tf
+++ b/deployments/gcp/terraform/scheduler_platform.tf
@@ -16,6 +16,14 @@ locals {
       attempt_deadline = "180s"
       retry_count      = 0
     }
+    drift = {
+      name             = "${local.foundation_name_prefix}-drift-staging-schedule"
+      description      = "Daily batch drift over the last 24h of prediction events."
+      schedule         = "17 5 * * *"
+      paused           = false
+      attempt_deadline = "300s"
+      retry_count      = 0
+    }
   }
 }
 

--- a/deployments/observability/grafana/provisioning/alerting/rules.yaml
+++ b/deployments/observability/grafana/provisioning/alerting/rules.yaml
@@ -162,6 +162,41 @@ groups:
                 - evaluator: { type: gt, params: [93600] }
 
   - orgId: 1
+    name: drift
+    folder: mlp-alerts
+    interval: 5m
+    rules:
+      - uid: drift-ks-breach
+        title: Batch drift KS statistic above threshold
+        condition: C
+        for: 10m
+        noDataState: NoData
+        execErrState: Error
+        labels:
+          severity: warning
+          service: drift
+        annotations:
+          summary: mlp_drift_ks_statistic above 0.3 for a model/feature
+          runbook_url: https://github.com/jellewillekes/ml-lifecycle-platform/blob/master/docs/runbooks/observability-alerts.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 172800, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: "max by (model, feature) (mlp_drift_ks_statistic)"
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.3] }
+
+  - orgId: 1
     name: serving-slo-burn
     folder: mlp-alerts
     interval: 1m

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The hosted staging path is a separate advanced path documented under [Advanced h
 - [`runbooks/promotion.md`](./runbooks/promotion.md): dry-run and real promotion
 - [`runbooks/rollback.md`](./runbooks/rollback.md): rollback current prod
 - [`runbooks/reproduce.md`](./runbooks/reproduce.md): reproduce a registered model
+- [`runbooks/drift.md`](./runbooks/drift.md): run batch drift, read the report, and the KS alert
 
 ## Advanced hosted runbooks
 

--- a/docs/runbooks/drift.md
+++ b/docs/runbooks/drift.md
@@ -1,0 +1,131 @@
+# Batch Drift Runbook
+
+Last verified: 2026-07-03
+
+Batch drift (UP-32) reads a rolling window of prediction events, compares each
+feature against the model's release baseline, writes a `drift_report.json` into
+release evidence, and exposes a `mlp_drift_ks_statistic{model, feature}`
+Prometheus gauge for alerting. It runs on demand locally (`make drift`) and on a
+daily Cloud Scheduler cadence in staging. It is read-only: it mutates no model
+state.
+
+## How it works
+
+- **Port:** [`BatchEventReader`](../../src/ml_lifecycle_platform/core/ports.py) —
+  the cold-path read counterpart to the `PredictionEventSink`. It returns one
+  row per event with the event's features expanded into columns.
+  - Local: [`DuckDBEventReader`](../../src/ml_lifecycle_platform/backends/local/event_reader.py)
+    over the JSONL event file.
+  - Hosted: [`BigQueryEventReader`](../../src/ml_lifecycle_platform/backends/gcp/bigquery_event_reader.py)
+    over the partitioned `prediction_events_v1` table.
+- **Comparison:** [`core/drift.py`](../../src/ml_lifecycle_platform/core/drift.py)
+  computes the KS statistic per feature from the baseline's quantile grid versus
+  the live window's empirical CDF, plus the mean/std delta. A feature is flagged
+  when its KS statistic exceeds the threshold (default `0.3`).
+- **Baseline:** the release-linked `DriftBaseline` on the model's `prod` version
+  (UP-31). No `prod` alias or no baseline means the model is skipped, not failed.
+- **Output:** `drift_report.json` written to
+  `reports/drift/<model>/v<version>/` in release evidence (MLflow artifact and
+  the local artifact-store mirror), and the `mlp_drift_ks_statistic` gauge
+  flushed to the OTel collector before the job exits.
+
+The event sink and reader are two halves of the same plane; see
+[`event-plane.md`](event-plane.md).
+
+## Run it locally
+
+The default local path reads the JSONL event file the serving container writes
+(`MLP_EVENT_SINK=jsonl`). Generate events first by serving traffic (see
+[`local-bootstrap.md`](local-bootstrap.md)), then:
+
+```bash
+make drift                       # every model spec with a prod baseline
+make drift MODEL=binance_btc_1m  # one model
+make drift WINDOW_HOURS=6 THRESHOLD=0.2
+```
+
+Environment knobs (all optional):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MODEL` | _all specs_ | run drift for one model instead of `--all` |
+| `WINDOW_HOURS` | `24` | rolling window read back from now |
+| `THRESHOLD` | `0.3` | KS flag threshold |
+| `MLP_EVENT_SINK` | `jsonl` | reader backend (`jsonl` or `bigquery`) |
+| `MLP_EVENT_JSONL_PATH` | `artifacts/prediction-events.jsonl` | JSONL source for the DuckDB reader |
+
+A model with no `prod` baseline or no events in the window is skipped; if nothing
+could be compared the job prints a single "no model had a baseline and events"
+line and exits `0`.
+
+### Local schedule parity
+
+Staging runs drift on Cloud Scheduler (below). The local parity is the same job
+entrypoint on the host crontab — no extra container. To mirror the `17 5 * * *`
+UTC cadence against a running local stack:
+
+```cron
+17 5 * * * cd /path/to/ml-lifecycle-platform && make drift >> /tmp/mlp-drift.log 2>&1
+```
+
+For local development, running `make drift` by hand after generating traffic is
+the normal path.
+
+## Run it in staging
+
+The hosted job is `mlp-drift-staging` (Cloud Run Job), scheduled by
+`mlp-drift-staging-schedule` at `17 5 * * *` UTC. It reads the BigQuery event
+plane (`MLP_EVENT_SINK=bigquery`, `MLP_EVENT_BQ_TABLE` pointing at
+`prediction_events_v1`) and runs `--all`.
+
+The runtime service account needs `roles/bigquery.jobUser` at the project level
+to run the query job (granted in
+[`foundation.tf`](../../deployments/gcp/terraform/foundation.tf); apply with
+owner credentials). Table-level read access is already granted in `events.tf`.
+
+Force-run it two ways:
+
+```bash
+# directly
+gcloud run jobs execute mlp-drift-staging \
+  --region europe-west1 --project fpl-project-jelle --wait
+
+# or the schedule
+gcloud scheduler jobs run mlp-drift-staging-schedule \
+  --location europe-west1 --project fpl-project-jelle
+```
+
+`drift` is also a selectable job in the
+[`Ops / Run Platform Job / Staging`](../../.github/workflows/run-platform-job-staging.yml)
+workflow (`workflow_dispatch` → `job_name: drift`, default execution mode). It
+uses the job's deployed args; `dry_run` is not supported.
+
+Scheduler inspect/pause/resume and the failure model are shared with the other
+hosted jobs — see [`schedule-platform-jobs.md`](schedule-platform-jobs.md).
+
+## Read the report
+
+`drift_report.json` (schema `drift_report/v1`) carries, per feature, the KS
+statistic against the baseline, the mean/std deltas, the event count, and the
+flag. The top-level `drifted` is true when any feature is flagged. Pull the
+latest for a model from its release evidence:
+
+```bash
+mlp registry show-baseline --model-name binance_btc_1m --alias prod
+# drift reports live alongside under reports/drift/<model>/v<version>/
+```
+
+## Metric and alert
+
+The `mlp_drift_ks_statistic{model, feature}` gauge is dual-emitted to the OTel
+collector on job exit and scraped into the observability stack. The
+`DriftKsBreach` Grafana alert fires when
+`max by (model, feature) (mlp_drift_ks_statistic) > 0.3` for 10m (query lookback
+48h, so one missed daily run does not clear it). Triage steps are in
+[`observability-alerts.md`](observability-alerts.md).
+
+## Non-goals
+
+- in-request (online) drift — this is batch only
+- auto promote/demote on drift — promotion gates (UP-35) consume the report; the
+  drift job never changes model state

--- a/docs/runbooks/observability-alerts.md
+++ b/docs/runbooks/observability-alerts.md
@@ -100,6 +100,21 @@ muting at CM means you lose the log record that the alert ever fired.
 - **Likely causes:** scheduler paused, job image broken, job auth
   regression.
 
+### DriftKsBreach
+
+- **What fires it:** `max by (model, feature) (mlp_drift_ks_statistic) > 0.3`
+  for 10m. The gauge lands from the daily batch-drift job (UP-32); the
+  alert query looks back 48h so one missed run does not clear it. `0.3`
+  matches the job's `DEFAULT_KS_THRESHOLD`, so a firing alert means the job
+  already flagged that feature and wrote a flagging `drift_report.json`.
+- **Check:** the model/feature label on the alert, then the latest
+  `drift_report.json` in that model's release evidence (`reports/drift/...`)
+  for the per-feature KS and mean/std deltas. See
+  [`drift.md`](drift.md) for how to re-run the comparison.
+- **Likely causes:** genuine feature-distribution shift in live prediction
+  events versus the release baseline, a stale baseline after a data-schema
+  change, or a thin event window (few events → noisy empirical CDF).
+
 ### ServingAvailabilityBurnFast / BurnSlow
 
 - **What fires it:** multi-window burn against a 99.5% availability SLO.

--- a/docs/runbooks/schedule-platform-jobs.md
+++ b/docs/runbooks/schedule-platform-jobs.md
@@ -17,7 +17,6 @@ Out of scope here:
 - scheduled `rollback`
 - automatic promotion to `prod`
 - workflow engine behavior
-- drift-specific workloads that do not exist in this repo yet
 
 ## Resource contract
 
@@ -29,11 +28,13 @@ Managed scheduler jobs:
 
 - `mlp-maintenance-staging-schedule`
 - `mlp-pipeline-staging-schedule`
+- `mlp-drift-staging-schedule`
 
 Target Cloud Run jobs:
 
 - `mlp-maintenance-staging`
 - `mlp-pipeline-staging`
+- `mlp-drift-staging`
 
 Current committed cadence:
 
@@ -41,12 +42,18 @@ Current committed cadence:
 | --- | --- | --- | --- | --- | --- |
 | `mlp-maintenance-staging-schedule` | `mlp-maintenance-staging` | `17 3 * * *` | `UTC` | `false` | daily hosted control-plane verification |
 | `mlp-pipeline-staging-schedule` | `mlp-pipeline-staging` | `17 4 * * 1` | `UTC` | `true` | optional weekly candidate-generation path |
+| `mlp-drift-staging-schedule` | `mlp-drift-staging` | `17 5 * * *` | `UTC` | `false` | daily batch drift over the last 24h of prediction events |
 
 Intentional boundary:
 
 - only `maintenance` is enabled first
 - `pipeline` exists as an operator-controlled next step
+- `drift` is enabled: it is read-only (reads the event plane, writes a
+  `drift_report.json` and a Prometheus gauge, mutates no model state)
 - `promote` and `rollback` remain manual release actions
+
+Drift operations (re-run on demand, local parity, alerting) live in the
+dedicated [`drift.md`](drift.md) runbook.
 
 ## Deploy path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.5.5"
 requires-python = ">=3.11.7"
 dependencies = [
     "boto3>=1.42.34",
+    "duckdb>=1.1,<2.0",
     "fastapi>=0.128.0",
     "google-auth>=2.48.0",
     "google-cloud-bigquery>=3.25,<4.0",

--- a/src/ml_lifecycle_platform/backends/gcp/bigquery_event_reader.py
+++ b/src/ml_lifecycle_platform/backends/gcp/bigquery_event_reader.py
@@ -1,0 +1,69 @@
+"""BigQuery ``BatchEventReader`` over ``prediction_events_v1`` (UP-32).
+
+Runs a partition-pruned window query (filtering the ``event_time`` TIMESTAMP
+partition column plus the exact ``event_time_ns`` bounds) and expands the
+``features`` JSON column into DataFrame columns — the hosted parity for the
+DuckDB reader.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pandas as pd
+
+try:  # pragma: no cover - exercised only in the hosted image
+    from google.cloud import bigquery
+except Exception:  # pragma: no cover
+    bigquery = None  # type: ignore[assignment]
+
+EVENT_TIME_COLUMN = "event_time_ns"
+
+_QUERY = """
+SELECT event_time_ns, TO_JSON_STRING(features) AS features_json
+FROM `{table}`
+WHERE model_name = @model_name
+  AND event_time >= TIMESTAMP_MICROS(@start_us)
+  AND event_time < TIMESTAMP_MICROS(@end_us)
+  AND event_time_ns >= @start_ns
+  AND event_time_ns < @end_ns
+ORDER BY event_time_ns
+"""
+
+
+class BigQueryEventReader:
+    """Read prediction events from the BigQuery events table."""
+
+    def __init__(self, table: str, *, client: Any | None = None) -> None:
+        if client is None:
+            if bigquery is None:
+                raise RuntimeError("google-cloud-bigquery is not installed")
+            client = bigquery.Client()
+        self._client = client
+        self._table = table
+
+    def read_window(self, model_name: str, start_ns: int, end_ns: int) -> pd.DataFrame:
+        if bigquery is None:
+            raise RuntimeError("google-cloud-bigquery is not installed")
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("model_name", "STRING", model_name),
+                # Partition pruning: widen to whole microseconds around the window.
+                bigquery.ScalarQueryParameter("start_us", "INT64", start_ns // 1000),
+                bigquery.ScalarQueryParameter("end_us", "INT64", -(-end_ns // 1000)),
+                bigquery.ScalarQueryParameter("start_ns", "INT64", start_ns),
+                bigquery.ScalarQueryParameter("end_ns", "INT64", end_ns),
+            ]
+        )
+        result = self._client.query(
+            _QUERY.format(table=self._table), job_config=job_config
+        ).result()
+        records: list[dict[str, Any]] = []
+        for row in result:
+            raw = row["features_json"]
+            features = json.loads(raw) if raw else {}
+            record: dict[str, Any] = {str(k): v for k, v in features.items()}
+            record[EVENT_TIME_COLUMN] = int(row["event_time_ns"])
+            records.append(record)
+        return pd.DataFrame(records)

--- a/src/ml_lifecycle_platform/backends/local/event_reader.py
+++ b/src/ml_lifecycle_platform/backends/local/event_reader.py
@@ -1,0 +1,55 @@
+"""Local DuckDB ``BatchEventReader`` over the JSONL event file (UP-32).
+
+DuckDB reads the newline-delimited events, filters to one model and time window
+in SQL, and returns the features expanded into columns — the local parity for
+the BigQuery reader. This is the read counterpart to the JSONL sink.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pandas as pd
+
+EVENT_TIME_COLUMN = "event_time_ns"
+
+_QUERY = """
+SELECT event_time_ns, to_json(features) AS features_json
+FROM read_json_auto(?, format='newline_delimited')
+WHERE model_ref.model_name = ?
+  AND event_time_ns >= ?
+  AND event_time_ns < ?
+ORDER BY event_time_ns
+"""
+
+
+class DuckDBEventReader:
+    """Read prediction events from a JSONL file via DuckDB."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def read_window(self, model_name: str, start_ns: int, end_ns: int) -> pd.DataFrame:
+        if not self._path.exists():
+            return pd.DataFrame()
+        connection = duckdb.connect(database=":memory:")
+        try:
+            rows = connection.execute(
+                _QUERY, [str(self._path), model_name, start_ns, end_ns]
+            ).fetchall()
+        finally:
+            connection.close()
+        return _rows_to_frame(rows)
+
+
+def _rows_to_frame(rows: list[Any]) -> pd.DataFrame:
+    records: list[dict[str, Any]] = []
+    for event_time_ns, features_json in rows:
+        features = json.loads(features_json) if features_json else {}
+        record: dict[str, Any] = {str(key): value for key, value in features.items()}
+        record[EVENT_TIME_COLUMN] = int(event_time_ns)
+        records.append(record)
+    return pd.DataFrame(records)

--- a/src/ml_lifecycle_platform/common/constants.py
+++ b/src/ml_lifecycle_platform/common/constants.py
@@ -12,6 +12,7 @@ REPRO_CONTRACT_SCHEMA_VERSION = "repro_contract/v1"
 MODEL_SPEC_SCHEMA_VERSION = "model_spec/v1"
 RELEASE_REPORT_SCHEMA_VERSION = "release_reports/v1"
 DRIFT_BASELINE_SCHEMA_VERSION = "drift_baseline/v1"
+DRIFT_REPORT_SCHEMA_VERSION = "drift_report/v1"
 RUNTIME_EVENT_SCHEMA_VERSION = "runtime_event/v1"
 
 # Event-plane contracts use a bare-major envelope version (not the name/vN
@@ -85,6 +86,7 @@ ART_RELEASE_MANIFEST_JSON = "release_manifest.json"
 ART_ROLLBACK_TARGET_JSON = "rollback_target.json"
 ART_MODEL_CARD_MD = "model_card.md"
 ART_DRIFT_BASELINE_JSON = "drift_baseline.json"
+ART_DRIFT_REPORT_JSON = "drift_report.json"
 
 # Artifact paths inside MLflow
 MLFLOW_ARTIFACT_PATH_REPORTS = "reports"

--- a/src/ml_lifecycle_platform/contracts/drift_report.py
+++ b/src/ml_lifecycle_platform/contracts/drift_report.py
@@ -1,0 +1,107 @@
+"""Schema-versioned ``DriftReport`` artifact — the output of batch drift
+(UP-32). Per feature it carries the KS statistic against the release baseline,
+the mean/std deltas, and whether it breached the threshold. Written into release
+evidence and consumed by promotion gates (UP-35)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ml_lifecycle_platform.common.constants import DRIFT_REPORT_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class FeatureDrift:
+    feature: str
+    ks_statistic: float
+    mean_delta: float
+    std_delta: float
+    n_events: int
+    flagged: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "feature": self.feature,
+            "ks_statistic": self.ks_statistic,
+            "mean_delta": self.mean_delta,
+            "std_delta": self.std_delta,
+            "n_events": self.n_events,
+            "flagged": self.flagged,
+        }
+
+    @staticmethod
+    def from_dict(payload: Mapping[str, Any]) -> FeatureDrift:
+        return FeatureDrift(
+            feature=str(payload["feature"]),
+            ks_statistic=float(payload["ks_statistic"]),
+            mean_delta=float(payload["mean_delta"]),
+            std_delta=float(payload["std_delta"]),
+            n_events=int(payload["n_events"]),
+            flagged=bool(payload["flagged"]),
+        )
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    model_name: str
+    model_version: str
+    window_start_ns: int
+    window_end_ns: int
+    n_events: int
+    threshold: float
+    created_at: str
+    features: dict[str, FeatureDrift]
+    drifted: bool
+    schema_version: str = DRIFT_REPORT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "model_name": self.model_name,
+            "model_version": self.model_version,
+            "window_start_ns": self.window_start_ns,
+            "window_end_ns": self.window_end_ns,
+            "n_events": self.n_events,
+            "threshold": self.threshold,
+            "created_at": self.created_at,
+            "drifted": self.drifted,
+            "features": {
+                name: feature.to_dict() for name, feature in self.features.items()
+            },
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    @staticmethod
+    def from_dict(payload: Mapping[str, Any]) -> DriftReport:
+        schema_version = str(payload.get("schema_version", ""))
+        if schema_version != DRIFT_REPORT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported DriftReport schema_version={schema_version!r} "
+                f"(expected {DRIFT_REPORT_SCHEMA_VERSION!r})"
+            )
+        raw_features = payload.get("features")
+        if not isinstance(raw_features, dict):
+            raise TypeError("DriftReport.features must be a dict")
+        return DriftReport(
+            model_name=str(payload["model_name"]),
+            model_version=str(payload["model_version"]),
+            window_start_ns=int(payload["window_start_ns"]),
+            window_end_ns=int(payload["window_end_ns"]),
+            n_events=int(payload["n_events"]),
+            threshold=float(payload["threshold"]),
+            created_at=str(payload["created_at"]),
+            features={
+                str(name): FeatureDrift.from_dict(value)
+                for name, value in raw_features.items()
+            },
+            drifted=bool(payload["drifted"]),
+        )
+
+    @staticmethod
+    def from_json(payload: str) -> DriftReport:
+        return DriftReport.from_dict(json.loads(payload))

--- a/src/ml_lifecycle_platform/core/drift.py
+++ b/src/ml_lifecycle_platform/core/drift.py
@@ -1,0 +1,79 @@
+"""Batch drift computation (UP-32): compare a live event window against a
+release ``DriftBaseline``.
+
+The KS statistic is computed directly from the baseline's quantile grid (a
+step-CDF) versus the live window's empirical CDF — no resampling, deterministic.
+``mean_delta`` / ``std_delta`` come from the stored summary stats. A feature is
+flagged when its KS statistic exceeds the threshold.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+
+from ml_lifecycle_platform.contracts.drift_baseline import ColumnStats, DriftBaseline
+from ml_lifecycle_platform.contracts.drift_report import DriftReport, FeatureDrift
+
+DEFAULT_KS_THRESHOLD = 0.3
+
+
+def _ks_from_quantiles(
+    stats: ColumnStats, grid: Sequence[float], live_sorted: np.ndarray
+) -> float:
+    """KS = sup_x |F_live(x) - F_base(x)|, F_base from the baseline quantiles."""
+    n = int(live_sorted.size)
+    if n == 0:
+        return 0.0
+    xs = np.array([stats.quantiles[f"{q:.2f}"] for q in grid], dtype=float)
+    ps = np.array(list(grid), dtype=float)
+    # Degenerate (constant) baseline column: full distance unless live matches.
+    if float(xs.max() - xs.min()) == 0.0:
+        return 0.0 if bool(np.all(live_sorted == xs[0])) else 1.0
+    eval_points = np.union1d(live_sorted, xs)
+    f_live = np.searchsorted(live_sorted, eval_points, side="right") / n
+    f_base = np.clip(np.interp(eval_points, xs, ps), 0.0, 1.0)
+    return float(np.max(np.abs(f_live - f_base)))
+
+
+def compute_drift(
+    window: pd.DataFrame,
+    baseline: DriftBaseline,
+    *,
+    window_start_ns: int,
+    window_end_ns: int,
+    created_at: str,
+    threshold: float = DEFAULT_KS_THRESHOLD,
+) -> DriftReport:
+    """Compare every baseline feature also present in ``window``."""
+    grid = baseline.quantile_grid
+    features: dict[str, FeatureDrift] = {}
+    for name, stats in baseline.columns.items():
+        if name not in window.columns:
+            continue
+        live = pd.to_numeric(window[name], errors="coerce").dropna()
+        if live.empty:
+            continue
+        live_sorted = np.sort(live.to_numpy(dtype=float))
+        ks = _ks_from_quantiles(stats, grid, live_sorted)
+        features[name] = FeatureDrift(
+            feature=name,
+            ks_statistic=ks,
+            mean_delta=abs(float(live.mean()) - stats.mean),
+            std_delta=abs(float(live.std(ddof=0)) - stats.std),
+            n_events=int(live.size),
+            flagged=ks > threshold,
+        )
+    return DriftReport(
+        model_name=baseline.model_name,
+        model_version=baseline.model_version,
+        window_start_ns=window_start_ns,
+        window_end_ns=window_end_ns,
+        n_events=int(len(window)),
+        threshold=threshold,
+        created_at=created_at,
+        features=features,
+        drifted=any(feature.flagged for feature in features.values()),
+    )

--- a/src/ml_lifecycle_platform/core/ports.py
+++ b/src/ml_lifecycle_platform/core/ports.py
@@ -56,6 +56,19 @@ class PredictionEventSink(Protocol):
 
 
 @runtime_checkable
+class BatchEventReader(Protocol):
+    """Read a model's prediction events in a time window for batch analysis.
+
+    The cold-path read counterpart to ``PredictionEventSink``: drift, replay,
+    and feedback read events back through this port. Adapters (local DuckDB over
+    JSONL, BigQuery hosted) return one row per event with the event's features
+    expanded into columns plus an ``event_time_ns`` column."""
+
+    def read_window(self, model_name: str, start_ns: int, end_ns: int) -> pd.DataFrame:
+        """Return events for ``model_name`` with event_time_ns in [start, end)."""
+
+
+@runtime_checkable
 class DataSource(Protocol):
     """Produce a model-ready labeled dataframe for one training run.
 

--- a/src/ml_lifecycle_platform/jobs/drift.py
+++ b/src/ml_lifecycle_platform/jobs/drift.py
@@ -1,0 +1,205 @@
+"""Batch drift job (UP-32): for each model, read a rolling window of prediction
+events through a ``BatchEventReader``, compare each feature against the prod
+release baseline, write ``drift_report.json`` into release evidence, and expose
+``mlp_drift_ks_statistic{model, feature}`` for Grafana alerting.
+
+Reads on demand locally (``make drift``) and on a schedule in staging. No
+baseline or no events for a model means it is skipped, not a failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Iterable
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.metrics import CallbackOptions, Observation
+
+from ml_lifecycle_platform.backends.gcp.bigquery_event_reader import BigQueryEventReader
+from ml_lifecycle_platform.backends.local.event_reader import DuckDBEventReader
+from ml_lifecycle_platform.common.constants import (
+    ALIAS_PROD,
+    ART_DRIFT_REPORT_JSON,
+    MLFLOW_ARTIFACT_PATH_REPORTS,
+)
+from ml_lifecycle_platform.common.jobs import start_job
+from ml_lifecycle_platform.contracts.drift_baseline import DriftBaseline
+from ml_lifecycle_platform.contracts.drift_report import DriftReport
+from ml_lifecycle_platform.contracts.release_reports import utc_now_iso
+from ml_lifecycle_platform.core.drift import DEFAULT_KS_THRESHOLD, compute_drift
+from ml_lifecycle_platform.core.model_specs import discover_model_specs
+from ml_lifecycle_platform.core.ports import BatchEventReader
+from ml_lifecycle_platform.registry.show_baseline import load_baseline
+from ml_lifecycle_platform.runtime.bootstrap import (
+    configure_mlflow,
+    get_runtime_context,
+)
+from ml_lifecycle_platform.runtime.mlflow import client as mlflow_client
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_JSONL_PATH = "artifacts/prediction-events.jsonl"
+_NS_PER_HOUR = 3_600 * 1_000_000_000
+
+# Latest KS values, read by the observable gauge callback on metric flush.
+_ks_values: dict[tuple[str, str], float] = {}
+
+
+def _observe_ks(options: CallbackOptions) -> Iterable[Observation]:  # noqa: ARG001
+    return tuple(
+        Observation(value, {"model": model, "feature": feature})
+        for (model, feature), value in _ks_values.items()
+    )
+
+
+@lru_cache(maxsize=1)
+def _register_ks_gauge() -> Any:
+    meter = otel_metrics.get_meter("ml_lifecycle_platform.jobs.drift")
+    return meter.create_observable_gauge(
+        "mlp_drift_ks_statistic",
+        callbacks=[_observe_ks],
+        description="KS statistic per model/feature versus the release baseline.",
+    )
+
+
+def build_event_reader() -> BatchEventReader:
+    kind = os.getenv("MLP_EVENT_SINK", "none").strip().lower()
+    if kind == "jsonl":
+        path = os.getenv("MLP_EVENT_JSONL_PATH", _DEFAULT_JSONL_PATH)
+        return DuckDBEventReader(Path(path))
+    if kind == "bigquery":
+        table = os.getenv("MLP_EVENT_BQ_TABLE", "").strip()
+        if not table:
+            raise RuntimeError("MLP_EVENT_BQ_TABLE is required for the bigquery reader")
+        return BigQueryEventReader(table)
+    raise RuntimeError(f"no batch event reader for MLP_EVENT_SINK={kind!r}")
+
+
+def _load_prod_baseline(client: MlflowClient, model_name: str) -> DriftBaseline | None:
+    try:
+        model_version = client.get_model_version_by_alias(model_name, ALIAS_PROD)
+    except MlflowException as exc:
+        logger.warning("No prod alias for %s; skipping drift: %s", model_name, exc)
+        return None
+    try:
+        return load_baseline(
+            client, model_name=model_name, version=str(model_version.version)
+        )
+    except SystemExit as exc:
+        logger.warning("No drift baseline for %s: %s", model_name, exc)
+        return None
+
+
+def _emit_drift_report(
+    client: MlflowClient, *, report: DriftReport, source_run_id: str
+) -> str:
+    root = (
+        f"{MLFLOW_ARTIFACT_PATH_REPORTS}/drift/"
+        f"{report.model_name}/v{report.model_version}"
+    )
+    content = report.to_json().encode("utf-8")
+    with tempfile.TemporaryDirectory(prefix="drift-report-") as tmpdir:
+        local = Path(tmpdir) / ART_DRIFT_REPORT_JSON
+        local.write_bytes(content)
+        try:
+            client.log_artifact(
+                run_id=source_run_id, local_path=str(local), artifact_path=root
+            )
+        except MlflowException as exc:
+            logger.warning("Could not log drift report to MLflow: %s", exc)
+    try:
+        get_runtime_context().artifact_store.write_bytes(
+            f"{root}/{ART_DRIFT_REPORT_JSON}", content
+        )
+    except OSError as exc:
+        logger.warning("Could not mirror drift report locally: %s", exc)
+    return root
+
+
+def run_drift_for_model(
+    client: MlflowClient,
+    model_name: str,
+    *,
+    reader: BatchEventReader,
+    window_hours: float,
+    threshold: float,
+    now_ns: int,
+) -> DriftReport | None:
+    baseline = _load_prod_baseline(client, model_name)
+    if baseline is None:
+        return None
+    start_ns = now_ns - int(window_hours * _NS_PER_HOUR)
+    window = reader.read_window(model_name, start_ns, now_ns)
+    report = compute_drift(
+        window,
+        baseline,
+        window_start_ns=start_ns,
+        window_end_ns=now_ns,
+        created_at=utc_now_iso(),
+        threshold=threshold,
+    )
+    _register_ks_gauge()
+    for feature in report.features.values():
+        _ks_values[(model_name, feature.feature)] = feature.ks_statistic
+    _emit_drift_report(client, report=report, source_run_id=baseline.source_run_id)
+    return report
+
+
+def _resolve_models(args: argparse.Namespace, model_name: str) -> list[str]:
+    if args.all:
+        return [spec.model_name for spec in discover_model_specs()]
+    if args.model:
+        return [str(args.model)]
+    return [model_name]
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="drift")
+    selector = parser.add_mutually_exclusive_group()
+    selector.add_argument("--model", help="Run drift for one model by name")
+    selector.add_argument("--all", action="store_true", help="Run drift for every spec")
+    parser.add_argument("--window-hours", type=float, default=24.0)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_KS_THRESHOLD)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    runtime = get_runtime_context()
+    with start_job("drift", level=runtime.log_level):
+        configure_mlflow(runtime)
+        client = mlflow_client()
+        reader = build_event_reader()
+        now_ns = time.time_ns()
+        reports = 0
+        for model_name in _resolve_models(args, runtime.model_name):
+            report = run_drift_for_model(
+                client,
+                model_name,
+                reader=reader,
+                window_hours=args.window_hours,
+                threshold=args.threshold,
+                now_ns=now_ns,
+            )
+            if report is not None:
+                reports += 1
+                print(
+                    f"[drift] {model_name}: drifted={report.drifted} "
+                    f"features={len(report.features)} n_events={report.n_events}"
+                )
+        if reports == 0:
+            print("[drift] no model had a baseline and events to compare.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_bigquery_event_reader.py
+++ b/tests/integration/test_bigquery_event_reader.py
@@ -1,0 +1,31 @@
+"""Integration smoke test for the BigQuery event reader.
+
+Skipped unless ``GCP_PROJECT_ID`` is set and BigQuery credentials are available.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_PROJECT = os.getenv("GCP_PROJECT_ID")
+
+
+@pytest.mark.skipif(not _PROJECT, reason="requires GCP_PROJECT_ID and BigQuery access")
+def test_bigquery_event_reader_runs_a_window_query() -> None:
+    pytest.importorskip("google.cloud.bigquery")
+
+    from ml_lifecycle_platform.backends.gcp.bigquery_event_reader import (
+        BigQueryEventReader,
+    )
+
+    table = os.getenv(
+        "MLP_EVENT_BQ_TABLE", f"{_PROJECT}.mlp_events.prediction_events_v1"
+    )
+    reader = BigQueryEventReader(table)
+    # A wide window; the query must run (the frame may be empty).
+    df = reader.read_window("binance_btc_1m", 0, 9_000_000_000_000_000_000)
+    assert df is not None

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ml_lifecycle_platform.contracts.drift_baseline import DriftBaseline
+from ml_lifecycle_platform.contracts.drift_report import DriftReport
+from ml_lifecycle_platform.core.drift import compute_drift
+from ml_lifecycle_platform.registry.drift_baseline import compute_drift_baseline
+
+pytestmark = pytest.mark.unit
+
+
+def _baseline() -> DriftBaseline:
+    ref = pd.DataFrame({"f1": list(range(100)), "f2": [5.0] * 100})
+    return compute_drift_baseline(
+        ref, model_name="m", model_version="1", source_run_id="r", created_at="t"
+    )
+
+
+def _report(window: pd.DataFrame) -> DriftReport:
+    return compute_drift(
+        window, _baseline(), window_start_ns=0, window_end_ns=1, created_at="t"
+    )
+
+
+def test_stable_window_not_flagged() -> None:
+    report = _report(pd.DataFrame({"f1": list(range(100))}))
+    assert report.features["f1"].ks_statistic <= 0.3
+    assert not report.features["f1"].flagged
+    assert not report.drifted
+
+
+def test_shifted_window_flagged() -> None:
+    report = _report(pd.DataFrame({"f1": list(range(1000, 1100))}))
+    assert report.features["f1"].ks_statistic > 0.3
+    assert report.features["f1"].flagged
+    assert report.drifted
+
+
+def test_only_compares_shared_features() -> None:
+    report = _report(pd.DataFrame({"f1": list(range(100)), "unknown": [1] * 100}))
+    # f2 is in the baseline but absent from the window; unknown is not in the baseline
+    assert set(report.features) == {"f1"}
+
+
+def test_report_round_trips() -> None:
+    report = _report(pd.DataFrame({"f1": list(range(100))}))
+    assert DriftReport.from_dict(report.to_dict()) == report
+
+
+def test_unknown_report_schema_rejected() -> None:
+    payload = _report(pd.DataFrame({"f1": list(range(100))})).to_dict()
+    payload["schema_version"] = "drift_report/v2"
+    with pytest.raises(ValueError, match="schema_version"):
+        DriftReport.from_dict(payload)

--- a/tests/unit/test_event_reader_duckdb.py
+++ b/tests/unit/test_event_reader_duckdb.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ml_lifecycle_platform.backends.local.event_reader import DuckDBEventReader
+from ml_lifecycle_platform.backends.local.prediction_event_sink import (
+    LocalPredictionEventSink,
+)
+from ml_lifecycle_platform.contracts.model_ref import ModelRef
+from ml_lifecycle_platform.contracts.prediction_event import (
+    EventEnvelope,
+    PredictionEvent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _event(model_name: str, event_time_ns: int, ret: float) -> PredictionEvent:
+    return PredictionEvent(
+        corr_id="c",
+        event_time_ns=event_time_ns,
+        ingest_time_ns=event_time_ns + 1,
+        model_ref=ModelRef(model_name=model_name, alias="prod", version="1"),
+        features={"ret_1": ret, "vol": 2.0},
+        prediction=1,
+        latency_ns=10,
+        envelope=EventEnvelope(service="serving", env="local"),
+    )
+
+
+def test_reads_window_for_model(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    sink = LocalPredictionEventSink(path)
+    sink.write_batch(
+        [
+            _event("m1", 100, 0.1),
+            _event("m1", 200, 0.2),
+            _event("m1", 300, 0.3),  # outside [100, 300)
+            _event("m2", 150, 9.9),  # other model
+        ]
+    )
+
+    df = DuckDBEventReader(path).read_window("m1", 100, 300)
+
+    assert len(df) == 2
+    assert {"ret_1", "vol", "event_time_ns"} <= set(df.columns)
+    assert sorted(df["ret_1"].tolist()) == [0.1, 0.2]
+
+
+def test_missing_file_returns_empty(tmp_path: Path) -> None:
+    reader = DuckDBEventReader(tmp_path / "nope.jsonl")
+    assert reader.read_window("m1", 0, 10).empty

--- a/uv.lock
+++ b/uv.lock
@@ -604,6 +604,42 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.131.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1473,6 +1509,7 @@ version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "duckdb" },
     { name = "fastapi" },
     { name = "google-auth" },
     { name = "google-cloud-bigquery" },
@@ -1512,6 +1549,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.34" },
+    { name = "duckdb", specifier = ">=1.1,<2.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-auth", specifier = ">=2.48.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.25,<4.0" },


### PR DESCRIPTION
## Summary

- Add the `BatchEventReader` port with a local DuckDB reader over the JSONL event file and a hosted BigQuery reader over `prediction_events_v1`.
- Add KS-based batch drift (`core/drift.py`): per-feature KS statistic vs the release `DriftBaseline` quantile grid, plus mean/std deltas, flagged at a `0.3` threshold.
- Add the `drift_report/v1` contract, written into release evidence at `reports/drift/<model>/v<version>/`.
- Add the drift job (`jobs/drift.py`) exposing `mlp_drift_ks_statistic{model, feature}`; runs on demand via `make drift` and daily in staging via a new Cloud Run Job + Cloud Scheduler (`17 5 * * *`).
- Grant the runtime SA project-level `roles/bigquery.jobUser` so the hosted job can run the window query.
- Add `duckdb` to the platform image dependencies.
- Add a `DriftKsBreach` Grafana alert on the gauge, the `drift.md` runbook, and the `drift` option in the Run Platform Job workflow.

## Test plan

- [x] `make check` — format, lint, mypy (151 files), 237 unit tests
- [x] `make docs-check` — runbook links resolve
- [x] `terraform fmt -check` — clean
- [ ] `make e2e-clean` — infra/pipeline touched (Docker; runs locally)
- [ ] `terraform apply` with owner creds — new `bigquery.jobUser` binding requires it
- [ ] Publish the platform image (now needs `duckdb`), execute `mlp-drift-staging` against real Binance events in BigQuery, confirm `drift_report.json` lands in release evidence and the gauge shows in Grafana; capture screenshots + the report JSON as evidence

Closes #209