### PR TITLE
docs: update README for hosted staging status and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/ci.yml?branch=master&label=ci)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/ci.yml)
 [![e2e](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/e2e.yml?branch=master&label=e2e)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/e2e.yml)
-[![staging](https://img.shields.io/github/actions/workflow/status/jellewillekes/ml-lifecycle-platform/hosted-golden-path-staging.yml?branch=master&label=staging)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/workflows/hosted-golden-path-staging.yml)
+[![staging](https://img.shields.io/badge/staging-paused-lightgrey)](https://github.com/jellewillekes/ml-lifecycle-platform/actions/runs/28663089165)
 [![coverage](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)](https://codecov.io/gh/jellewillekes/ml-lifecycle-platform/branch/master/graph/badge.svg)
 [![release](https://img.shields.io/github/v/release/jellewillekes/ml-lifecycle-platform?label=release)](https://github.com/jellewillekes/ml-lifecycle-platform/releases)
 [![python](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fjellewillekes%2Fml-lifecycle-platform%2Fmaster%2Fpyproject.toml&label=python)](pyproject.toml)
@@ -10,11 +10,19 @@
 
 _Spec-driven ML lifecycle platform with MLflow as the control plane with both local and hosted GCP staging._
 
-An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. The current implementation is local-first with Terraform-managed GCP foundation and staging infra plus GitHub Actions-produced runtime images ready for hosted rollout.
+> **Status: hosted staging is paused (July 2026).** There is no GCP project connected, so the hosted workflows do not run. They are set to `workflow_dispatch` only.
+>
+> The staging badge points at the last run that passed on `master`: [run #142](https://github.com/jellewillekes/ml-lifecycle-platform/actions/runs/28663089165), commit [`353a10a`](https://github.com/jellewillekes/ml-lifecycle-platform/commit/353a10ab3a6217dcf5566b42c808f914fadf7530), 3 July 2026. That run built and pushed the images, deployed MLflow, serving, and the platform jobs to Cloud Run, seeded the staging fixture, and then ran maintenance, reproduce, promote dry-run, rollback dry-run, the pipeline, and the serving smoke test against it.
+>
+> Local is not affected. Use `make e2e`. Terraform `fmt`, `validate`, and `plan` also still work without a project.
+>
+> To turn hosted back on: connect a GCP project and put the workflow triggers back.
+
+An ML platform for training, evaluating, registering, promoting, serving, and reproducing models. MLflow is the control plane. It runs local-first. There is a Terraform-managed GCP foundation and GitHub Actions builds the runtime images. The hosted staging lane is paused, see the status above.
 
 ```text
 local path:   train -> register -> promote -> serve
-hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging validation
+hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging validation  (paused)
 ```
 
 [Quick Start](#quick-start) · [Architecture](docs/architecture.md) · [CI/CD](docs/ci.md) · [Hosted Staging Runbook](docs/runbooks/hosted-golden-path.md) · [Contributing](CONTRIBUTING.md)
@@ -22,8 +30,8 @@ hosted path:  GitHub Actions -> Artifact Registry -> Cloud Run / Jobs -> staging
 ## Current Status
 
 - local runtime is the default developer and operator path
-- hosted staging exists for image publication, staged deploy, and release validation
-- the supported first validation path is local `make e2e`
+- the supported validation path is local `make e2e`
+- hosted GCP staging is paused since July 2026, no project connected. It last passed the full golden path on `master` in [run #142](https://github.com/jellewillekes/ml-lifecycle-platform/actions/runs/28663089165) (commit `353a10a`, 3 July 2026)
 - production rollout and multi-environment promotion remain out of scope
 
 ## Architecture
@@ -34,7 +42,7 @@ The platform runs the same logical contract across two environments. Local goes 
 
 ![Architecture context diagram for local Compose runtime](docs/diagrams/context_local.svg)
 
-**Hosted — GCP staging, CI-gated**
+**Hosted — GCP staging, CI-gated** _(paused, see [Current Status](#current-status))_
 
 ![Architecture context diagram for hosted GCP staging](docs/diagrams/context_hosted.svg)
 
@@ -47,7 +55,7 @@ The full set (container + deployment + M6 low-latency views) lives in [`docs/dia
 - [`docs/architecture.md`](docs/architecture.md): system boundaries, serving contract, release evidence, and code layout
 - [`docs/ci.md`](docs/ci.md): contributor checks and CI lane reference
 
-Advanced (hosted — maintainer only):
+Advanced (hosted — maintainer only, paused):
 
 - [`docs/runbooks/hosted-golden-path.md`](docs/runbooks/hosted-golden-path.md): canonical hosted staging validation path
 - [`docs/runbooks/gcp-bootstrap.md`](docs/runbooks/gcp-bootstrap.md): bootstrap and hosted foundation setup
@@ -172,13 +180,13 @@ Local infra:
 - `make logs`
 - `make build`
 
-Advanced (hosted infra — maintainer only):
+Advanced (hosted infra — maintainer only). `fmt`, `validate`, and `plan` work without a GCP project. `init` and `apply` need one, so they do not work while hosted staging is paused:
 
 - `make terraform-gcp-fmt`
-- `make terraform-gcp-init`
-- `make terraform-gcp-plan`
-- `make terraform-gcp-apply`
 - `make terraform-gcp-validate`
+- `make terraform-gcp-plan`
+- `make terraform-gcp-init`
+- `make terraform-gcp-apply`
 
 Registry and serving:
 
@@ -232,4 +240,3 @@ configs/
 examples/
   csv/          public sample CSV data
 ```
-


### PR DESCRIPTION
Updated README to reflect the paused status of hosted staging and clarified local and hosted paths.