### PR TITLE
feat: add one-command GCP teardown and restore runbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ PRECOMMIT := $(PY) -m pre_commit
 
 TF_STATE_BUCKET ?= fpl-tf-state-jelle
 TF_STATE_PREFIX ?= ml-lifecycle-platform/gcp/bootstrap
+DEPLOYMENTS_OBS_TERRAFORM_DIR ?= deployments/observability/terraform
+TF_STATE_PREFIX_OBS ?= ml-lifecycle-platform/observability
 export TF_VAR_project_id ?= fpl-project-jelle
 export TF_VAR_region ?= europe-west1
 
@@ -88,6 +90,7 @@ help:
 	@echo "  make terraform-gcp-plan      plan the GCP Terraform root"
 	@echo "  make terraform-gcp-apply     apply the GCP Terraform root"
 	@echo "  make terraform-gcp-validate  validate the GCP Terraform root"
+	@echo "  make gcp-teardown            DESTROY all hosted infra (both roots); keeps TF state bucket. Owner creds."
 	@echo ""
 	@echo "Housekeeping:"
 	@echo "  make clean             remove local caches"
@@ -301,6 +304,32 @@ terraform-gcp-apply:
 
 terraform-gcp-validate:
 	@$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) validate
+
+.PHONY: gcp-teardown
+gcp-teardown:
+	@set -euo pipefail; \
+	echo "⚠️  This DESTROYS all hosted GCP infrastructure in both Terraform roots:"; \
+	echo "     observability -> GCE VM, alert-router, tempo/config buckets"; \
+	echo "     gcp           -> Cloud SQL, Cloud Run (mlflow/serving), BigQuery events,"; \
+	echo "                      platform jobs, schedulers, foundation (SAs/WIF/AR/buckets)"; \
+	echo "     Kept: the external TF state bucket ($(TF_STATE_BUCKET)) and the GCP project."; \
+	echo "     Run with owner credentials. Restore: docs/runbooks/teardown-and-restore.md"; \
+	echo "     Terraform will prompt for 'yes' once per root."; \
+	echo ""; \
+	$(TERRAFORM) -chdir=$(DEPLOYMENTS_OBS_TERRAFORM_DIR) init -reconfigure \
+		-backend-config="bucket=$(TF_STATE_BUCKET)" \
+		-backend-config="prefix=$(TF_STATE_PREFIX_OBS)"; \
+	$(TERRAFORM) -chdir=$(DEPLOYMENTS_OBS_TERRAFORM_DIR) destroy \
+		-var enable_deletion_protection=false; \
+	$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) init -reconfigure \
+		-backend-config="bucket=$(TF_STATE_BUCKET)" \
+		-backend-config="prefix=$(TF_STATE_PREFIX)"; \
+	$(TERRAFORM) -chdir=$(DEPLOYMENTS_GCP_TERRAFORM_DIR) destroy \
+		-var enable_deletion_protection=false; \
+	echo ""; \
+	echo "✅ Teardown complete. Verify zero billed resources:"; \
+	echo "   gcloud sql instances list --project $(TF_VAR_project_id)"; \
+	echo "   gcloud compute instances list --project $(TF_VAR_project_id)"
 
 .PHONY: clean
 clean:

--- a/deployments/gcp/terraform/events.tf
+++ b/deployments/gcp/terraform/events.tf
@@ -25,7 +25,7 @@ resource "google_bigquery_table" "prediction_events" {
   project             = data.google_project.current.project_id
   dataset_id          = google_bigquery_dataset.events.dataset_id
   table_id            = local.prediction_events_table_id
-  deletion_protection = true
+  deletion_protection = var.enable_deletion_protection
 
   labels = merge(local.common_labels, { purpose = "events" })
 

--- a/deployments/gcp/terraform/foundation.tf
+++ b/deployments/gcp/terraform/foundation.tf
@@ -50,7 +50,7 @@ resource "google_storage_bucket" "foundation" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
-  force_destroy               = false
+  force_destroy               = !var.enable_deletion_protection
 
   labels = merge(local.common_labels, { purpose = each.key })
 

--- a/deployments/gcp/terraform/run_mlflow.tf
+++ b/deployments/gcp/terraform/run_mlflow.tf
@@ -60,7 +60,7 @@ resource "google_cloud_run_v2_service" "mlflow" {
   name                = "${local.foundation_name_prefix}-mlflow-${each.key}"
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
-  deletion_protection = true
+  deletion_protection = var.enable_deletion_protection
 
   labels = merge(local.common_labels, { purpose = "mlflow_${each.key}" })
 

--- a/deployments/gcp/terraform/run_serving.tf
+++ b/deployments/gcp/terraform/run_serving.tf
@@ -25,7 +25,7 @@ resource "google_cloud_run_v2_service" "serving" {
   name                = "${local.foundation_name_prefix}-serving-${each.key}"
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
-  deletion_protection = true
+  deletion_protection = var.enable_deletion_protection
 
   labels = merge(local.common_labels, { purpose = "serving_${each.key}" })
 

--- a/deployments/gcp/terraform/sql.tf
+++ b/deployments/gcp/terraform/sql.tf
@@ -28,7 +28,7 @@ resource "google_sql_database_instance" "mlflow" {
   name                = local.mlflow_sql_instance_name
   region              = var.region
   database_version    = "POSTGRES_16"
-  deletion_protection = true
+  deletion_protection = var.enable_deletion_protection
 
   settings {
     edition           = "ENTERPRISE"
@@ -92,7 +92,7 @@ resource "google_sql_database_instance" "mlflow_production" {
   name                = local.mlflow_sql_instance_name_production
   region              = var.region
   database_version    = "POSTGRES_16"
-  deletion_protection = true
+  deletion_protection = var.enable_deletion_protection
 
   settings {
     edition           = "ENTERPRISE"

--- a/deployments/gcp/terraform/variables.tf
+++ b/deployments/gcp/terraform/variables.tf
@@ -141,3 +141,9 @@ variable "manage_production_foundation" {
   type        = bool
   default     = false
 }
+
+variable "enable_deletion_protection" {
+  description = "Guard stateful resources (Cloud SQL, Cloud Run services, the BigQuery events table) and their backing buckets against accidental deletion. Default true for normal operation. Set false only to let `make gcp-teardown` run `terraform destroy`; see docs/runbooks/teardown-and-restore.md."
+  type        = bool
+  default     = true
+}

--- a/deployments/observability/terraform/storage.tf
+++ b/deployments/observability/terraform/storage.tf
@@ -5,7 +5,7 @@ resource "google_storage_bucket" "tempo" {
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
-  force_destroy               = false
+  force_destroy               = !var.enable_deletion_protection
 
   labels = merge(local.common_labels, { purpose = "tempo_blocks" })
 

--- a/deployments/observability/terraform/variables.tf
+++ b/deployments/observability/terraform/variables.tf
@@ -110,3 +110,9 @@ variable "alert_router_image" {
     error_message = "alert_router_image must be a non-empty image reference."
   }
 }
+
+variable "enable_deletion_protection" {
+  description = "Guard the Tempo trace-block bucket against accidental deletion. Default true for normal operation. Set false only to let `make gcp-teardown` run `terraform destroy`; see docs/runbooks/teardown-and-restore.md."
+  type        = bool
+  default     = true
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ These runbooks cover the GCP staging path. You do not need them for normal local
 - [`runbooks/schedule-platform-jobs.md`](./runbooks/schedule-platform-jobs.md): inspect, pause, resume, and verify Cloud Scheduler for hosted jobs
 - [`runbooks/serving-staging-baseline.md`](./runbooks/serving-staging-baseline.md): advisory k6 baseline against hosted serving staging
 - [`runbooks/gcp-ci-auth.md`](./runbooks/gcp-ci-auth.md): verify GitHub Actions OIDC auth into GCP
+- [`runbooks/teardown-and-restore.md`](./runbooks/teardown-and-restore.md): `make gcp-teardown` to near-zero cost, then rebuild from the same state bucket
 
 ## Delivery docs
 

--- a/docs/runbooks/hosted-golden-path.md
+++ b/docs/runbooks/hosted-golden-path.md
@@ -98,3 +98,9 @@ Treat these as different failures:
 - expected policy-blocked dry-run: promotion or rollback dry-run returned a safe policy block
 
 Do not treat those as the same incident.
+
+## Tearing down
+
+To bring the whole hosted footprint to near-zero cost and rebuild it later from
+the same state bucket, see [`teardown-and-restore.md`](teardown-and-restore.md)
+(`make gcp-teardown`).

--- a/docs/runbooks/teardown-and-restore.md
+++ b/docs/runbooks/teardown-and-restore.md
@@ -1,0 +1,126 @@
+# Teardown and Restore Runbook
+
+Last verified: 2026-07-03
+
+Bring the hosted GCP footprint to near-zero cost with one command, and rebuild
+it later from the same Terraform state bucket. Use this when you are stepping
+away from the project and do not want the always-on Cloud SQL instance and
+observability VM to keep billing.
+
+Everything hosted lives in two independent Terraform roots:
+
+- [`deployments/gcp/terraform`](../../deployments/gcp/terraform) — foundation +
+  staging: Cloud SQL, Cloud Run (MLflow/serving), BigQuery event plane, platform
+  jobs, schedulers, service accounts, Workload Identity Federation, Artifact
+  Registry, artifact buckets.
+- [`deployments/observability/terraform`](../../deployments/observability/terraform) —
+  the always-on GCE VM (Grafana/Prometheus/Tempo), the alert-router Cloud Run
+  service, and the Tempo/config buckets.
+
+## Tear it down
+
+```bash
+gcloud auth application-default login   # owner credentials — see below
+make gcp-teardown
+```
+
+`make gcp-teardown` destroys the **observability root first** (the leaf), then
+the **gcp root**. Terraform prompts for `yes` once per root.
+
+**Why owner credentials.** The gcp root owns project-level IAM bindings and the
+WIF pool. Removing those needs `setIamPolicy`, which the scoped staging CI
+service account does not have. Run the teardown yourself with owner creds, the
+same way the one-off `roles/bigquery.jobUser` grant is applied.
+
+### What survives
+
+- The **external Terraform state bucket** (`fpl-tf-state-jelle`). It is
+  referenced by name, never managed by either root, so `destroy` cannot brick
+  its own backend. Its state files remain — now describing zero resources — so a
+  later `apply` rebuilds from a clean slate.
+- The **GCP project** itself. An empty project bills nothing.
+
+Everything else — Cloud SQL, the VM, Cloud Run, BigQuery data, buckets and their
+objects, service accounts, WIF, secrets, the Artifact Registry repo and its
+images — is deleted.
+
+### How the guards are handled
+
+Stateful resources normally carry `deletion_protection = true` (Cloud SQL, the
+two Cloud Run services, the BigQuery events table) or `force_destroy = false`
+(artifact and Tempo buckets), so a stray `terraform destroy` fails safely. Both
+are wired to a single variable `enable_deletion_protection` (default `true`).
+The teardown target passes `enable_deletion_protection=false` at destroy time,
+which is enough to remove every guard in one `destroy` — no preceding `apply`.
+Normal applies keep protection on; the variable only ever flips during teardown.
+
+### Confirm zero billed resources
+
+```bash
+gcloud sql instances list      --project fpl-project-jelle   # expect: Listed 0 items
+gcloud compute instances list  --project fpl-project-jelle   # expect: Listed 0 items
+gcloud run services list       --region europe-west1 --project fpl-project-jelle
+gcloud run jobs list           --region europe-west1 --project fpl-project-jelle
+```
+
+Storage on the surviving state bucket is a few cents per month; the empty
+project and disabled APIs cost nothing.
+
+## Restore it
+
+Order matters: the first apply recreates the CI identity, so it cannot run in
+CI. Do the foundation apply locally with owner credentials, then let the normal
+CD workflows take over.
+
+1. **Owner-credentialed foundation apply.** Recreates APIs, service accounts,
+   WIF, Artifact Registry, the VPC, Cloud SQL, and buckets. Cloud Run image vars
+   default to `""` on a fresh apply, so services come up as IAM/skeletons first
+   — same as the original bootstrap.
+
+   ```bash
+   gcloud auth application-default login
+   make terraform-gcp-init
+   terraform -chdir=deployments/gcp/terraform apply
+   ```
+
+   Detailed walkthrough: [`gcp-bootstrap.md`](gcp-bootstrap.md) →
+   [`gcp-foundation.md`](gcp-foundation.md) →
+   [`gcp-staging-infra.md`](gcp-staging-infra.md).
+
+2. **Verify CI auth is back.** WIF was just recreated; confirm GitHub Actions can
+   federate before relying on CD: [`gcp-ci-auth.md`](gcp-ci-auth.md).
+
+3. **Publish images and deploy.** The CD workflows build and push the MLflow,
+   serving, and platform-jobs images, then re-apply the gcp root with the real
+   image refs. Follow the canonical path:
+   [`hosted-golden-path.md`](hosted-golden-path.md), or step-by-step via
+   [`deploy-mlflow.md`](deploy-mlflow.md) → [`deploy-serving.md`](deploy-serving.md)
+   → [`deploy-platform-jobs.md`](deploy-platform-jobs.md).
+
+4. **Schedulers.** Cloud Scheduler jobs are recreated by the platform-jobs apply;
+   confirm cadence and paused state with
+   [`schedule-platform-jobs.md`](schedule-platform-jobs.md).
+
+5. **Rebuild observability.** Rebuild the alert-router image, re-init the
+   observability root against its own state prefix, and apply. Then feed the
+   collector endpoint back into the gcp root's `otlp_collector_endpoint` so the
+   drift and maintenance gauges export again. See
+   [`observability-setup.md`](observability-setup.md) and the Bootstrap section
+   of [`observability-alerts.md`](observability-alerts.md).
+
+6. **Re-seed anything TF does not own.** Secret Manager *versions* that are not
+   generated by `random_password` (none today — the MLflow DB password and the
+   alert-router token are both TF-generated) and any manually pushed data. If you
+   add such secrets later, note them here.
+
+Forking into a fresh project instead of restoring this one? Start from
+[`oss-deploy.md`](oss-deploy.md), which walks the same graph from an empty GCP
+project.
+
+## Non-goals
+
+- deleting the GCP project or the Terraform state bucket — both are near-zero
+  cost and are what make restore a single `apply`; delete them by hand only if
+  you are abandoning the project entirely
+- partial / per-service teardown — this is all-or-nothing by design; scale a
+  single Cloud Run service to zero instead if that is all you need


### PR DESCRIPTION
## Summary

- Add `enable_deletion_protection` variable (default `true`) to both Terraform roots and wire it to the existing `deletion_protection` (Cloud SQL, Cloud Run, BigQuery events table) and `force_destroy` (artifact + Tempo buckets) guards, so normal applies stay protected.
- Add `make gcp-teardown`: destroy the observability root then the gcp root in one command, flipping the guard off at destroy time. Interactive confirm per root; run with owner credentials.
- Keep the external Terraform state bucket and the GCP project so restore is a single `apply`.
- Add `docs/runbooks/teardown-and-restore.md` (destroyed vs kept, residual cost, zero-billing checks, ordered restore path); link it from the handbook and the hosted golden path.

## Test plan

- [x] `terraform fmt -check -recursive` passes on both roots
- [x] `terraform validate` passes on both roots
- [x] `make docs-check` passes (all runbook links resolve)
- [ ] `make gcp-teardown` against live staging, then `gcloud sql/compute instances list` return zero items (destructive; owner creds — you run)
- [ ] `make e2e-clean` — not exercised by this diff (no local-stack/src/pipeline/serving change); run only for the full gate

Closes #251